### PR TITLE
Refactor: Add useFormValidation hook

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,425 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { motion } from 'framer-motion'
+import Link from 'next/link'
+import { useAuth } from '@/context/AuthContext'
+import { useFormValidation, commonValidators } from '@/hooks'
+
+/**
+ * Obsidian Vault Login Page - Day 13
+ *
+ * Design: "Secure Vault" visual metaphor with premium Oat & Obsidian styling.
+ * Zero-Storage Promise badge prominently displayed to reinforce trust.
+ *
+ * Refactored: Now uses useFormValidation hook for form state management
+ *
+ * See: skills/theme-factory/themes/oat-and-obsidian.md
+ */
+
+interface LoginFormValues {
+  email: string
+  password: string
+  rememberMe: boolean
+}
+
+const initialValues: LoginFormValues = {
+  email: '',
+  password: '',
+  rememberMe: false,
+}
+
+export default function LoginPage() {
+  const router = useRouter()
+  const { login, isAuthenticated, isLoading: authLoading } = useAuth()
+
+  // Server-side error (from failed login attempt)
+  const [serverError, setServerError] = useState('')
+
+  // Form state via useFormValidation hook
+  const {
+    values,
+    isSubmitting,
+    setValue,
+    handleSubmit,
+  } = useFormValidation<LoginFormValues>({
+    initialValues,
+    validationRules: {
+      email: [
+        commonValidators.required('Email is required'),
+        commonValidators.email('Please enter a valid email'),
+      ],
+      password: [
+        commonValidators.required('Password is required'),
+      ],
+    },
+    onSubmit: async (formValues) => {
+      setServerError('')
+
+      const result = await login({
+        email: formValues.email,
+        password: formValues.password,
+      })
+
+      if (result.success) {
+        // Check for stored redirect path
+        const redirectPath = sessionStorage.getItem('paciolus_redirect') || '/'
+        sessionStorage.removeItem('paciolus_redirect')
+        router.push(redirectPath)
+      } else {
+        setServerError(result.error || 'Invalid email or password')
+      }
+    },
+  })
+
+  // Redirect if already authenticated
+  useEffect(() => {
+    if (!authLoading && isAuthenticated) {
+      // Check for stored redirect path
+      const redirectPath = sessionStorage.getItem('paciolus_redirect') || '/'
+      sessionStorage.removeItem('paciolus_redirect')
+      router.push(redirectPath)
+    }
+  }, [isAuthenticated, authLoading, router])
+
+  // Animation variants
+  const containerVariants = {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 1,
+      transition: {
+        staggerChildren: 0.1,
+        delayChildren: 0.1,
+      },
+    },
+  }
+
+  const itemVariants = {
+    hidden: { opacity: 0, y: 20 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        type: 'spring' as const,
+        stiffness: 300,
+        damping: 24,
+      },
+    },
+  }
+
+  const vaultIconVariants = {
+    hidden: { scale: 0.8, opacity: 0, rotateY: -15 },
+    visible: {
+      scale: 1,
+      opacity: 1,
+      rotateY: 0,
+      transition: {
+        type: 'spring' as const,
+        stiffness: 200,
+        damping: 20,
+        delay: 0.2,
+      },
+    },
+  }
+
+  return (
+    <main className="min-h-screen bg-gradient-obsidian flex items-center justify-center p-6">
+      <motion.div
+        className="w-full max-w-md"
+        variants={containerVariants}
+        initial="hidden"
+        animate="visible"
+      >
+        {/* Vault Card */}
+        <motion.div
+          className="bg-obsidian-800 border border-obsidian-600 rounded-2xl shadow-2xl overflow-hidden"
+          variants={itemVariants}
+        >
+          {/* Header with Vault Icon */}
+          <div className="px-8 pt-8 pb-6 text-center border-b border-obsidian-700">
+            {/* Vault Icon */}
+            <motion.div
+              className="w-20 h-20 mx-auto mb-4 rounded-2xl bg-obsidian-700 border border-obsidian-500 flex items-center justify-center"
+              variants={vaultIconVariants}
+            >
+              <svg
+                className="w-10 h-10 text-sage-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+                />
+              </svg>
+            </motion.div>
+
+            <motion.h1
+              className="text-2xl font-serif font-bold text-oatmeal-200 mb-2"
+              variants={itemVariants}
+            >
+              Obsidian Vault
+            </motion.h1>
+
+            <motion.p
+              className="text-oatmeal-400 font-sans text-sm"
+              variants={itemVariants}
+            >
+              Secure access to your audit workspace
+            </motion.p>
+          </div>
+
+          {/* Zero-Storage Badge */}
+          <motion.div
+            className="px-8 py-4 bg-obsidian-700/30 border-b border-obsidian-700"
+            variants={itemVariants}
+          >
+            <div className="flex items-center justify-center gap-2">
+              <div className="w-2 h-2 bg-sage-400 rounded-full animate-pulse"></div>
+              <span className="text-sage-300 text-sm font-sans font-medium">
+                Zero-Storage Promise
+              </span>
+              <div className="group relative">
+                <button
+                  type="button"
+                  aria-label="What is Zero-Storage?"
+                  className="w-4 h-4 rounded-full bg-obsidian-600 text-oatmeal-400 text-xs flex items-center justify-center hover:bg-obsidian-500 transition-colors"
+                >
+                  ?
+                </button>
+                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-obsidian-900 border border-obsidian-500 rounded-lg text-xs text-oatmeal-300 w-56 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-10 font-sans">
+                  Your trial balance data never touches our servers. Credentials are stored securely, but your financial data is processed entirely in-memory.
+                  <div className="absolute top-full left-1/2 -translate-x-1/2 border-8 border-transparent border-t-obsidian-500"></div>
+                </div>
+              </div>
+            </div>
+          </motion.div>
+
+          {/* Login Form */}
+          <motion.form
+            onSubmit={handleSubmit}
+            className="px-8 py-6 space-y-5"
+            variants={itemVariants}
+          >
+            {/* Server Error Message */}
+            {serverError && (
+              <motion.div
+                className="p-4 rounded-lg bg-clay-500/10 border border-clay-500/30"
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+              >
+                <div className="flex items-center gap-3">
+                  <svg
+                    className="w-5 h-5 text-clay-400 flex-shrink-0"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                  <p className="text-clay-300 text-sm font-sans">{serverError}</p>
+                </div>
+              </motion.div>
+            )}
+
+            {/* Email Input */}
+            <div>
+              <label
+                htmlFor="email"
+                className="block text-sm font-sans font-medium text-oatmeal-300 mb-2"
+              >
+                Email Address
+              </label>
+              <div className="relative">
+                <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+                  <svg
+                    className="w-5 h-5 text-oatmeal-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9m4.5-1.206a8.959 8.959 0 01-4.5 1.207"
+                    />
+                  </svg>
+                </div>
+                <input
+                  type="email"
+                  id="email"
+                  value={values.email}
+                  onChange={(e) => setValue('email', e.target.value)}
+                  placeholder="you@company.com"
+                  required
+                  className="w-full pl-12 pr-4 py-3 bg-obsidian-900 border border-obsidian-500 rounded-xl text-oatmeal-200 placeholder-oatmeal-600 font-sans focus:outline-none focus:ring-2 focus:ring-sage-500 focus:border-transparent transition-all"
+                />
+              </div>
+            </div>
+
+            {/* Password Input */}
+            <div>
+              <label
+                htmlFor="password"
+                className="block text-sm font-sans font-medium text-oatmeal-300 mb-2"
+              >
+                Password
+              </label>
+              <div className="relative">
+                <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+                  <svg
+                    className="w-5 h-5 text-oatmeal-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  type="password"
+                  id="password"
+                  value={values.password}
+                  onChange={(e) => setValue('password', e.target.value)}
+                  placeholder="Enter your password"
+                  required
+                  className="w-full pl-12 pr-4 py-3 bg-obsidian-900 border border-obsidian-500 rounded-xl text-oatmeal-200 placeholder-oatmeal-600 font-sans focus:outline-none focus:ring-2 focus:ring-sage-500 focus:border-transparent transition-all"
+                />
+              </div>
+            </div>
+
+            {/* Remember Me & Forgot Password Row */}
+            <div className="flex items-center justify-between">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <div
+                  className={`w-5 h-5 rounded border-2 flex items-center justify-center transition-all ${
+                    values.rememberMe
+                      ? 'bg-sage-500 border-sage-500'
+                      : 'border-oatmeal-500/50 hover:border-oatmeal-400'
+                  }`}
+                  onClick={() => setValue('rememberMe', !values.rememberMe)}
+                >
+                  {values.rememberMe && (
+                    <svg className="w-3 h-3 text-obsidian-900" fill="currentColor" viewBox="0 0 20 20">
+                      <path
+                        fillRule="evenodd"
+                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  )}
+                </div>
+                <input
+                  type="checkbox"
+                  checked={values.rememberMe}
+                  onChange={(e) => setValue('rememberMe', e.target.checked)}
+                  className="sr-only"
+                />
+                <span className="text-sm text-oatmeal-400 font-sans">Remember me</span>
+              </label>
+
+              <button
+                type="button"
+                className="text-sm text-oatmeal-500 hover:text-oatmeal-400 font-sans transition-colors cursor-not-allowed"
+                disabled
+                title="Coming soon"
+              >
+                Forgot password?
+              </button>
+            </div>
+
+            {/* Submit Button */}
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className={`w-full py-3 rounded-xl font-sans font-bold transition-all transform ${
+                isSubmitting
+                  ? 'bg-obsidian-600 text-oatmeal-500 cursor-not-allowed'
+                  : 'bg-sage-500 hover:bg-sage-400 text-obsidian-900 hover:scale-[1.02] active:scale-[0.98]'
+              }`}
+            >
+              {isSubmitting ? (
+                <span className="flex items-center justify-center gap-2">
+                  <div className="w-5 h-5 border-2 border-oatmeal-400/30 border-t-oatmeal-400 rounded-full animate-spin"></div>
+                  Unlocking Vault...
+                </span>
+              ) : (
+                <span className="flex items-center justify-center gap-2">
+                  <svg
+                    className="w-5 h-5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z"
+                    />
+                  </svg>
+                  Enter Vault
+                </span>
+              )}
+            </button>
+          </motion.form>
+
+          {/* Footer - Register Link */}
+          <motion.div
+            className="px-8 py-5 bg-obsidian-700/30 border-t border-obsidian-700 text-center"
+            variants={itemVariants}
+          >
+            <p className="text-oatmeal-400 text-sm font-sans">
+              New to Paciolus?{' '}
+              <Link
+                href="/register"
+                className="text-sage-400 hover:text-sage-300 font-medium transition-colors"
+              >
+                Create an account
+              </Link>
+            </p>
+          </motion.div>
+        </motion.div>
+
+        {/* Bottom Link - Back to Home */}
+        <motion.div
+          className="mt-6 text-center"
+          variants={itemVariants}
+        >
+          <Link
+            href="/"
+            className="text-oatmeal-500 hover:text-oatmeal-400 text-sm font-sans transition-colors inline-flex items-center gap-2"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 19l-7-7m0 0l7-7m-7 7h18"
+              />
+            </svg>
+            Back to Paciolus
+          </Link>
+        </motion.div>
+      </motion.div>
+    </main>
+  )
+}

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,0 +1,659 @@
+'use client'
+
+import { useState, useMemo, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { motion } from 'framer-motion'
+import Link from 'next/link'
+import { useAuth } from '@/context/AuthContext'
+import { useFormValidation, commonValidators } from '@/hooks'
+
+/**
+ * Obsidian Vault Registration Page - Day 13
+ *
+ * Design: Same vault aesthetic as login with password strength indicator.
+ * Zero-Storage Promise badge reinforces trust messaging.
+ *
+ * Refactored: Now uses useFormValidation hook for form state management
+ *
+ * See: skills/theme-factory/themes/oat-and-obsidian.md
+ */
+
+interface PasswordStrength {
+  score: number // 0-5
+  label: string
+  color: string
+  requirements: {
+    length: boolean
+    uppercase: boolean
+    lowercase: boolean
+    number: boolean
+    special: boolean
+  }
+}
+
+function calculatePasswordStrength(password: string): PasswordStrength {
+  const requirements = {
+    length: password.length >= 8,
+    uppercase: /[A-Z]/.test(password),
+    lowercase: /[a-z]/.test(password),
+    number: /[0-9]/.test(password),
+    special: /[!@#$%^&*(),.?":{}|<>]/.test(password),
+  }
+
+  const score = Object.values(requirements).filter(Boolean).length
+
+  const labels = ['Very Weak', 'Weak', 'Fair', 'Strong', 'Very Strong']
+  const colors = ['clay-500', 'clay-400', 'oatmeal-400', 'sage-400', 'sage-500']
+
+  return {
+    score,
+    label: labels[score - 1] || 'Very Weak',
+    color: colors[score - 1] || 'clay-500',
+    requirements,
+  }
+}
+
+interface RegisterFormValues {
+  email: string
+  password: string
+  confirmPassword: string
+  acceptTerms: boolean
+}
+
+const initialValues: RegisterFormValues = {
+  email: '',
+  password: '',
+  confirmPassword: '',
+  acceptTerms: false,
+}
+
+export default function RegisterPage() {
+  const router = useRouter()
+  const { register, isAuthenticated, isLoading: authLoading } = useAuth()
+
+  // Server-side error (from failed registration attempt)
+  const [serverError, setServerError] = useState('')
+
+  // Form state via useFormValidation hook
+  const {
+    values,
+    isSubmitting,
+    isValid,
+    setValue,
+    handleSubmit,
+  } = useFormValidation<RegisterFormValues>({
+    initialValues,
+    validationRules: {
+      email: [
+        commonValidators.required('Email is required'),
+        commonValidators.email('Please enter a valid email'),
+      ],
+      password: [
+        commonValidators.required('Password is required'),
+        commonValidators.minLength(8, 'Password must be at least 8 characters'),
+        {
+          test: (value) => {
+            if (typeof value !== 'string') return true
+            const strength = calculatePasswordStrength(value)
+            return strength.score >= 3
+          },
+          message: 'Please choose a stronger password',
+        },
+      ],
+      confirmPassword: [
+        commonValidators.required('Please confirm your password'),
+        commonValidators.matches<RegisterFormValues>('password', 'Passwords do not match'),
+      ],
+      acceptTerms: [
+        {
+          test: (value) => value === true,
+          message: 'Please accept the terms of service',
+        },
+      ],
+    },
+    onSubmit: async (formValues) => {
+      setServerError('')
+
+      const result = await register({
+        email: formValues.email,
+        password: formValues.password,
+      })
+
+      if (result.success) {
+        router.push('/')
+      } else {
+        setServerError(result.error || 'Registration failed. Please try again.')
+      }
+    },
+  })
+
+  // Password strength for UI display (separate from validation)
+  const passwordStrength = useMemo(
+    () => calculatePasswordStrength(values.password),
+    [values.password]
+  )
+
+  // Computed: do passwords match (for UI indicator)
+  const passwordsMatch = values.password === values.confirmPassword && values.confirmPassword.length > 0
+
+  // Redirect if already authenticated
+  useEffect(() => {
+    if (!authLoading && isAuthenticated) {
+      router.push('/')
+    }
+  }, [isAuthenticated, authLoading, router])
+
+  // Button disabled state
+  const isButtonDisabled = isSubmitting || !values.acceptTerms || !passwordsMatch || passwordStrength.score < 3
+
+  // Animation variants
+  const containerVariants = {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 1,
+      transition: {
+        staggerChildren: 0.1,
+        delayChildren: 0.1,
+      },
+    },
+  }
+
+  const itemVariants = {
+    hidden: { opacity: 0, y: 20 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        type: 'spring' as const,
+        stiffness: 300,
+        damping: 24,
+      },
+    },
+  }
+
+  const vaultIconVariants = {
+    hidden: { scale: 0.8, opacity: 0, rotateY: -15 },
+    visible: {
+      scale: 1,
+      opacity: 1,
+      rotateY: 0,
+      transition: {
+        type: 'spring' as const,
+        stiffness: 200,
+        damping: 20,
+        delay: 0.2,
+      },
+    },
+  }
+
+  return (
+    <main className="min-h-screen bg-gradient-obsidian flex items-center justify-center p-6">
+      <motion.div
+        className="w-full max-w-md"
+        variants={containerVariants}
+        initial="hidden"
+        animate="visible"
+      >
+        {/* Vault Card */}
+        <motion.div
+          className="bg-obsidian-800 border border-obsidian-600 rounded-2xl shadow-2xl overflow-hidden"
+          variants={itemVariants}
+        >
+          {/* Header with Vault Icon */}
+          <div className="px-8 pt-8 pb-6 text-center border-b border-obsidian-700">
+            {/* Vault Icon - with key symbol for registration */}
+            <motion.div
+              className="w-20 h-20 mx-auto mb-4 rounded-2xl bg-obsidian-700 border border-obsidian-500 flex items-center justify-center"
+              variants={vaultIconVariants}
+            >
+              <svg
+                className="w-10 h-10 text-sage-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
+                />
+              </svg>
+            </motion.div>
+
+            <motion.h1
+              className="text-2xl font-serif font-bold text-oatmeal-200 mb-2"
+              variants={itemVariants}
+            >
+              Create Your Vault
+            </motion.h1>
+
+            <motion.p
+              className="text-oatmeal-400 font-sans text-sm"
+              variants={itemVariants}
+            >
+              Join Paciolus for secure trial balance auditing
+            </motion.p>
+          </div>
+
+          {/* Zero-Storage Badge */}
+          <motion.div
+            className="px-8 py-4 bg-obsidian-700/30 border-b border-obsidian-700"
+            variants={itemVariants}
+          >
+            <div className="flex items-center justify-center gap-2">
+              <div className="w-2 h-2 bg-sage-400 rounded-full animate-pulse"></div>
+              <span className="text-sage-300 text-sm font-sans font-medium">
+                Zero-Storage Architecture
+              </span>
+            </div>
+            <p className="text-oatmeal-500 text-xs font-sans text-center mt-2">
+              Your financial data is never stored. Only credentials are saved securely.
+            </p>
+          </motion.div>
+
+          {/* Registration Form */}
+          <motion.form
+            onSubmit={handleSubmit}
+            className="px-8 py-6 space-y-5"
+            variants={itemVariants}
+          >
+            {/* Server Error Message */}
+            {serverError && (
+              <motion.div
+                className="p-4 rounded-lg bg-clay-500/10 border border-clay-500/30"
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+              >
+                <div className="flex items-center gap-3">
+                  <svg
+                    className="w-5 h-5 text-clay-400 flex-shrink-0"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                  <p className="text-clay-300 text-sm font-sans">{serverError}</p>
+                </div>
+              </motion.div>
+            )}
+
+            {/* Email Input */}
+            <div>
+              <label
+                htmlFor="email"
+                className="block text-sm font-sans font-medium text-oatmeal-300 mb-2"
+              >
+                Email Address
+              </label>
+              <div className="relative">
+                <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+                  <svg
+                    className="w-5 h-5 text-oatmeal-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9m4.5-1.206a8.959 8.959 0 01-4.5 1.207"
+                    />
+                  </svg>
+                </div>
+                <input
+                  type="email"
+                  id="email"
+                  value={values.email}
+                  onChange={(e) => setValue('email', e.target.value)}
+                  placeholder="you@company.com"
+                  required
+                  className="w-full pl-12 pr-4 py-3 bg-obsidian-900 border border-obsidian-500 rounded-xl text-oatmeal-200 placeholder-oatmeal-600 font-sans focus:outline-none focus:ring-2 focus:ring-sage-500 focus:border-transparent transition-all"
+                />
+              </div>
+            </div>
+
+            {/* Password Input */}
+            <div>
+              <label
+                htmlFor="password"
+                className="block text-sm font-sans font-medium text-oatmeal-300 mb-2"
+              >
+                Password
+              </label>
+              <div className="relative">
+                <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+                  <svg
+                    className="w-5 h-5 text-oatmeal-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  type="password"
+                  id="password"
+                  value={values.password}
+                  onChange={(e) => setValue('password', e.target.value)}
+                  placeholder="Create a strong password"
+                  required
+                  className="w-full pl-12 pr-4 py-3 bg-obsidian-900 border border-obsidian-500 rounded-xl text-oatmeal-200 placeholder-oatmeal-600 font-sans focus:outline-none focus:ring-2 focus:ring-sage-500 focus:border-transparent transition-all"
+                />
+              </div>
+
+              {/* Password Strength Indicator */}
+              {values.password.length > 0 && (
+                <motion.div
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: 'auto' }}
+                  className="mt-3 space-y-2"
+                >
+                  {/* Strength Bar */}
+                  <div className="flex gap-1">
+                    {[1, 2, 3, 4, 5].map((level) => (
+                      <div
+                        key={level}
+                        className={`h-1.5 flex-1 rounded-full transition-all ${
+                          level <= passwordStrength.score
+                            ? level <= 2
+                              ? 'bg-clay-500'
+                              : level <= 3
+                              ? 'bg-oatmeal-400'
+                              : 'bg-sage-500'
+                            : 'bg-obsidian-600'
+                        }`}
+                      />
+                    ))}
+                  </div>
+
+                  {/* Strength Label */}
+                  <div className="flex justify-between items-center">
+                    <span
+                      className={`text-xs font-sans font-medium ${
+                        passwordStrength.score <= 2
+                          ? 'text-clay-400'
+                          : passwordStrength.score === 3
+                          ? 'text-oatmeal-300'
+                          : 'text-sage-400'
+                      }`}
+                    >
+                      {passwordStrength.label}
+                    </span>
+                  </div>
+
+                  {/* Requirements Checklist */}
+                  <div className="grid grid-cols-2 gap-1 text-xs font-sans">
+                    <div className={`flex items-center gap-1 ${passwordStrength.requirements.length ? 'text-sage-400' : 'text-oatmeal-500'}`}>
+                      {passwordStrength.requirements.length ? (
+                        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+                          <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        </svg>
+                      ) : (
+                        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <circle cx="12" cy="12" r="10" strokeWidth={2} />
+                        </svg>
+                      )}
+                      8+ characters
+                    </div>
+                    <div className={`flex items-center gap-1 ${passwordStrength.requirements.uppercase ? 'text-sage-400' : 'text-oatmeal-500'}`}>
+                      {passwordStrength.requirements.uppercase ? (
+                        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+                          <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        </svg>
+                      ) : (
+                        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <circle cx="12" cy="12" r="10" strokeWidth={2} />
+                        </svg>
+                      )}
+                      Uppercase
+                    </div>
+                    <div className={`flex items-center gap-1 ${passwordStrength.requirements.lowercase ? 'text-sage-400' : 'text-oatmeal-500'}`}>
+                      {passwordStrength.requirements.lowercase ? (
+                        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+                          <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        </svg>
+                      ) : (
+                        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <circle cx="12" cy="12" r="10" strokeWidth={2} />
+                        </svg>
+                      )}
+                      Lowercase
+                    </div>
+                    <div className={`flex items-center gap-1 ${passwordStrength.requirements.number ? 'text-sage-400' : 'text-oatmeal-500'}`}>
+                      {passwordStrength.requirements.number ? (
+                        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+                          <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        </svg>
+                      ) : (
+                        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <circle cx="12" cy="12" r="10" strokeWidth={2} />
+                        </svg>
+                      )}
+                      Number
+                    </div>
+                    <div className={`flex items-center gap-1 col-span-2 ${passwordStrength.requirements.special ? 'text-sage-400' : 'text-oatmeal-500'}`}>
+                      {passwordStrength.requirements.special ? (
+                        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+                          <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        </svg>
+                      ) : (
+                        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <circle cx="12" cy="12" r="10" strokeWidth={2} />
+                        </svg>
+                      )}
+                      Special character (!@#$%^&*)
+                    </div>
+                  </div>
+                </motion.div>
+              )}
+            </div>
+
+            {/* Confirm Password Input */}
+            <div>
+              <label
+                htmlFor="confirmPassword"
+                className="block text-sm font-sans font-medium text-oatmeal-300 mb-2"
+              >
+                Confirm Password
+              </label>
+              <div className="relative">
+                <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+                  <svg
+                    className="w-5 h-5 text-oatmeal-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  type="password"
+                  id="confirmPassword"
+                  value={values.confirmPassword}
+                  onChange={(e) => setValue('confirmPassword', e.target.value)}
+                  placeholder="Confirm your password"
+                  required
+                  className={`w-full pl-12 pr-10 py-3 bg-obsidian-900 border rounded-xl text-oatmeal-200 placeholder-oatmeal-600 font-sans focus:outline-none focus:ring-2 focus:ring-sage-500 focus:border-transparent transition-all ${
+                    values.confirmPassword.length > 0
+                      ? passwordsMatch
+                        ? 'border-sage-500'
+                        : 'border-clay-500'
+                      : 'border-obsidian-500'
+                  }`}
+                />
+                {values.confirmPassword.length > 0 && (
+                  <div className="absolute inset-y-0 right-0 pr-4 flex items-center">
+                    {passwordsMatch ? (
+                      <svg className="w-5 h-5 text-sage-400" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                      </svg>
+                    ) : (
+                      <svg className="w-5 h-5 text-clay-400" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+                      </svg>
+                    )}
+                  </div>
+                )}
+              </div>
+              {values.confirmPassword.length > 0 && !passwordsMatch && (
+                <p className="mt-2 text-xs text-clay-400 font-sans">
+                  Passwords do not match
+                </p>
+              )}
+            </div>
+
+            {/* Terms Acceptance */}
+            <div>
+              <label className="flex items-start gap-3 cursor-pointer">
+                <div
+                  className={`mt-0.5 w-5 h-5 rounded border-2 flex items-center justify-center flex-shrink-0 transition-all ${
+                    values.acceptTerms
+                      ? 'bg-sage-500 border-sage-500'
+                      : 'border-oatmeal-500/50 hover:border-oatmeal-400'
+                  }`}
+                  onClick={() => setValue('acceptTerms', !values.acceptTerms)}
+                >
+                  {values.acceptTerms && (
+                    <svg className="w-3 h-3 text-obsidian-900" fill="currentColor" viewBox="0 0 20 20">
+                      <path
+                        fillRule="evenodd"
+                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  )}
+                </div>
+                <input
+                  type="checkbox"
+                  checked={values.acceptTerms}
+                  onChange={(e) => setValue('acceptTerms', e.target.checked)}
+                  className="sr-only"
+                  required
+                />
+                <span className="text-sm text-oatmeal-400 font-sans">
+                  I agree to the{' '}
+                  <button
+                    type="button"
+                    className="text-sage-400 hover:text-sage-300 underline transition-colors"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      // TODO: Open terms modal
+                    }}
+                  >
+                    Terms of Service
+                  </button>
+                  {' '}and{' '}
+                  <button
+                    type="button"
+                    className="text-sage-400 hover:text-sage-300 underline transition-colors"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      // TODO: Open privacy modal
+                    }}
+                  >
+                    Privacy Policy
+                  </button>
+                </span>
+              </label>
+            </div>
+
+            {/* Submit Button */}
+            <button
+              type="submit"
+              disabled={isButtonDisabled}
+              className={`w-full py-3 rounded-xl font-sans font-bold transition-all transform ${
+                isButtonDisabled
+                  ? 'bg-obsidian-600 text-oatmeal-500 cursor-not-allowed'
+                  : 'bg-sage-500 hover:bg-sage-400 text-obsidian-900 hover:scale-[1.02] active:scale-[0.98]'
+              }`}
+            >
+              {isSubmitting ? (
+                <span className="flex items-center justify-center gap-2">
+                  <div className="w-5 h-5 border-2 border-oatmeal-400/30 border-t-oatmeal-400 rounded-full animate-spin"></div>
+                  Creating Your Vault...
+                </span>
+              ) : (
+                <span className="flex items-center justify-center gap-2">
+                  <svg
+                    className="w-5 h-5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
+                    />
+                  </svg>
+                  Create My Vault
+                </span>
+              )}
+            </button>
+          </motion.form>
+
+          {/* Footer - Login Link */}
+          <motion.div
+            className="px-8 py-5 bg-obsidian-700/30 border-t border-obsidian-700 text-center"
+            variants={itemVariants}
+          >
+            <p className="text-oatmeal-400 text-sm font-sans">
+              Already have a vault?{' '}
+              <Link
+                href="/login"
+                className="text-sage-400 hover:text-sage-300 font-medium transition-colors"
+              >
+                Sign in
+              </Link>
+            </p>
+          </motion.div>
+        </motion.div>
+
+        {/* Bottom Link - Back to Home */}
+        <motion.div
+          className="mt-6 text-center"
+          variants={itemVariants}
+        >
+          <Link
+            href="/"
+            className="text-oatmeal-500 hover:text-oatmeal-400 text-sm font-sans transition-colors inline-flex items-center gap-2"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 19l-7-7m0 0l7-7m-7 7h18"
+              />
+            </svg>
+            Back to Paciolus
+          </Link>
+        </motion.div>
+      </motion.div>
+    </main>
+  )
+}

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Paciolus Hooks
+ * Centralized exports for custom React hooks.
+ *
+ * Phase 2 Refactor: Named exports only (no default exports)
+ */
+
+export { useClients } from './useClients';
+export { useSettings } from './useSettings';
+export {
+  useFormValidation,
+  commonValidators,
+  type ValidationRule,
+  type ValidationRules,
+  type FormValues,
+  type FormErrors,
+  type TouchedFields,
+  type UseFormValidationConfig,
+  type UseFormValidationReturn,
+} from './useFormValidation';

--- a/frontend/src/hooks/useFormValidation.ts
+++ b/frontend/src/hooks/useFormValidation.ts
@@ -1,0 +1,517 @@
+/**
+ * useFormValidation - Shared Form Validation Hook
+ *
+ * Abstracts common form patterns from:
+ * - CreateClientModal (field-level validation, touched tracking)
+ * - Login/Register pages (form-level validation, submit state)
+ *
+ * Features:
+ * - Generic type support for form values
+ * - Declarative validation rules
+ * - Per-field and form-level validation
+ * - Touched state tracking
+ * - Submit state management
+ * - Reset functionality
+ *
+ * @example
+ * const { values, errors, touched, handleChange, handleBlur, handleSubmit, isValid } = useFormValidation({
+ *   initialValues: { name: '', email: '' },
+ *   validationRules: {
+ *     name: [
+ *       { test: (v) => !!v.trim(), message: 'Name is required' },
+ *       { test: (v) => v.length >= 2, message: 'Name must be at least 2 characters' },
+ *     ],
+ *     email: [
+ *       { test: (v) => !!v.trim(), message: 'Email is required' },
+ *       { test: (v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v), message: 'Invalid email format' },
+ *     ],
+ *   },
+ *   onSubmit: async (values) => { ... },
+ * });
+ */
+
+import { useState, useCallback, useMemo } from 'react';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Single validation rule for a field
+ */
+export interface ValidationRule<T, K extends keyof T = keyof T> {
+  /** Test function - returns true if valid */
+  test: (value: T[K], allValues: T) => boolean;
+  /** Error message to display when test fails */
+  message: string;
+}
+
+/**
+ * Validation rules mapped to form field keys
+ */
+export type ValidationRules<T> = {
+  [K in keyof T]?: ValidationRule<T, K>[];
+};
+
+/**
+ * Errors object - maps field names to error messages
+ */
+export type FormErrors<T> = {
+  [K in keyof T]?: string;
+};
+
+/**
+ * Touched state - maps field names to boolean (has been blurred)
+ */
+export type TouchedFields<T> = {
+  [K in keyof T]?: boolean;
+};
+
+/**
+ * Base constraint for form values - allows any object with string keys
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type FormValues = { [key: string]: any };
+
+/**
+ * Configuration for useFormValidation hook
+ */
+export interface UseFormValidationConfig<T extends FormValues> {
+  /** Initial form values */
+  initialValues: T;
+  /** Validation rules per field */
+  validationRules?: ValidationRules<T>;
+  /** Callback when form is submitted and valid */
+  onSubmit?: (values: T) => void | Promise<void>;
+  /** Whether to validate on change (default: false, validates on blur) */
+  validateOnChange?: boolean;
+  /** Whether to validate on blur (default: true) */
+  validateOnBlur?: boolean;
+}
+
+/**
+ * Return type of useFormValidation hook
+ */
+export interface UseFormValidationReturn<T extends FormValues> {
+  /** Current form values */
+  values: T;
+  /** Current validation errors */
+  errors: FormErrors<T>;
+  /** Fields that have been touched (blurred) */
+  touched: TouchedFields<T>;
+  /** Whether form is currently submitting */
+  isSubmitting: boolean;
+  /** Whether form has been submitted at least once */
+  isSubmitted: boolean;
+  /** Whether all fields are valid */
+  isValid: boolean;
+  /** Whether form has any changes from initial values */
+  isDirty: boolean;
+
+  // Field handlers
+  /** Set a single field value */
+  setValue: <K extends keyof T>(field: K, value: T[K]) => void;
+  /** Set multiple field values at once */
+  setValues: (values: Partial<T>) => void;
+  /** Handle input change event */
+  handleChange: (field: keyof T) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => void;
+  /** Handle field blur event */
+  handleBlur: (field: keyof T) => () => void;
+  /** Set a field as touched */
+  setTouched: (field: keyof T, isTouched?: boolean) => void;
+  /** Set all fields as touched */
+  setAllTouched: () => void;
+
+  // Validation
+  /** Validate a single field, returns error message or undefined */
+  validateField: (field: keyof T) => string | undefined;
+  /** Validate all fields, returns true if valid */
+  validate: () => boolean;
+  /** Set a custom error for a field */
+  setError: (field: keyof T, message: string | undefined) => void;
+  /** Clear all errors */
+  clearErrors: () => void;
+
+  // Form actions
+  /** Handle form submission */
+  handleSubmit: (e?: React.FormEvent) => Promise<void>;
+  /** Reset form to initial values */
+  reset: (newInitialValues?: T) => void;
+  /** Get props for an input field (value, onChange, onBlur) */
+  getFieldProps: (field: keyof T) => {
+    value: T[keyof T];
+    onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => void;
+    onBlur: () => void;
+  };
+  /** Get field state (error, touched, hasValue) for styling */
+  getFieldState: (field: keyof T) => {
+    error: string | undefined;
+    touched: boolean;
+    hasValue: boolean;
+    hasError: boolean;
+    showError: boolean;
+  };
+}
+
+// ============================================================================
+// Hook Implementation
+// ============================================================================
+
+export function useFormValidation<T extends FormValues>(
+  config: UseFormValidationConfig<T>
+): UseFormValidationReturn<T> {
+  const {
+    initialValues,
+    validationRules = {} as ValidationRules<T>,
+    onSubmit,
+    validateOnChange = false,
+    validateOnBlur = true,
+  } = config;
+
+  // Core state
+  const [values, setValuesState] = useState<T>(initialValues);
+  const [errors, setErrors] = useState<FormErrors<T>>({});
+  const [touched, setTouchedState] = useState<TouchedFields<T>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  // -------------------------------------------------------------------------
+  // Validation
+  // -------------------------------------------------------------------------
+
+  /**
+   * Validate a single field against its rules
+   */
+  const validateField = useCallback(
+    (field: keyof T): string | undefined => {
+      const fieldRules = validationRules[field];
+      if (!fieldRules || fieldRules.length === 0) {
+        return undefined;
+      }
+
+      const value = values[field];
+
+      for (const rule of fieldRules) {
+        if (!rule.test(value, values)) {
+          return rule.message;
+        }
+      }
+
+      return undefined;
+    },
+    [values, validationRules]
+  );
+
+  /**
+   * Validate all fields
+   */
+  const validate = useCallback((): boolean => {
+    const newErrors: FormErrors<T> = {};
+    let isValid = true;
+
+    // Validate each field that has rules
+    for (const field of Object.keys(validationRules) as (keyof T)[]) {
+      const error = validateField(field);
+      if (error) {
+        newErrors[field] = error;
+        isValid = false;
+      }
+    }
+
+    setErrors(newErrors);
+    return isValid;
+  }, [validateField, validationRules]);
+
+  // -------------------------------------------------------------------------
+  // Computed values
+  // -------------------------------------------------------------------------
+
+  const isValid = useMemo(() => {
+    for (const field of Object.keys(validationRules) as (keyof T)[]) {
+      const error = validateField(field);
+      if (error) return false;
+    }
+    return true;
+  }, [validateField, validationRules]);
+
+  const isDirty = useMemo(() => {
+    for (const key of Object.keys(initialValues) as (keyof T)[]) {
+      if (values[key] !== initialValues[key]) return true;
+    }
+    return false;
+  }, [values, initialValues]);
+
+  // -------------------------------------------------------------------------
+  // Field handlers
+  // -------------------------------------------------------------------------
+
+  const setValue = useCallback(
+    <K extends keyof T>(field: K, value: T[K]) => {
+      setValuesState((prev) => ({ ...prev, [field]: value }));
+
+      if (validateOnChange) {
+        // Validate after state update
+        setTimeout(() => {
+          const fieldRules = validationRules[field];
+          if (fieldRules) {
+            const newValues = { ...values, [field]: value };
+            let error: string | undefined;
+            for (const rule of fieldRules) {
+              if (!rule.test(value, newValues)) {
+                error = rule.message;
+                break;
+              }
+            }
+            setErrors((prev) => ({ ...prev, [field]: error }));
+          }
+        }, 0);
+      }
+    },
+    [validateOnChange, validationRules, values]
+  );
+
+  const setValues = useCallback((newValues: Partial<T>) => {
+    setValuesState((prev) => ({ ...prev, ...newValues }));
+  }, []);
+
+  const handleChange = useCallback(
+    (field: keyof T) =>
+      (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+        const { type } = e.target;
+        const value = type === 'checkbox'
+          ? (e.target as HTMLInputElement).checked
+          : e.target.value;
+        setValue(field, value as T[keyof T]);
+      },
+    [setValue]
+  );
+
+  const handleBlur = useCallback(
+    (field: keyof T) => () => {
+      setTouchedState((prev) => ({ ...prev, [field]: true }));
+
+      if (validateOnBlur) {
+        const error = validateField(field);
+        setErrors((prev) => ({ ...prev, [field]: error }));
+      }
+    },
+    [validateOnBlur, validateField]
+  );
+
+  const setTouched = useCallback((field: keyof T, isTouched = true) => {
+    setTouchedState((prev) => ({ ...prev, [field]: isTouched }));
+  }, []);
+
+  const setAllTouched = useCallback(() => {
+    const allTouched: TouchedFields<T> = {};
+    for (const key of Object.keys(initialValues) as (keyof T)[]) {
+      allTouched[key] = true;
+    }
+    setTouchedState(allTouched);
+  }, [initialValues]);
+
+  // -------------------------------------------------------------------------
+  // Error handlers
+  // -------------------------------------------------------------------------
+
+  const setError = useCallback((field: keyof T, message: string | undefined) => {
+    setErrors((prev) => ({ ...prev, [field]: message }));
+  }, []);
+
+  const clearErrors = useCallback(() => {
+    setErrors({});
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Form actions
+  // -------------------------------------------------------------------------
+
+  const handleSubmit = useCallback(
+    async (e?: React.FormEvent) => {
+      if (e) {
+        e.preventDefault();
+      }
+
+      setIsSubmitted(true);
+      setAllTouched();
+
+      if (!validate()) {
+        return;
+      }
+
+      if (onSubmit) {
+        setIsSubmitting(true);
+        try {
+          await onSubmit(values);
+        } finally {
+          setIsSubmitting(false);
+        }
+      }
+    },
+    [validate, onSubmit, values, setAllTouched]
+  );
+
+  const reset = useCallback(
+    (newInitialValues?: T) => {
+      const resetValues = newInitialValues ?? initialValues;
+      setValuesState(resetValues);
+      setErrors({});
+      setTouchedState({});
+      setIsSubmitting(false);
+      setIsSubmitted(false);
+    },
+    [initialValues]
+  );
+
+  // -------------------------------------------------------------------------
+  // Convenience getters
+  // -------------------------------------------------------------------------
+
+  const getFieldProps = useCallback(
+    (field: keyof T) => ({
+      value: values[field],
+      onChange: handleChange(field),
+      onBlur: handleBlur(field),
+    }),
+    [values, handleChange, handleBlur]
+  );
+
+  const getFieldState = useCallback(
+    (field: keyof T) => {
+      const error = errors[field];
+      const isTouched = touched[field] ?? false;
+      const value = values[field];
+      const hasValue = value !== undefined && value !== null && value !== '';
+
+      return {
+        error,
+        touched: isTouched,
+        hasValue,
+        hasError: !!error,
+        showError: (isTouched || isSubmitted) && !!error,
+      };
+    },
+    [errors, touched, values, isSubmitted]
+  );
+
+  // -------------------------------------------------------------------------
+  // Return
+  // -------------------------------------------------------------------------
+
+  return {
+    // State
+    values,
+    errors,
+    touched,
+    isSubmitting,
+    isSubmitted,
+    isValid,
+    isDirty,
+
+    // Field handlers
+    setValue,
+    setValues,
+    handleChange,
+    handleBlur,
+    setTouched,
+    setAllTouched,
+
+    // Validation
+    validateField,
+    validate,
+    setError,
+    clearErrors,
+
+    // Form actions
+    handleSubmit,
+    reset,
+    getFieldProps,
+    getFieldState,
+  };
+}
+
+// ============================================================================
+// Common Validation Rules (Reusable)
+// ============================================================================
+
+/**
+ * Pre-built validation rules for common use cases
+ */
+export const commonValidators = {
+  /** Field is required (non-empty after trim) */
+  required: (message = 'This field is required'): ValidationRule<FormValues> => ({
+    test: (value) => {
+      if (typeof value === 'string') return value.trim().length > 0;
+      if (typeof value === 'boolean') return true; // Booleans are always "filled"
+      return value !== null && value !== undefined;
+    },
+    message,
+  }),
+
+  /** Minimum length for strings */
+  minLength: (min: number, message?: string): ValidationRule<FormValues> => ({
+    test: (value) => {
+      if (typeof value !== 'string') return true;
+      return value.trim().length >= min;
+    },
+    message: message ?? `Must be at least ${min} characters`,
+  }),
+
+  /** Maximum length for strings */
+  maxLength: (max: number, message?: string): ValidationRule<FormValues> => ({
+    test: (value) => {
+      if (typeof value !== 'string') return true;
+      return value.trim().length <= max;
+    },
+    message: message ?? `Must be no more than ${max} characters`,
+  }),
+
+  /** Valid email format */
+  email: (message = 'Invalid email address'): ValidationRule<FormValues> => ({
+    test: (value) => {
+      if (typeof value !== 'string' || !value.trim()) return true; // Let required handle empty
+      return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+    },
+    message,
+  }),
+
+  /** Matches another field (e.g., confirm password) */
+  matches: <T extends FormValues>(
+    otherField: keyof T,
+    message = 'Fields must match'
+  ): ValidationRule<T> => ({
+    test: (value, allValues) => value === allValues[otherField],
+    message,
+  }),
+
+  /** Minimum numeric value */
+  min: (min: number, message?: string): ValidationRule<FormValues> => ({
+    test: (value) => {
+      const num = typeof value === 'string' ? parseFloat(value) : value;
+      if (typeof num !== 'number' || isNaN(num)) return true;
+      return num >= min;
+    },
+    message: message ?? `Must be at least ${min}`,
+  }),
+
+  /** Maximum numeric value */
+  max: (max: number, message?: string): ValidationRule<FormValues> => ({
+    test: (value) => {
+      const num = typeof value === 'string' ? parseFloat(value) : value;
+      if (typeof num !== 'number' || isNaN(num)) return true;
+      return num <= max;
+    },
+    message: message ?? `Must be no more than ${max}`,
+  }),
+
+  /** Custom regex pattern */
+  pattern: (regex: RegExp, message = 'Invalid format'): ValidationRule<FormValues> => ({
+    test: (value) => {
+      if (typeof value !== 'string' || !value.trim()) return true;
+      return regex.test(value);
+    },
+    message,
+  }),
+};
+
+export default useFormValidation;


### PR DESCRIPTION
## Summary
- Add `useFormValidation` hook with declarative validation rules and common validators
- Refactor `CreateClientModal`, `Login`, and `Register` pages to use the new hook
- Reduce ~55 lines of duplicated form state management across components

## Changes
| Component | Before | After |
|-----------|--------|-------|
| CreateClientModal | 5 useState hooks | 1 useFormValidation |
| Login page | 4 useState hooks | 1 useFormValidation + serverError |
| Register page | 5 useState hooks | 1 useFormValidation + serverError |

## New Hook Features
- Generic TypeScript support for form values
- Declarative validation rules with `commonValidators` (required, email, minLength, maxLength, matches, etc.)
- Per-field and form-level validation
- Touched state tracking
- `getFieldState()` helper for input styling
- `isSubmitting`, `isValid`, `isDirty` computed flags

## Test plan
- [x] `npm run build` passes
- [ ] Verify CreateClientModal form validation works
- [ ] Verify Login page form submission works
- [ ] Verify Register page password matching and strength validation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)