### PR TITLE
Sprint 594: Email case-insensitivity fix (prod lockout hotfix)

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -477,9 +477,22 @@ class AuthResponse(BaseModel):
 # =============================================================================
 
 
+def normalize_email(email: str) -> str:
+    """
+    Canonicalize an email for storage and lookup.
+
+    Email local-parts are formally case-sensitive per RFC 5321, but every
+    mail provider we care about treats them case-insensitively in practice.
+    We lowercase + strip so that register/login/reset/change-email all agree
+    on a single canonical form, preventing "account exists but I can't log in"
+    lockouts when the user types a different case than at registration.
+    """
+    return email.strip().lower()
+
+
 def get_user_by_email(db: Session, email: str) -> Optional[User]:
-    """Get a user by email address."""
-    return db.query(User).filter(User.email == email).first()
+    """Get a user by email address (case-insensitive lookup)."""
+    return db.query(User).filter(User.email == normalize_email(email)).first()
 
 
 def create_user(db: Session, user_data: UserCreate) -> User:
@@ -488,16 +501,17 @@ def create_user(db: Session, user_data: UserCreate) -> User:
 
     SECURITY: Password is hashed before storage.
     Plaintext password is NEVER stored or logged.
+    Email is normalized (lowercased + stripped) for consistent lookup.
     """
     hashed = hash_password(user_data.password)
 
-    db_user = User(email=user_data.email, hashed_password=hashed)
+    db_user = User(email=normalize_email(user_data.email), hashed_password=hashed)
 
     db.add(db_user)
     db.commit()
     db.refresh(db_user)
 
-    log_secure_operation("user_created", f"New user registered: {mask_email(user_data.email)}")
+    log_secure_operation("user_created", f"New user registered: {mask_email(db_user.email)}")
 
     return db_user
 
@@ -545,10 +559,10 @@ def update_user_profile(db: Session, user: User, profile_data: UserProfileUpdate
 
     verification_token = None
 
-    if profile_data.email and profile_data.email != user.email:
-        new_email = profile_data.email
+    if profile_data.email and normalize_email(profile_data.email) != user.email:
+        new_email = normalize_email(profile_data.email)
 
-        # Check if new email is already taken
+        # Check if new email is already taken (case-insensitive)
         existing = db.query(User).filter(User.email == new_email, User.id != user.id).first()
         if existing:
             raise ValueError("Email already in use by another account")

--- a/backend/migrations/alembic/versions/f7b3c91a04e2_normalize_user_emails_lowercase.py
+++ b/backend/migrations/alembic/versions/f7b3c91a04e2_normalize_user_emails_lowercase.py
@@ -1,0 +1,90 @@
+"""Normalize user.email to lowercase + stripped form.
+
+Fixes the production lockout where a mixed-case registration created a
+user row whose email did not match the lowercased lookup performed by
+/auth/forgot-password (and, after the accompanying code fix, by
+/auth/login and /auth/register as well).
+
+Strategy:
+  1. Detect case-collision groups. If `SELECT LOWER(TRIM(email)) ... GROUP BY 1
+     HAVING COUNT(*) > 1` returns any rows, abort with a clear error so the
+     operator can resolve duplicates manually — we refuse to silently drop
+     user data.
+  2. Otherwise, UPDATE users SET email = LOWER(TRIM(email)) for any row that
+     is not already normalized.
+  3. Apply the same normalization to `pending_email` for consistency with
+     the Sprint 203 email-change flow.
+
+Downgrade is a no-op: lowercasing is not reversible, and restoring the
+original casing would require information we no longer have.
+
+Revision ID: f7b3c91a04e2
+Revises: a848ac91d39a
+Create Date: 2026-04-09
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f7b3c91a04e2"
+down_revision = "a848ac91d39a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # 1. Detect case-collision groups — refuse to clobber real data.
+    collisions = bind.execute(
+        sa.text(
+            """
+            SELECT LOWER(TRIM(email)) AS normalized, COUNT(*) AS n
+            FROM users
+            WHERE email IS NOT NULL
+            GROUP BY LOWER(TRIM(email))
+            HAVING COUNT(*) > 1
+            """
+        )
+    ).fetchall()
+
+    if collisions:
+        rows = ", ".join(f"{row.normalized!r}={row.n}" for row in collisions)
+        raise RuntimeError(
+            "Email normalization aborted: case-colliding user rows detected "
+            f"({rows}). Resolve duplicates manually before re-running this "
+            "migration."
+        )
+
+    # 2. Lowercase + strip existing emails. Only touch rows that need it to
+    #    minimize UPDATE noise on quiet tables.
+    bind.execute(
+        sa.text(
+            """
+            UPDATE users
+            SET email = LOWER(TRIM(email))
+            WHERE email IS NOT NULL
+              AND email <> LOWER(TRIM(email))
+            """
+        )
+    )
+
+    # 3. Same treatment for pending_email (Sprint 203 flow).
+    bind.execute(
+        sa.text(
+            """
+            UPDATE users
+            SET pending_email = LOWER(TRIM(pending_email))
+            WHERE pending_email IS NOT NULL
+              AND pending_email <> LOWER(TRIM(pending_email))
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # No-op: case-folding is lossy.
+    pass

--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -430,7 +430,7 @@ def forgot_password(
         message="If an account with that email exists, a password reset link has been sent."
     )
 
-    user = get_user_by_email(db, body.email.strip().lower())
+    user = get_user_by_email(db, body.email)
     if not user:
         # Don't reveal whether the email is registered
         logger.info("Password reset requested for unknown email: %s", masked)

--- a/backend/tests/test_auth_routes_api.py
+++ b/backend/tests/test_auth_routes_api.py
@@ -176,6 +176,77 @@ class TestLogin:
             )
             assert response.status_code == 401
 
+    @pytest.mark.asyncio
+    async def test_register_then_login_case_insensitive(self, override_db):
+        """
+        Regression test for 2026-04-09 lockout incident.
+
+        A user registered with a mixed-case email, and /auth/login with a
+        lower-case email returned 401 because the DB lookup was case-sensitive.
+        Registration, login, and forgot-password must all agree on a single
+        canonical (lowercased) email form.
+        """
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+            # Register with mixed-case email
+            register_response = await client.post(
+                "/auth/register",
+                json={
+                    "email": "MixedCase@Example.COM",
+                    "password": TEST_PASSWORD,
+                },
+            )
+            assert register_response.status_code == 201
+            # Stored canonical form is lowercased
+            assert register_response.json()["user"]["email"] == "mixedcase@example.com"
+
+            # Lowercase login succeeds
+            lower_response = await client.post(
+                "/auth/login",
+                json={
+                    "email": "mixedcase@example.com",
+                    "password": TEST_PASSWORD,
+                },
+            )
+            assert lower_response.status_code == 200, (
+                "Lowercase login must match a mixed-case registration (2026-04-09 regression guard)"
+            )
+
+            # Alternating-case login succeeds
+            alt_response = await client.post(
+                "/auth/login",
+                json={
+                    "email": "mIxEdCaSe@ExAmPlE.cOm",
+                    "password": TEST_PASSWORD,
+                },
+            )
+            assert alt_response.status_code == 200
+
+            # Leading/trailing whitespace is tolerated
+            padded_response = await client.post(
+                "/auth/login",
+                json={
+                    "email": "  mixedcase@example.com  ",
+                    "password": TEST_PASSWORD,
+                },
+            )
+            assert padded_response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_register_duplicate_differs_only_in_case(self, override_db):
+        """A second registration with only case differences must be rejected."""
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+            first = await client.post(
+                "/auth/register",
+                json={"email": "dup@example.com", "password": TEST_PASSWORD},
+            )
+            assert first.status_code == 201
+
+            second = await client.post(
+                "/auth/register",
+                json={"email": "DUP@Example.com", "password": TEST_PASSWORD},
+            )
+            assert second.status_code == 400
+
 
 # =============================================================================
 # POST /auth/logout

--- a/scripts/smoke_test_render.sh
+++ b/scripts/smoke_test_render.sh
@@ -16,9 +16,12 @@
 #   3.  /auth/register succeeds and sets paciolus_access + paciolus_refresh HttpOnly cookies
 #   4.  Register response includes access_token + csrf_token + user object
 #   5.  /auth/me with the register cookies returns 200 and the same user
-#   6.  /auth/login (fresh attempt with a known-bad password) returns 401
-#   7.  /auth/logout succeeds and the Set-Cookie header clears both cookies
-#   8.  /auth/me after logout returns 401 (session is actually revoked)
+#   6.  /auth/login with the CORRECT password returns 200 (proves login works)
+#   7.  /auth/login with a known-bad password returns 401 (proves wrong creds rejected)
+#   8.  /auth/login with the registered email in DIFFERENT CASE returns 200
+#       (regression guard for case-sensitivity lockout — see 2026-04-09 incident)
+#   9.  /auth/logout succeeds and the Set-Cookie header clears both cookies
+#  10.  /auth/me after logout returns 401 (session is actually revoked)
 #
 # Exit codes:
 #   0  all checks pass
@@ -130,9 +133,38 @@ ME_EMAIL=$(jq -r '.email' <<<"$ME_JSON")
 pass "/auth/me returned correct user"
 
 # -----------------------------------------------------------------------------
-# Step 5: /auth/login with wrong password (should be 401)
+# Step 5a: /auth/login with CORRECT password (should be 200)
+#
+# Without this check, a broken login path can ship silently because /auth/me
+# succeeds via the cookie set by /auth/register. The 2026-04-09 incident
+# (case-sensitive email lookup locking out a mixed-case registration) went
+# undetected precisely because this assertion was missing.
 # -----------------------------------------------------------------------------
-step "5. /auth/login (wrong password)"
+step "5a. /auth/login (correct password)"
+GOOD_LOGIN=$(jq -n --arg email "$TEST_EMAIL" --arg pw "$TEST_PASSWORD" \
+    '{email: $email, password: $pw}')
+
+GOOD_LOGIN_RESPONSE=$(curl --silent --show-error --max-time 15 \
+    -H "Content-Type: application/json" \
+    -H "X-Requested-With: XMLHttpRequest" \
+    -d "$GOOD_LOGIN" \
+    -w "\n%{http_code}" \
+    "$BASE_URL/auth/login")
+
+GOOD_LOGIN_CODE="${GOOD_LOGIN_RESPONSE##*$'\n'}"
+GOOD_LOGIN_JSON="${GOOD_LOGIN_RESPONSE%$'\n'*}"
+
+[ "$GOOD_LOGIN_CODE" = "200" ] || fail "/auth/login returned $GOOD_LOGIN_CODE (expected 200)\n$GOOD_LOGIN_JSON"
+pass "/auth/login accepted correct credentials"
+
+jq -e '.access_token' <<<"$GOOD_LOGIN_JSON" >/dev/null || fail "login response missing access_token"
+jq -e '.csrf_token'   <<<"$GOOD_LOGIN_JSON" >/dev/null || fail "login response missing csrf_token"
+pass "login response shape valid (access_token, csrf_token)"
+
+# -----------------------------------------------------------------------------
+# Step 5b: /auth/login with wrong password (should be 401)
+# -----------------------------------------------------------------------------
+step "5b. /auth/login (wrong password)"
 BAD_LOGIN=$(jq -n --arg email "$TEST_EMAIL" '{email: $email, password: "definitelyWrongPassword!1"}')
 
 BAD_LOGIN_CODE=$(curl --silent --max-time 15 --output /dev/null --write-out "%{http_code}" \
@@ -143,6 +175,34 @@ BAD_LOGIN_CODE=$(curl --silent --max-time 15 --output /dev/null --write-out "%{h
 
 [ "$BAD_LOGIN_CODE" = "401" ] && pass "/auth/login correctly rejected wrong password" \
                               || fail "/auth/login returned $BAD_LOGIN_CODE (expected 401)"
+
+# -----------------------------------------------------------------------------
+# Step 5c: /auth/login with mixed-case email (regression guard)
+#
+# Canonicalizing emails on register and lookup means the exact same account
+# must be reachable regardless of how the user types the email. Compute an
+# alternating-case variant and confirm login still returns 200.
+# -----------------------------------------------------------------------------
+step "5c. /auth/login (mixed-case email — regression guard)"
+MIXED_EMAIL=$(printf '%s' "$TEST_EMAIL" | awk '{
+    out="";
+    for (i=1; i<=length($0); i++) {
+        ch = substr($0, i, 1);
+        out = out (i % 2 == 0 ? toupper(ch) : tolower(ch));
+    }
+    print out
+}')
+MIXED_LOGIN=$(jq -n --arg email "$MIXED_EMAIL" --arg pw "$TEST_PASSWORD" \
+    '{email: $email, password: $pw}')
+
+MIXED_LOGIN_CODE=$(curl --silent --max-time 15 --output /dev/null --write-out "%{http_code}" \
+    -H "Content-Type: application/json" \
+    -H "X-Requested-With: XMLHttpRequest" \
+    -d "$MIXED_LOGIN" \
+    "$BASE_URL/auth/login")
+
+[ "$MIXED_LOGIN_CODE" = "200" ] && pass "/auth/login accepted mixed-case email ($MIXED_EMAIL)" \
+                                || fail "/auth/login returned $MIXED_LOGIN_CODE for mixed-case email $MIXED_EMAIL (expected 200 — case-insensitive lookup regression)"
 
 # -----------------------------------------------------------------------------
 # Step 6: /auth/logout

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -72,6 +72,29 @@
 - No `dangerouslySetInnerHTML` usage found in codebase (clean baseline)
 - `style-src 'unsafe-inline'` retained (React inline styles — documented limitation)
 
+### Sprint 594: Email Case-Insensitivity Fix (Production Lockout Hotfix)
+**Status:** COMPLETE
+**Goal:** Resolve 2026-04-09 production login lockout caused by case-sensitive email lookup
+
+**Incident:** CEO registered on prod Neon DB at 17:39 UTC, then could not log in or request a password reset at 21:24/22:07. Render logs showed `POST /auth/login 401` and `"Password reset requested for unknown email"`. Root cause: `create_user` stored the email exactly as typed (`auth.py:494`), but `forgot_password` did `get_user_by_email(db, body.email.strip().lower())` (`auth_routes.py:433`). A mixed-case registration created a user row that lowercased lookups could not find. Login's `get_user_by_email` was also case-sensitive, so the same row was unreachable from `/auth/login` when the email was typed in a different case. The Phase 1 smoke test masked the bug because it only verified `/auth/me` (which rides the cookie set by `/auth/register`) plus a deliberately-wrong-password `/auth/login → 401` — it never asserted that a correct-password `/auth/login` returns 200.
+
+**Changes:**
+- [x] Backend: new `normalize_email()` helper in `auth.py` — canonical form is `email.strip().lower()`
+- [x] Backend: `get_user_by_email` normalizes input before the ORM filter (case-insensitive lookup at the application layer)
+- [x] Backend: `create_user` stores the normalized email so existing-row checks are deterministic
+- [x] Backend: `update_user_profile` normalizes both the duplicate-email check and the `pending_email` assignment
+- [x] Backend: `/auth/forgot-password` drops its redundant inline `.strip().lower()` — normalization is centralized in `get_user_by_email`
+- [x] Migration: `f7b3c91a04e2_normalize_user_emails_lowercase.py` backfills `users.email` and `users.pending_email` with `LOWER(TRIM(...))`; aborts with a clear error if case-collision duplicates exist rather than silently dropping rows
+- [x] Smoke test: `scripts/smoke_test_render.sh` adds three new assertions — correct-password login → 200, wrong-password login → 401 (renamed 5b), mixed-case email login → 200 (regression guard)
+- [x] Tests: `test_register_then_login_case_insensitive` covers mixed-case register → lowercase/alt-case/padded login → 200; `test_register_duplicate_differs_only_in_case` asserts case-only duplicates are rejected at registration
+
+**Review:**
+- No existing tests or fixtures needed to change: `make_user` (bypasses `create_user`) and the existing test emails are already lowercase
+- Migration is idempotent: the `WHERE email <> LOWER(TRIM(email))` filter means re-running on an already-normalized table is a no-op
+- Downgrade is a deliberate no-op: lowercasing is lossy and restoring original casing would require information we no longer have
+- Backfill pre-check refuses to merge case-collision groups — operator must resolve manually. Production currently has one user (the CEO) so the collision branch is inert, but the guard protects future re-runs on a populated DB
+- Deploy sequence: push → Render auto-deploys → Alembic runs in Dockerfile entrypoint (per Sprint 545) → CEO retries password reset → SendGrid email arrives → CEO sets new password → login succeeds
+
 ### Sprint 593: Share-Link Security Hardening + Documentation Integrity CI
 **Status:** COMPLETE
 **Goal:** Strengthen public share-link security and prevent documentation drift


### PR DESCRIPTION
## Summary
- Fix production login lockout: CEO registered with a mixed-case email, but `get_user_by_email` used case-sensitive exact match while `/auth/forgot-password` lowercased the input — the account was reachable from neither endpoint.
- New `normalize_email()` helper (`strip().lower()`) applied uniformly at read and write time across `create_user`, `get_user_by_email`, and `update_user_profile`; redundant inline `.strip().lower()` removed from `/auth/forgot-password`.
- Alembic migration `f7b3c91a04e2` backfills `users.email` and `users.pending_email` with `LOWER(TRIM(...))`. Pre-check refuses to merge case-colliding rows so operator data cannot be silently dropped; downgrade is a deliberate no-op. Single head verified via `alembic heads`.
- `scripts/smoke_test_render.sh` adds the correct-password login → 200 assertion that was missing (the gap that let this bug ship), plus a mixed-case login regression guard.

## Root cause

```
register input:  Comcgee89@gmail.com
EmailStr:        Comcgee89@gmail.com   (lowercases domain only)
create_user:     Comcgee89@gmail.com   (stored as-is)

login input:     comcgee89@gmail.com
exact match:     NO ROW FOUND → 401

forgot-password input: comcgee89@gmail.com
.strip().lower():      comcgee89@gmail.com
exact match:           NO ROW FOUND → "unknown email" log
```

The Phase 1 smoke test passed because it verified `/auth/me` (which rides the cookie set by `/auth/register`) and an intentional wrong-password `/auth/login` → 401. Correct-password login was never exercised end-to-end.

## Test plan
- [x] `backend/tests/test_auth_routes_api.py::TestLogin::test_register_then_login_case_insensitive` — mixed-case register → lowercase / alternating-case / whitespace-padded login → 200
- [x] `backend/tests/test_auth_routes_api.py::TestLogin::test_register_duplicate_differs_only_in_case` — case-only duplicate registration → 400
- [x] `pytest tests/test_auth_routes_api.py` — 28 passed (2 new)
- [x] `pytest tests/test_password_reset.py tests/test_email_change.py tests/test_password_revocation.py` — 49 passed (adjacent auth surfaces)
- [x] `pytest tests/` — 7,363 passed, 19 xfailed, 0 failures
- [x] Migration SQL dry-run on sqlite: normalizes mixed-case + whitespace-padded + uppercase-domain rows, leaves already-normalized rows untouched, collision pre-check correctly catches manually-inserted duplicates
- [x] `alembic heads` → single head `f7b3c91a04e2`
- [ ] Post-merge: retry `/auth/forgot-password` on paciolus.com → SendGrid email arrives → set new password → login succeeds

## Deploy sequence
1. Merge PR
2. Render auto-deploys from `main`
3. Alembic runs at container start (Sprint 545 entrypoint) → existing CEO user row lowercased in Neon
4. CEO retries password reset → email arrives → new password set → login works

🤖 Generated with [Claude Code](https://claude.com/claude-code)