### PR TITLE
Sprint 595: verify-email 422 fix + forgot-password diagnostic

### DIFF
--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -432,8 +432,22 @@ def forgot_password(
 
     user = get_user_by_email(db, body.email)
     if not user:
-        # Don't reveal whether the email is registered
-        logger.info("Password reset requested for unknown email: %s", masked)
+        # Don't reveal whether the email is registered.
+        # Temporary diagnostic (Sprint 594/595 incident): when the lookup
+        # fails, log the total user row count so we can distinguish
+        # "DB was wiped" (count=0) from "stored email does not match typed
+        # email" (count>0). No PII is leaked — we never log other users'
+        # addresses. Remove this instrumentation once the post-incident
+        # root cause is fully understood.
+        try:
+            total_users = db.query(User).count()
+        except Exception:  # pragma: no cover — diagnostic must never block the response
+            total_users = -1
+        logger.info(
+            "Password reset requested for unknown email: %s (total_users=%d)",
+            masked,
+            total_users,
+        )
         return generic_response
 
     if not user.is_active:

--- a/backend/scripts/set_superadmin.py
+++ b/backend/scripts/set_superadmin.py
@@ -24,6 +24,7 @@ import engagement_model  # noqa: F401
 import follow_up_items_model  # noqa: F401
 import subscription_model  # noqa: F401
 import tool_session_model  # noqa: F401
+from auth import get_user_by_email
 from database import SessionLocal
 from models import User
 
@@ -36,9 +37,13 @@ def main() -> None:
 
     db = SessionLocal()
     try:
-        user = db.query(User).filter(User.email == args.email).first()
+        # Sprint 594: `get_user_by_email` normalizes email case so a
+        # mixed-case registration can still be located from the CLI.
+        user = get_user_by_email(db, args.email)
         if not user:
+            total_users = db.query(User).count()
             print(f"ERROR: No user found with email '{args.email}'")
+            print(f"       Total user rows in DB: {total_users}")
             sys.exit(1)
 
         if args.revoke:

--- a/frontend/src/__tests__/VerificationContext.test.tsx
+++ b/frontend/src/__tests__/VerificationContext.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Regression test for the 2026-04-09 verify-email 422 incident.
+ *
+ * The bug: `VerificationContext.verifyEmail` was POSTing the token as a
+ * URL query parameter with an empty body, but the backend's
+ * `VerifyEmailRequest` is a Pydantic body model. Every click-through from
+ * a verification email produced 422 "Field required" because the body
+ * lacked `token`. Phase 1 only verified that the email *arrived*, never
+ * that clicking the link actually worked.
+ *
+ * This test locks the fix in place: the token must travel in the JSON body.
+ */
+import { ReactNode } from 'react'
+import { renderHook, act } from '@testing-library/react'
+import {
+  VerificationProvider,
+  useVerificationContext,
+} from '@/contexts/VerificationContext'
+import { apiPost } from '@/utils'
+
+// Minimal AuthSession mock — VerificationProvider reads token + refreshUser
+jest.mock('@/contexts/AuthSessionContext', () => ({
+  useAuthSession: () => ({
+    token: null,
+    refreshUser: jest.fn(),
+  }),
+}))
+
+jest.mock('@/utils', () => ({
+  apiPost: jest.fn(),
+  apiGet: jest.fn(),
+}))
+
+const mockApiPost = apiPost as jest.Mock
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <VerificationProvider>{children}</VerificationProvider>
+}
+
+describe('VerificationContext.verifyEmail — 2026-04-09 regression guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockApiPost.mockResolvedValue({
+      ok: true,
+      data: { message: 'ok', user: { id: 1, email: 'a@b.c', is_verified: true } },
+    })
+  })
+
+  it('POSTs token in the JSON body, not in the URL query string', async () => {
+    const { result } = renderHook(() => useVerificationContext(), { wrapper })
+
+    await act(async () => {
+      await result.current.verifyEmail('test-token-abc-123')
+    })
+
+    expect(mockApiPost).toHaveBeenCalledTimes(1)
+    const [endpoint, token, body] = mockApiPost.mock.calls[0]
+
+    // Endpoint must be the clean path without query params — Pydantic body
+    // models cannot read from the query string.
+    expect(endpoint).toBe('/auth/verify-email')
+    expect(endpoint).not.toContain('?')
+    expect(endpoint).not.toContain('token=')
+
+    // No bearer token (public endpoint).
+    expect(token).toBeNull()
+
+    // Body must contain the token field the backend schema expects.
+    expect(body).toEqual({ token: 'test-token-abc-123' })
+  })
+
+  it('returns success: true on 2xx response', async () => {
+    const { result } = renderHook(() => useVerificationContext(), { wrapper })
+
+    let response: { success: boolean; error?: string } | undefined
+    await act(async () => {
+      response = await result.current.verifyEmail('valid-token')
+    })
+
+    expect(response).toEqual({ success: true })
+  })
+
+  it('returns success: false with error message on failure', async () => {
+    mockApiPost.mockResolvedValue({
+      ok: false,
+      error: 'Invalid verification token',
+    })
+
+    const { result } = renderHook(() => useVerificationContext(), { wrapper })
+
+    let response: { success: boolean; error?: string } | undefined
+    await act(async () => {
+      response = await result.current.verifyEmail('bad-token')
+    })
+
+    expect(response).toEqual({
+      success: false,
+      error: 'Invalid verification token',
+    })
+  })
+})

--- a/frontend/src/contexts/VerificationContext.tsx
+++ b/frontend/src/contexts/VerificationContext.tsx
@@ -40,12 +40,18 @@ const VerificationContext = createContext<VerificationContextType | undefined>(u
 export function VerificationProvider({ children }: { children: ReactNode }): ReactElement {
   const { token: authToken, refreshUser } = useAuthSession()
 
-  // Verify email with token — no auth required
+  // Verify email with token — no auth required.
+  //
+  // NOTE: the token MUST be sent in the request body. The backend's
+  // `VerifyEmailRequest` is a Pydantic body model (not a query param), so
+  // passing the token via the URL query string produced a 422 on the
+  // missing body field. This was a latent bug until the 2026-04-09
+  // incident exposed it — Phase 1 only tested delivery, never click-through.
   const verifyEmail = useCallback(async (verificationToken: string): Promise<AuthResult> => {
     const { error, ok } = await apiPost<{ message: string; user: { id: number; email: string; is_verified: boolean } }>(
-      `/auth/verify-email?token=${encodeURIComponent(verificationToken)}`,
+      '/auth/verify-email',
       null,
-      {}
+      { token: verificationToken }
     )
 
     if (ok) {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -72,6 +72,30 @@
 - No `dangerouslySetInnerHTML` usage found in codebase (clean baseline)
 - `style-src 'unsafe-inline'` retained (React inline styles — documented limitation)
 
+### Sprint 595: verify-email 422 Fix + forgot-password Diagnostic
+**Status:** COMPLETE
+**Goal:** Unblock the production email-verification click-through and gather data on why post-Sprint-594 password reset still returns "unknown email".
+
+**Symptoms observed post-Sprint-594 deploy:**
+1. CEO clicks an email (from spam) → `/verify-email` page shows "Verification Failed". Render logs: `POST /auth/verify-email?token=... 422`.
+2. CEO retries `/auth/forgot-password` → still logs `"Password reset requested for unknown email: com***@gmail.com"`. The Sprint 594 migration ran cleanly (`Running upgrade a848ac91d39a -> f7b3c91a04e2`) but the lookup still fails.
+
+**Root cause (Problem A — verify-email 422):**
+`VerificationContext.verifyEmail` was calling `apiPost('/auth/verify-email?token=...', null, {})` — token in the URL query string, empty body. The backend's `VerifyEmailRequest` is a Pydantic body model requiring `{token: string}` in the JSON body, so every click-through 422'd on the missing field. Latent since Sprint 58 (original email verification work) because Phase 1 only tested email *delivery*, not the click-through path. The email the CEO kept clicking was the old verification email from the 17:39:51 registration sitting in spam.
+
+**Root cause (Problem B — unknown email):** still undetermined. Options are (a) the Neon DB has zero user rows (user wiped somehow between 17:39 creation and now), or (b) the stored email is genuinely different from `comcgee89@gmail.com` despite what the CEO is typing. Sprint 595 instruments this so the NEXT failure answers the question.
+
+**Changes:**
+- [x] Frontend: `VerificationContext.verifyEmail` now POSTs `'/auth/verify-email'` with `{token}` in the JSON body. Retains the `encodeURIComponent`-free path since tokens are already URL-safe hex.
+- [x] Frontend test: `src/__tests__/VerificationContext.test.tsx` — new file with 3 tests asserting (i) endpoint has no query string, (ii) body contains `{token}`, (iii) success/failure paths propagate correctly. Regression guard for this specific bug.
+- [x] Backend: `/auth/forgot-password` now logs `total_users=N` when the lookup fails. Zero PII leaked (we do not log other addresses). Temporary instrumentation — to be removed once the root cause is understood. Docstring notes the Sprint tie-in so it's clear this is not permanent.
+- [x] Backend: `scripts/set_superadmin.py` switches from raw `User.email == args.email` to `get_user_by_email(db, args.email)` so the CLI respects the Sprint 594 case-insensitive lookup. Also prints `total_users=N` on failure so a Render Shell session can diagnose from the other direction.
+
+**Review:**
+- All 40 backend auth/password-reset tests green (`test_auth_routes_api.py` + `test_password_reset.py`)
+- New `VerificationContext.test.tsx` — 3/3 pass
+- Deploy sequence: push → Vercel auto-deploys frontend → Render auto-deploys backend → CEO retries forgot-password → Render logs expose `total_users` → we know whether the DB is empty or the email is mismatched → either re-register or dig into the stored email
+
 ### Sprint 594: Email Case-Insensitivity Fix (Production Lockout Hotfix)
 **Status:** COMPLETE
 **Goal:** Resolve 2026-04-09 production login lockout caused by case-sensitive email lookup


### PR DESCRIPTION
## Summary
Two follow-ups to the 2026-04-09 production lockout incident (Sprint 594).

**Problem A (fixed):** `/verify-email` click-through always returned 422. `VerificationContext.verifyEmail` was calling `apiPost('/auth/verify-email?token=...', null, {})` — token in the URL query string, empty JSON body. The backend's `VerifyEmailRequest` is a Pydantic body model, so every click-through 422'd on the missing `token` field. Latent since Sprint 58 because Phase 1 only verified email *delivery*, never click-through. The email the CEO kept clicking was the original 17:39 registration verification email sitting in spam.

**Problem B (instrumented):** `/auth/forgot-password` returns "unknown email" for `comcgee89@gmail.com` even after the Sprint 594 migration ran successfully. We do not yet know whether Neon has 0 user rows (data loss) or N rows with a genuinely different stored email. This PR adds targeted logging so the next reset attempt answers the question without additional deploys.

## Changes
- **Frontend** (`VerificationContext.tsx`): `verifyEmail` now POSTs `'/auth/verify-email'` (clean path, no query params) with `{token: verificationToken}` in the JSON body. Matches the backend `VerifyEmailRequest` Pydantic schema.
- **Frontend test** (`VerificationContext.test.tsx`, new): 3 tests lock the fix in place — asserts endpoint has no `?token=`, body is `{token}`, and success/failure paths propagate.
- **Backend** (`auth_routes.py`): `/auth/forgot-password` now logs `total_users=N` when the lookup fails. Zero PII leaked. Marked as temporary diagnostic to be removed post-incident.
- **Backend script** (`set_superadmin.py`): switches from raw `User.email == args.email` to `get_user_by_email(db, args.email)` so the CLI respects Sprint 594 case-insensitivity, and prints `total_users=N` on failure so a Render Shell session can diagnose from the other direction.

## Test plan
- [x] `frontend/src/__tests__/VerificationContext.test.tsx` — 3/3 pass
- [x] Jest pre-commit gate — 1754 tests / 168 suites pass
- [x] `pytest tests/test_auth_routes_api.py tests/test_password_reset.py` — 40/40 pass
- [ ] Post-deploy: CEO clicks the old verification email from spam → `/verify-email` page shows success
- [ ] Post-deploy: CEO retries `/auth/forgot-password` → Render logs show `total_users=N` → we know whether to re-register or hunt the email mismatch

## Deploy sequence
1. Merge PR
2. Vercel auto-deploys frontend, Render auto-deploys backend
3. CEO retries forgot-password → Render logs expose `total_users` → definitive diagnostic
4. Based on the number:
   - `total_users=0` → DB was wiped at some point; re-register from scratch
   - `total_users>=1` → the stored email is genuinely different from what the CEO is typing; Render Shell + `python scripts/set_superadmin.py --email comcgee89@gmail.com` will identify the mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)