### PR TITLE
Sprint 596: UnverifiedCTA — explicit verification prompt on all tool pages

### DIFF
--- a/frontend/src/app/tools/ap-testing/page.tsx
+++ b/frontend/src/app/tools/ap-testing/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback } from 'react'
 import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { APScoreCard, APTestResultGrid, APDataQualityBadge, FlaggedPaymentTable } from '@/components/apTesting'
-import { GuestCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, ToolSettingsDrawer, CitationFooter } from '@/components/shared'
+import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, ToolSettingsDrawer, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractAPProof } from '@/components/shared/proof'
 import { useAPTesting } from '@/hooks/useAPTesting'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
@@ -86,6 +86,10 @@ export default function APTestingPage() {
         {/* Guest CTA */}
         {!authLoading && !isAuthenticated && (
           <GuestCTA description="AP Payment Testing requires a verified account. Sign in or create an account to analyze your payment data." />
+        )}
+
+        {!authLoading && isAuthenticated && !isVerified && (
+          <UnverifiedCTA />
         )}
 
         {/* State Choreography — Upload/Loading/Error/Results */}

--- a/frontend/src/app/tools/ar-aging/page.tsx
+++ b/frontend/src/app/tools/ar-aging/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useRef } from 'react'
 import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { ARScoreCard, ARTestResultGrid, ARDataQualityBadge, FlaggedARTable } from '@/components/arAging'
-import { GuestCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
+import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractARProof } from '@/components/shared/proof'
 import { useARAging } from '@/hooks/useARAging'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
@@ -92,6 +92,10 @@ export default function ARAgingPage() {
         {/* Guest CTA */}
         {!authLoading && !isAuthenticated && (
           <GuestCTA description="AR Aging Analysis requires a verified account. Sign in or create an account to analyze your receivables data." />
+        )}
+
+        {!authLoading && isAuthenticated && !isVerified && (
+          <UnverifiedCTA />
         )}
 
         {/* State blocks */}

--- a/frontend/src/app/tools/bank-rec/page.tsx
+++ b/frontend/src/app/tools/bank-rec/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useRef } from 'react'
 import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { MatchSummaryCards, BankRecMatchTable, ReconciliationBridge } from '@/components/bankRec'
-import { FileDropZone, GuestCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
+import { FileDropZone, GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractBankRecProof } from '@/components/shared/proof'
 import { useBankReconciliation } from '@/hooks/useBankReconciliation'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
@@ -156,6 +156,10 @@ export default function BankRecPage() {
         {/* Guest CTA */}
         {!authLoading && !isAuthenticated && (
           <GuestCTA description="Bank Reconciliation requires a verified account. Sign in or create an account to reconcile your data." />
+        )}
+
+        {!authLoading && isAuthenticated && !isVerified && (
+          <UnverifiedCTA />
         )}
 
         {/* State blocks — wrapped in ToolStatePresence for unified transitions */}

--- a/frontend/src/app/tools/fixed-assets/page.tsx
+++ b/frontend/src/app/tools/fixed-assets/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback } from 'react'
 import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { FixedAssetScoreCard, FixedAssetTestResultGrid, FixedAssetDataQualityBadge, FlaggedFixedAssetTable } from '@/components/fixedAssetTesting'
-import { GuestCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
+import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractFAProof } from '@/components/shared/proof'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
 import { useFileUpload } from '@/hooks/useFileUpload'
@@ -73,6 +73,10 @@ export default function FixedAssetTestingPage() {
         {/* Guest CTA */}
         {!authLoading && !isAuthenticated && (
           <GuestCTA description="Fixed Asset Testing requires a verified account. Sign in or create an account to analyze your fixed asset register." />
+        )}
+
+        {!authLoading && isAuthenticated && !isVerified && (
+          <UnverifiedCTA />
         )}
 
         {/* Tool State Blocks */}

--- a/frontend/src/app/tools/inventory-testing/page.tsx
+++ b/frontend/src/app/tools/inventory-testing/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback } from 'react'
 import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { InventoryScoreCard, InventoryTestResultGrid, InventoryDataQualityBadge, FlaggedInventoryTable } from '@/components/inventoryTesting'
-import { GuestCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
+import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractInventoryProof } from '@/components/shared/proof'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
 import { useFileUpload } from '@/hooks/useFileUpload'
@@ -73,6 +73,10 @@ export default function InventoryTestingPage() {
         {/* Guest CTA */}
         {!authLoading && !isAuthenticated && (
           <GuestCTA description="Inventory Testing requires a verified account. Sign in or create an account to analyze your inventory register." />
+        )}
+
+        {!authLoading && isAuthenticated && !isVerified && (
+          <UnverifiedCTA />
         )}
 
         {/* State blocks */}

--- a/frontend/src/app/tools/journal-entry-testing/page.tsx
+++ b/frontend/src/app/tools/journal-entry-testing/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback } from 'react'
 import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { JEScoreCard, TestResultGrid, GLDataQualityBadge, BenfordChart, FlaggedEntryTable, SamplingPanel } from '@/components/jeTesting'
-import { GuestCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, ToolSettingsDrawer, Citation, CitationFooter } from '@/components/shared'
+import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, ToolSettingsDrawer, Citation, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractJEProof } from '@/components/shared/proof'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
 import { useFileUpload } from '@/hooks/useFileUpload'
@@ -88,6 +88,10 @@ export default function JournalEntryTestingPage() {
         {/* Guest CTA */}
         {!authLoading && !isAuthenticated && (
           <GuestCTA description="Journal Entry Testing requires a verified account. Sign in or create an account to analyze your GL data." />
+        )}
+
+        {!authLoading && isAuthenticated && !isVerified && (
+          <UnverifiedCTA />
         )}
 
         {/* State Choreography — Upload/Loading/Error/Results */}

--- a/frontend/src/app/tools/payroll-testing/page.tsx
+++ b/frontend/src/app/tools/payroll-testing/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback } from 'react'
 import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { PayrollScoreCard, PayrollTestResultGrid, PayrollDataQualityBadge, FlaggedEmployeeTable } from '@/components/payrollTesting'
-import { GuestCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, ToolSettingsDrawer, CitationFooter } from '@/components/shared'
+import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, ToolSettingsDrawer, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractPayrollProof } from '@/components/shared/proof'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
 import { useFileUpload } from '@/hooks/useFileUpload'
@@ -88,6 +88,10 @@ export default function PayrollTestingPage() {
         {/* Guest CTA */}
         {!authLoading && !isAuthenticated && (
           <GuestCTA description="Payroll &amp; Employee Testing requires a verified account. Sign in or create an account to analyze your payroll data." />
+        )}
+
+        {!authLoading && isAuthenticated && !isVerified && (
+          <UnverifiedCTA />
         )}
 
         {/* Tool State Blocks */}

--- a/frontend/src/app/tools/revenue-testing/page.tsx
+++ b/frontend/src/app/tools/revenue-testing/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback } from 'react'
 import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { RevenueScoreCard, RevenueTestResultGrid, RevenueDataQualityBadge, FlaggedRevenueTable } from '@/components/revenueTesting'
-import { GuestCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
+import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractRevenueProof } from '@/components/shared/proof'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
 import { useFileUpload } from '@/hooks/useFileUpload'
@@ -110,6 +110,10 @@ export default function RevenueTestingPage() {
         {/* Guest CTA */}
         {!authLoading && !isAuthenticated && (
           <GuestCTA description="Revenue Testing requires a verified account. Sign in or create an account to analyze your revenue data." />
+        )}
+
+        {!authLoading && isAuthenticated && !isVerified && (
+          <UnverifiedCTA />
         )}
 
         {/* Tool State Blocks */}

--- a/frontend/src/app/tools/statistical-sampling/page.tsx
+++ b/frontend/src/app/tools/statistical-sampling/page.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { useCanvasAccent } from '@/contexts/CanvasAccentContext'
-import { GuestCTA, ZeroStorageNotice, DisclaimerBox, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
+import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
 import {
   SamplingDesignPanel,
   SampleSelectionTable,
@@ -169,8 +169,12 @@ export default function StatisticalSamplingPage() {
           <GuestCTA description="Statistical Sampling requires a verified account. Sign in or create an account to design and evaluate audit samples." />
         )}
 
+        {!authLoading && isAuthenticated && !isVerified && (
+          <UnverifiedCTA />
+        )}
+
         {/* Authenticated Content */}
-        {isAuthenticated && (
+        {isAuthenticated && isVerified && (
           <UpgradeGate toolName="sampling">
           <>
             {/* Tab Navigation */}

--- a/frontend/src/app/tools/three-way-match/page.tsx
+++ b/frontend/src/app/tools/three-way-match/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback } from 'react'
 import { useAuthSession } from '@/contexts/AuthSessionContext'
-import { GuestCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, FileDropZone, UpgradeGate, ToolSettingsDrawer, CitationFooter } from '@/components/shared'
+import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, FileDropZone, UpgradeGate, ToolSettingsDrawer, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractTWMProof } from '@/components/shared/proof'
 import { MatchSummaryCard, MatchResultsTable, UnmatchedDocumentsPanel, VarianceDetailCard } from '@/components/threeWayMatch'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
@@ -88,6 +88,10 @@ export default function ThreeWayMatchPage() {
         {/* Guest CTA */}
         {!authLoading && !isAuthenticated && (
           <GuestCTA description="Three-Way Match Validation requires a verified account. Sign in or create an account to match your procurement documents." />
+        )}
+
+        {!authLoading && isAuthenticated && !isVerified && (
+          <UnverifiedCTA />
         )}
 
         {/* State blocks — wrapped in ToolStatePresence for unified transitions */}

--- a/frontend/src/app/tools/trial-balance/page.tsx
+++ b/frontend/src/app/tools/trial-balance/page.tsx
@@ -7,7 +7,7 @@ import { EngagementDetailsPanel, MaterialityControl, DEFAULT_ENGAGEMENT_METADATA
 import type { EngagementMetadata } from '@/components/diagnostic'
 import { ColumnMappingModal } from '@/components/mapping'
 import { PreFlightSummary } from '@/components/preflight/PreFlightSummary'
-import { GuestCTA, DisclaimerBox, Citation, CitationFooter } from '@/components/shared'
+import { GuestCTA, UnverifiedCTA, DisclaimerBox, Citation, CitationFooter } from '@/components/shared'
 import { PdfExtractionPreview } from '@/components/shared/PdfExtractionPreview'
 import { AuditResultsPanel } from '@/components/trialBalance/AuditResultsPanel'
 import { WorkbookInspector } from '@/components/workbook'
@@ -92,6 +92,10 @@ function HomeContent() {
         {/* Guest CTA */}
         {!isAuthenticated && (
           <GuestCTA description="Trial Balance Diagnostics requires a verified account. Sign in or create an account to analyze your trial balance." />
+        )}
+
+        {isAuthenticated && !isVerified && (
+          <UnverifiedCTA />
         )}
 
         {isAuthenticated && isVerified && (

--- a/frontend/src/components/shared/UnverifiedCTA.tsx
+++ b/frontend/src/components/shared/UnverifiedCTA.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+/**
+ * UnverifiedCTA — Shared email-verification prompt for authenticated
+ * but unverified users.
+ *
+ * Displayed on tool pages when the user is logged in but has not yet
+ * verified their email address. Parallel to `GuestCTA` (which handles
+ * the unauthenticated case).
+ *
+ * Sprint 595: Created after the 2026-04-09 incident exposed that all
+ * 11 tool pages silently hid their entire UI behind `isVerified` with
+ * no explanation — users saw a blank page below the title and assumed
+ * the app was broken.
+ */
+export function UnverifiedCTA() {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="max-w-lg mx-auto theme-card rounded-2xl p-10 text-center mb-10"
+    >
+      <div className="w-16 h-16 mx-auto mb-6 rounded-full bg-clay-50 dark:bg-clay-500/10 border border-clay-500/20 flex items-center justify-center">
+        <svg className="w-8 h-8 text-clay-600 dark:text-clay-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+        </svg>
+      </div>
+      <h2 className="text-2xl font-serif font-bold text-content-primary mb-3">
+        Verify Your Email
+      </h2>
+      <p className="text-content-secondary font-sans mb-2">
+        This tool requires a verified email address before it can be used.
+      </p>
+      <p className="text-content-tertiary font-sans text-sm">
+        Check your inbox for a verification link, or use the banner above to resend.
+      </p>
+    </motion.div>
+  )
+}

--- a/frontend/src/components/shared/index.ts
+++ b/frontend/src/components/shared/index.ts
@@ -27,6 +27,7 @@ export { ToolNav, type ToolKey } from './ToolNav'
 export { FileDropZone } from './FileDropZone'
 
 export { GuestCTA } from './GuestCTA'
+export { UnverifiedCTA } from './UnverifiedCTA'
 export { ZeroStorageNotice } from './ZeroStorageNotice'
 export { DisclaimerBox } from './DisclaimerBox'
 export { BrandIcon, type BrandIconName, type IconSize, type IconTone, type IconState } from './BrandIcon'

--- a/tasks/archive/sprints-592-595-details.md
+++ b/tasks/archive/sprints-592-595-details.md
@@ -1,0 +1,105 @@
+# Sprints 592–595 Details
+
+> Archived from `tasks/todo.md` Active Phase on 2026-04-10.
+
+---
+
+### Sprint 592: Token Exposure Reduction — Cookie-Only Auth
+**Status:** COMPLETE
+**Goal:** Eliminate JS-readable bearer tokens from browser auth flow
+
+**Changes:**
+- [x] Backend: `paciolus_access` HttpOnly cookie set on login/register/refresh, cleared on logout
+- [x] Backend: `resolve_access_token` dependency — Bearer header (API clients) → cookie fallback (browser)
+- [x] Backend: JWT lifetime reduced 30m → 15m (config default + .env.example)
+- [x] Frontend: `injectAuthHeaders` no longer injects `Authorization: Bearer` header
+- [x] Frontend: `fetchCsrfToken`, `uploadTransport` — use cookie auth, not Bearer
+- [x] Frontend: `downloadAdapter` — add missing `credentials: 'include'`
+- [x] ESLint: XSS sink governance — `no-eval`, `no-implied-eval`, ban `dangerouslySetInnerHTML`, `innerHTML`, `document.write`
+- [x] Tests: 3 test suites updated (removed Bearer assertions), 1745 frontend + 26 backend auth tests pass
+
+**Review:**
+- Access token cookie: HttpOnly, Secure (prod), SameSite=None (prod) / Lax (dev), path=/, max-age=JWT_EXPIRATION_MINUTES*60
+- Bearer header still accepted for non-browser API clients (backward compatible)
+- No `dangerouslySetInnerHTML` usage found in codebase (clean baseline)
+- `style-src 'unsafe-inline'` retained (React inline styles — documented limitation)
+
+---
+
+### Sprint 593: Share-Link Security Hardening + Documentation Integrity CI
+**Status:** COMPLETE
+**Goal:** Strengthen public share-link security and prevent documentation drift
+
+**Changes:**
+- [x] DB migration: `passcode_hash` (String(64)) + `single_use` (Boolean) columns on `export_shares`
+- [x] Optional passcode protection: SHA-256 hashed passcode, 403 on wrong/missing passcode
+- [x] Single-use mode: auto-revoke (`revoked_at = now`) after first successful download
+- [x] Tier-configurable TTL: Professional 24h, Enterprise 48h (was 48h flat), `share_ttl_hours` entitlement
+- [x] Security headers: `Cache-Control: no-store` on download responses (middleware provides `X-Content-Type-Options`, `Referrer-Policy`)
+- [x] Download anomaly logging: per-download structured log (share_id, masked IP, UA hash), warning at >10 access_count
+- [x] Frontend: passcode input + single-use checkbox in ShareExportModal, protection column in shares page
+- [x] Doc consistency guard: `guards/doc_consistency_guard.py` — checks tier names, pricing, JWT expiry across docs vs code
+- [x] CI job: `doc-consistency` gate in ci.yml (blocking)
+- [x] Doc fixes: SECURITY_POLICY.md (JWT 30m→15m, Team/Org→Professional/Enterprise, TTL 48h→24-48h, 10 compensating controls)
+- [x] Doc fixes: TERMS_OF_SERVICE.md (Solo limits 20→100/10→unlimited, Team/Org→Professional/Enterprise, seat pricing $80/$70→$65/$45 flat)
+- [x] Tests: 25 backend (12 new: passcode, single-use, headers, TTL, anomaly), 20 frontend (6 new)
+
+**Review:**
+- Backward compatible: existing shares (passcode_hash=NULL, single_use=False) work unchanged
+- Passcode brute-force mitigated by existing 20/min rate limit on download endpoint
+- Single-use race condition: concurrent downloads both succeed, link revoked after first commit (acceptable for ephemeral links)
+- Guard catches tier name drift, pricing drift, JWT expiry drift — stdlib only, no external deps
+
+---
+
+### Sprint 594: Email Case-Insensitivity Fix (Production Lockout Hotfix)
+**Status:** COMPLETE
+**Goal:** Resolve 2026-04-09 production login lockout caused by case-sensitive email lookup
+
+**Incident:** CEO registered on prod Neon DB at 17:39 UTC, then could not log in or request a password reset at 21:24/22:07. Render logs showed `POST /auth/login 401` and `"Password reset requested for unknown email"`. Root cause: `create_user` stored the email exactly as typed (`auth.py:494`), but `forgot_password` did `get_user_by_email(db, body.email.strip().lower())` (`auth_routes.py:433`). A mixed-case registration created a user row that lowercased lookups could not find. Login's `get_user_by_email` was also case-sensitive, so the same row was unreachable from `/auth/login` when the email was typed in a different case. The Phase 1 smoke test masked the bug because it only verified `/auth/me` (which rides the cookie set by `/auth/register`) plus a deliberately-wrong-password `/auth/login → 401` — it never asserted that a correct-password `/auth/login` returns 200.
+
+**Changes:**
+- [x] Backend: new `normalize_email()` helper in `auth.py` — canonical form is `email.strip().lower()`
+- [x] Backend: `get_user_by_email` normalizes input before the ORM filter (case-insensitive lookup at the application layer)
+- [x] Backend: `create_user` stores the normalized email so existing-row checks are deterministic
+- [x] Backend: `update_user_profile` normalizes both the duplicate-email check and the `pending_email` assignment
+- [x] Backend: `/auth/forgot-password` drops its redundant inline `.strip().lower()` — normalization is centralized in `get_user_by_email`
+- [x] Migration: `f7b3c91a04e2_normalize_user_emails_lowercase.py` backfills `users.email` and `users.pending_email` with `LOWER(TRIM(...))`; aborts with a clear error if case-collision duplicates exist rather than silently dropping rows
+- [x] Smoke test: `scripts/smoke_test_render.sh` adds three new assertions — correct-password login → 200, wrong-password login → 401 (renamed 5b), mixed-case email login → 200 (regression guard)
+- [x] Tests: `test_register_then_login_case_insensitive` covers mixed-case register → lowercase/alt-case/padded login → 200; `test_register_duplicate_differs_only_in_case` asserts case-only duplicates are rejected at registration
+
+**Review:**
+- No existing tests or fixtures needed to change: `make_user` (bypasses `create_user`) and the existing test emails are already lowercase
+- Migration is idempotent: the `WHERE email <> LOWER(TRIM(email))` filter means re-running on an already-normalized table is a no-op
+- Downgrade is a deliberate no-op: lowercasing is lossy and restoring original casing would require information we no longer have
+- Backfill pre-check refuses to merge case-collision groups — operator must resolve manually. Production currently has one user (the CEO) so the collision branch is inert, but the guard protects future re-runs on a populated DB
+- Deploy sequence: push → Render auto-deploys → Alembic runs in Dockerfile entrypoint (per Sprint 545) → CEO retries password reset → SendGrid email arrives → CEO sets new password → login succeeds
+
+---
+
+### Sprint 595: verify-email 422 Fix + forgot-password Diagnostic
+**Status:** COMPLETE
+**Goal:** Unblock the production email-verification click-through and gather data on why post-Sprint-594 password reset still returns "unknown email".
+
+**Symptoms observed post-Sprint-594 deploy:**
+1. CEO clicks an email (from spam) → `/verify-email` page shows "Verification Failed". Render logs: `POST /auth/verify-email?token=... 422`.
+2. CEO retries `/auth/forgot-password` → still logs `"Password reset requested for unknown email: com***@gmail.com"`. The Sprint 594 migration ran cleanly (`Running upgrade a848ac91d39a -> f7b3c91a04e2`) but the lookup still fails.
+
+**Root cause (Problem A — verify-email 422):**
+`VerificationContext.verifyEmail` was calling `apiPost('/auth/verify-email?token=...', null, {})` — token in the URL query string, empty body. The backend's `VerifyEmailRequest` is a Pydantic body model requiring `{token: string}` in the JSON body, so every click-through 422'd on the missing field. Latent since Sprint 58 (original email verification work) because Phase 1 only tested email *delivery*, not the click-through path. The email the CEO kept clicking was the old verification email from the 17:39:51 registration sitting in spam.
+
+**Root cause (Problem B — unknown email):** still undetermined. Options are (a) the Neon DB has zero user rows (user wiped somehow between 17:39 creation and now), or (b) the stored email is genuinely different from `comcgee89@gmail.com` despite what the CEO is typing. Sprint 595 instruments this so the NEXT failure answers the question.
+
+**Changes:**
+- [x] Frontend: `VerificationContext.verifyEmail` now POSTs `'/auth/verify-email'` with `{token}` in the JSON body. Retains the `encodeURIComponent`-free path since tokens are already URL-safe hex.
+- [x] Frontend test: `src/__tests__/VerificationContext.test.tsx` — new file with 3 tests asserting (i) endpoint has no query string, (ii) body contains `{token}`, (iii) success/failure paths propagate correctly. Regression guard for this specific bug.
+- [x] Backend: `/auth/forgot-password` now logs `total_users=N` when the lookup fails. Zero PII leaked (we do not log other addresses). Temporary instrumentation — to be removed once the root cause is understood. Docstring notes the Sprint tie-in so it's clear this is not permanent.
+- [x] Backend: `scripts/set_superadmin.py` switches from raw `User.email == args.email` to `get_user_by_email(db, args.email)` so the CLI respects the Sprint 594 case-insensitive lookup. Also prints `total_users=N` on failure so a Render Shell session can diagnose from the other direction.
+
+**Review:**
+- All 40 backend auth/password-reset tests green (`test_auth_routes_api.py` + `test_password_reset.py`)
+- New `VerificationContext.test.tsx` — 3/3 pass
+- Deploy sequence: push → Vercel auto-deploys frontend → Render auto-deploys backend → CEO retries forgot-password → Render logs expose `total_users` → we know whether the DB is empty or the email is mismatched → either re-register or dig into the stored email
+
+---
+

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -51,95 +51,23 @@
 > Sprints 572–578 archived to `tasks/archive/sprints-572-578-details.md`.
 > Sprints 579–585 archived to `tasks/archive/sprints-579-585-details.md`.
 > Sprints 586–591 archived to `tasks/archive/sprints-586-591-details.md`.
+> Sprints 592–595 archived to `tasks/archive/sprints-592-595-details.md`.
 
-### Sprint 592: Token Exposure Reduction — Cookie-Only Auth
+### Sprint 596: UnverifiedCTA — Explicit Verification Prompt on All Tool Pages
 **Status:** COMPLETE
-**Goal:** Eliminate JS-readable bearer tokens from browser auth flow
+**Goal:** Replace silent content gating with an explicit "Verify Your Email" card so unverified users understand why tool pages appear blank
+
+**Problem:** 11 of 12 tool pages hid their entire UI behind `isAuthenticated && isVerified` with no explanation. Authenticated users who hadn't verified their email saw only the page title and a blank area below — no upload zone, no controls, no message. The `VerificationBanner` in the top shell existed but was a small dismissible bar, easily overlooked. Users assumed the app was broken.
 
 **Changes:**
-- [x] Backend: `paciolus_access` HttpOnly cookie set on login/register/refresh, cleared on logout
-- [x] Backend: `resolve_access_token` dependency — Bearer header (API clients) → cookie fallback (browser)
-- [x] Backend: JWT lifetime reduced 30m → 15m (config default + .env.example)
-- [x] Frontend: `injectAuthHeaders` no longer injects `Authorization: Bearer` header
-- [x] Frontend: `fetchCsrfToken`, `uploadTransport` — use cookie auth, not Bearer
-- [x] Frontend: `downloadAdapter` — add missing `credentials: 'include'`
-- [x] ESLint: XSS sink governance — `no-eval`, `no-implied-eval`, ban `dangerouslySetInnerHTML`, `innerHTML`, `document.write`
-- [x] Tests: 3 test suites updated (removed Bearer assertions), 1745 frontend + 26 backend auth tests pass
+- [x] New `UnverifiedCTA` component (`frontend/src/components/shared/UnverifiedCTA.tsx`) — email icon, "Verify Your Email" heading, explanation text, pointer to the resend banner. Oat & Obsidian tokens, motion entrance animation. Parallel to `GuestCTA`.
+- [x] Exported from `frontend/src/components/shared/index.ts`
+- [x] Added `{isAuthenticated && !isVerified && (<UnverifiedCTA />)}` block to all 11 tool pages: trial-balance, ap-testing, ar-aging, bank-rec, fixed-assets, inventory-testing, journal-entry-testing, payroll-testing, revenue-testing, statistical-sampling, three-way-match
+- [x] Multi-period page left untouched — already has its own inline "Verify Your Email" card (Pattern B)
+- [x] `npm run build` passes — all 12 tool pages compile cleanly
 
 **Review:**
-- Access token cookie: HttpOnly, Secure (prod), SameSite=None (prod) / Lax (dev), path=/, max-age=JWT_EXPIRATION_MINUTES*60
-- Bearer header still accepted for non-browser API clients (backward compatible)
-- No `dangerouslySetInnerHTML` usage found in codebase (clean baseline)
-- `style-src 'unsafe-inline'` retained (React inline styles — documented limitation)
-
-### Sprint 595: verify-email 422 Fix + forgot-password Diagnostic
-**Status:** COMPLETE
-**Goal:** Unblock the production email-verification click-through and gather data on why post-Sprint-594 password reset still returns "unknown email".
-
-**Symptoms observed post-Sprint-594 deploy:**
-1. CEO clicks an email (from spam) → `/verify-email` page shows "Verification Failed". Render logs: `POST /auth/verify-email?token=... 422`.
-2. CEO retries `/auth/forgot-password` → still logs `"Password reset requested for unknown email: com***@gmail.com"`. The Sprint 594 migration ran cleanly (`Running upgrade a848ac91d39a -> f7b3c91a04e2`) but the lookup still fails.
-
-**Root cause (Problem A — verify-email 422):**
-`VerificationContext.verifyEmail` was calling `apiPost('/auth/verify-email?token=...', null, {})` — token in the URL query string, empty body. The backend's `VerifyEmailRequest` is a Pydantic body model requiring `{token: string}` in the JSON body, so every click-through 422'd on the missing field. Latent since Sprint 58 (original email verification work) because Phase 1 only tested email *delivery*, not the click-through path. The email the CEO kept clicking was the old verification email from the 17:39:51 registration sitting in spam.
-
-**Root cause (Problem B — unknown email):** still undetermined. Options are (a) the Neon DB has zero user rows (user wiped somehow between 17:39 creation and now), or (b) the stored email is genuinely different from `comcgee89@gmail.com` despite what the CEO is typing. Sprint 595 instruments this so the NEXT failure answers the question.
-
-**Changes:**
-- [x] Frontend: `VerificationContext.verifyEmail` now POSTs `'/auth/verify-email'` with `{token}` in the JSON body. Retains the `encodeURIComponent`-free path since tokens are already URL-safe hex.
-- [x] Frontend test: `src/__tests__/VerificationContext.test.tsx` — new file with 3 tests asserting (i) endpoint has no query string, (ii) body contains `{token}`, (iii) success/failure paths propagate correctly. Regression guard for this specific bug.
-- [x] Backend: `/auth/forgot-password` now logs `total_users=N` when the lookup fails. Zero PII leaked (we do not log other addresses). Temporary instrumentation — to be removed once the root cause is understood. Docstring notes the Sprint tie-in so it's clear this is not permanent.
-- [x] Backend: `scripts/set_superadmin.py` switches from raw `User.email == args.email` to `get_user_by_email(db, args.email)` so the CLI respects the Sprint 594 case-insensitive lookup. Also prints `total_users=N` on failure so a Render Shell session can diagnose from the other direction.
-
-**Review:**
-- All 40 backend auth/password-reset tests green (`test_auth_routes_api.py` + `test_password_reset.py`)
-- New `VerificationContext.test.tsx` — 3/3 pass
-- Deploy sequence: push → Vercel auto-deploys frontend → Render auto-deploys backend → CEO retries forgot-password → Render logs expose `total_users` → we know whether the DB is empty or the email is mismatched → either re-register or dig into the stored email
-
-### Sprint 594: Email Case-Insensitivity Fix (Production Lockout Hotfix)
-**Status:** COMPLETE
-**Goal:** Resolve 2026-04-09 production login lockout caused by case-sensitive email lookup
-
-**Incident:** CEO registered on prod Neon DB at 17:39 UTC, then could not log in or request a password reset at 21:24/22:07. Render logs showed `POST /auth/login 401` and `"Password reset requested for unknown email"`. Root cause: `create_user` stored the email exactly as typed (`auth.py:494`), but `forgot_password` did `get_user_by_email(db, body.email.strip().lower())` (`auth_routes.py:433`). A mixed-case registration created a user row that lowercased lookups could not find. Login's `get_user_by_email` was also case-sensitive, so the same row was unreachable from `/auth/login` when the email was typed in a different case. The Phase 1 smoke test masked the bug because it only verified `/auth/me` (which rides the cookie set by `/auth/register`) plus a deliberately-wrong-password `/auth/login → 401` — it never asserted that a correct-password `/auth/login` returns 200.
-
-**Changes:**
-- [x] Backend: new `normalize_email()` helper in `auth.py` — canonical form is `email.strip().lower()`
-- [x] Backend: `get_user_by_email` normalizes input before the ORM filter (case-insensitive lookup at the application layer)
-- [x] Backend: `create_user` stores the normalized email so existing-row checks are deterministic
-- [x] Backend: `update_user_profile` normalizes both the duplicate-email check and the `pending_email` assignment
-- [x] Backend: `/auth/forgot-password` drops its redundant inline `.strip().lower()` — normalization is centralized in `get_user_by_email`
-- [x] Migration: `f7b3c91a04e2_normalize_user_emails_lowercase.py` backfills `users.email` and `users.pending_email` with `LOWER(TRIM(...))`; aborts with a clear error if case-collision duplicates exist rather than silently dropping rows
-- [x] Smoke test: `scripts/smoke_test_render.sh` adds three new assertions — correct-password login → 200, wrong-password login → 401 (renamed 5b), mixed-case email login → 200 (regression guard)
-- [x] Tests: `test_register_then_login_case_insensitive` covers mixed-case register → lowercase/alt-case/padded login → 200; `test_register_duplicate_differs_only_in_case` asserts case-only duplicates are rejected at registration
-
-**Review:**
-- No existing tests or fixtures needed to change: `make_user` (bypasses `create_user`) and the existing test emails are already lowercase
-- Migration is idempotent: the `WHERE email <> LOWER(TRIM(email))` filter means re-running on an already-normalized table is a no-op
-- Downgrade is a deliberate no-op: lowercasing is lossy and restoring original casing would require information we no longer have
-- Backfill pre-check refuses to merge case-collision groups — operator must resolve manually. Production currently has one user (the CEO) so the collision branch is inert, but the guard protects future re-runs on a populated DB
-- Deploy sequence: push → Render auto-deploys → Alembic runs in Dockerfile entrypoint (per Sprint 545) → CEO retries password reset → SendGrid email arrives → CEO sets new password → login succeeds
-
-### Sprint 593: Share-Link Security Hardening + Documentation Integrity CI
-**Status:** COMPLETE
-**Goal:** Strengthen public share-link security and prevent documentation drift
-
-**Changes:**
-- [x] DB migration: `passcode_hash` (String(64)) + `single_use` (Boolean) columns on `export_shares`
-- [x] Optional passcode protection: SHA-256 hashed passcode, 403 on wrong/missing passcode
-- [x] Single-use mode: auto-revoke (`revoked_at = now`) after first successful download
-- [x] Tier-configurable TTL: Professional 24h, Enterprise 48h (was 48h flat), `share_ttl_hours` entitlement
-- [x] Security headers: `Cache-Control: no-store` on download responses (middleware provides `X-Content-Type-Options`, `Referrer-Policy`)
-- [x] Download anomaly logging: per-download structured log (share_id, masked IP, UA hash), warning at >10 access_count
-- [x] Frontend: passcode input + single-use checkbox in ShareExportModal, protection column in shares page
-- [x] Doc consistency guard: `guards/doc_consistency_guard.py` — checks tier names, pricing, JWT expiry across docs vs code
-- [x] CI job: `doc-consistency` gate in ci.yml (blocking)
-- [x] Doc fixes: SECURITY_POLICY.md (JWT 30m→15m, Team/Org→Professional/Enterprise, TTL 48h→24-48h, 10 compensating controls)
-- [x] Doc fixes: TERMS_OF_SERVICE.md (Solo limits 20→100/10→unlimited, Team/Org→Professional/Enterprise, seat pricing $80/$70→$65/$45 flat)
-- [x] Tests: 25 backend (12 new: passcode, single-use, headers, TTL, anomaly), 20 frontend (6 new)
-
-**Review:**
-- Backward compatible: existing shares (passcode_hash=NULL, single_use=False) work unchanged
-- Passcode brute-force mitigated by existing 20/min rate limit on download endpoint
-- Single-use race condition: concurrent downloads both succeed, link revoked after first commit (acceptable for ephemeral links)
-- Guard catches tier name drift, pricing drift, JWT expiry drift — stdlib only, no external deps
+- Consistent three-state UX across all tools: unauthenticated → GuestCTA, unverified → UnverifiedCTA, verified → full tool UI
+- The `VerificationBanner` in `AuthenticatedShell` still renders above the CTA for redundancy (resend button lives there)
+- No backend changes; purely frontend UX improvement
 


### PR DESCRIPTION
## Summary
- New `UnverifiedCTA` component shows "Verify Your Email" card with email icon, explanation, and pointer to the resend banner. Displayed on all tool pages for authenticated-but-unverified users.
- Fixes the blank-page UX: 11 of 12 tool pages previously hid their entire UI behind `isAuthenticated && isVerified` with zero explanation. Users saw only the page title and assumed the app was broken.
- Consistent three-state UX across all tools: unauthenticated → `GuestCTA`, unverified → `UnverifiedCTA`, verified → full tool UI.
- Multi-period page left untouched — already has its own inline Pattern B card.
- Also archives Sprints 592–595 to `tasks/archive/`.

## Test plan
- [x] `npm run build` — all 12 tool pages compile cleanly
- [x] Jest full suite — 1754/1754 pass, 168/168 suites
- [ ] Manual: register new account, do NOT verify → visit any tool page → see "Verify Your Email" card
- [ ] Manual: verify email → revisit tool page → see full upload zone + controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)