### PR TITLE
Add company name next to logo in marketing navigation toolbar

### DIFF
--- a/frontend/src/components/marketing/MarketingNav.tsx
+++ b/frontend/src/components/marketing/MarketingNav.tsx
@@ -78,6 +78,9 @@ export function MarketingNav() {
               height={510}
               className="h-9 w-auto max-h-9 object-contain transition-opacity group-hover:opacity-80"
             />
+            <span className="text-lg font-serif font-semibold text-oatmeal-100 tracking-wide transition-opacity group-hover:opacity-80">
+              Paciolus
+            </span>
           </Link>
 
           {/* Desktop Nav */}


### PR DESCRIPTION
Display "Paciolus" text beside the logo in MarketingNav using font-serif (Merriweather) to match the Oat & Obsidian brand identity.

https://claude.ai/code/session_01T4Fc38mLaUr9NJCRVfC6pp