### PR TITLE
Sprint 597: DOCX file format support

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -496,6 +496,7 @@ FORMAT_PDF_ENABLED = _load_optional("FORMAT_PDF_ENABLED", "true").lower() == "tr
 FORMAT_IIF_ENABLED = _load_optional("FORMAT_IIF_ENABLED", "true").lower() == "true"
 FORMAT_OFX_ENABLED = _load_optional("FORMAT_OFX_ENABLED", "true").lower() == "true"
 FORMAT_QBO_ENABLED = _load_optional("FORMAT_QBO_ENABLED", "true").lower() == "true"
+FORMAT_DOCX_ENABLED = _load_optional("FORMAT_DOCX_ENABLED", "true").lower() == "true"
 
 CLEANUP_SCHEDULER_ENABLED = _load_optional("CLEANUP_SCHEDULER_ENABLED", "true").lower() == "true"
 CLEANUP_REFRESH_TOKEN_INTERVAL_MINUTES = _load_optional_int("CLEANUP_REFRESH_TOKEN_INTERVAL_MINUTES", 60)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -40,6 +40,9 @@ odfpy>=1.4.1
 # PDF Table Extraction (Sprint 427)
 pdfplumber>=0.11.0
 
+# DOCX (Word Document) table extraction (Sprint 597)
+python-docx>=1.1.0
+
 # Safe XML parsing — defuses XXE / billion laughs (Sprint 470)
 defusedxml>=0.7.1
 

--- a/backend/shared/docx_parser.py
+++ b/backend/shared/docx_parser.py
@@ -1,0 +1,145 @@
+"""
+Paciolus — DOCX (Word Document) Parser
+
+Parses .docx files by extracting tabular data from Word document tables
+using the python-docx library. Trial balances embedded in Word documents
+are expected to be in table format.
+
+Design:
+- Uses python-docx to open the document and iterate over tables
+- First table with >= 2 rows is used (row 1 = headers, rest = data)
+- DocxMetadata frozen dataclass attached to df.attrs for downstream consumers
+- If no usable tables found, raises HTTP 400
+
+Security:
+- DOCX is ZIP-based — archive bomb checks reuse _validate_xlsx_archive()
+- Binary content read via io.BytesIO — no temp files
+- All processing runs inside asyncio.to_thread() + memory_cleanup() at route level
+"""
+
+import io
+import logging
+import zipfile
+from dataclasses import dataclass
+
+import pandas as pd
+from fastapi import HTTPException
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DocxMetadata:
+    """Metadata extracted from a DOCX file, attached to df.attrs['docx_metadata']."""
+
+    table_count: int
+    table_index: int  # which table was used (0-based)
+    original_row_count: int
+    original_col_count: int
+
+
+def _is_docx_zip(file_bytes: bytes) -> bool:
+    """Determine whether a PK-signature ZIP file is a DOCX document.
+
+    DOCX files contain a 'word/' directory structure (word/document.xml).
+    XLSX files contain 'xl/' and ODS files contain 'content.xml' or ODS mimetype.
+
+    Returns True if the ZIP is DOCX, False otherwise.
+    """
+    try:
+        with zipfile.ZipFile(io.BytesIO(file_bytes)) as zf:
+            names = zf.namelist()
+            has_word_dir = any(n.startswith("word/") for n in names)
+            has_xl_dir = any(n.startswith("xl/") for n in names)
+            # DOCX: has word/ directory but NOT xl/ directory
+            return has_word_dir and not has_xl_dir
+    except zipfile.BadZipFile:
+        return False
+
+
+def parse_docx(file_bytes: bytes, filename: str) -> pd.DataFrame:
+    """Parse DOCX file bytes into a pandas DataFrame by extracting table data.
+
+    Scans all tables in the document and uses the first table that has
+    at least one header row and one data row. The first row of the chosen
+    table is treated as column headers.
+    """
+    try:
+        from docx import Document
+    except ImportError:
+        raise HTTPException(
+            status_code=500,
+            detail="DOCX parsing is not available. The python-docx package is not installed.",
+        )
+
+    try:
+        doc = Document(io.BytesIO(file_bytes))
+    except Exception as e:
+        logger.warning("DOCX file open failed for '%s': %s", filename, e)
+        raise HTTPException(
+            status_code=400,
+            detail="The DOCX file could not be opened. Please verify it is a valid Word document.",
+        )
+
+    tables = doc.tables
+    if not tables:
+        raise HTTPException(
+            status_code=400,
+            detail="The DOCX file contains no tables. "
+            "Please provide a Word document with tabular data, "
+            "or use a spreadsheet format (CSV, XLSX) instead.",
+        )
+
+    # Find first table with at least 2 rows (header + data)
+    chosen_table = None
+    chosen_index = 0
+    for idx, table in enumerate(tables):
+        if len(table.rows) >= 2:
+            chosen_table = table
+            chosen_index = idx
+            break
+
+    if chosen_table is None:
+        # Fall back to first table even if it only has headers
+        chosen_table = tables[0]
+        chosen_index = 0
+
+    # Extract headers from first row
+    header_row = chosen_table.rows[0]
+    headers = [cell.text.strip() for cell in header_row.cells]
+
+    # Deduplicate headers (Word tables can have merged cells producing duplicates)
+    seen: dict[str, int] = {}
+    deduped_headers: list[str] = []
+    for h in headers:
+        label = h if h else f"Column {len(deduped_headers) + 1}"
+        if label in seen:
+            seen[label] += 1
+            label = f"{label}_{seen[label]}"
+        else:
+            seen[label] = 0
+        deduped_headers.append(label)
+
+    # Extract data rows
+    rows: list[dict[str, str]] = []
+    for row in chosen_table.rows[1:]:
+        cells = [cell.text.strip() for cell in row.cells]
+        # Pad or truncate to match header count
+        if len(cells) < len(deduped_headers):
+            cells.extend([""] * (len(deduped_headers) - len(cells)))
+        elif len(cells) > len(deduped_headers):
+            cells = cells[: len(deduped_headers)]
+        rows.append(dict(zip(deduped_headers, cells)))
+
+    df = pd.DataFrame(rows, columns=deduped_headers)
+
+    # Attach metadata
+    metadata = DocxMetadata(
+        table_count=len(tables),
+        table_index=chosen_index,
+        original_row_count=len(df),
+        original_col_count=len(df.columns),
+    )
+    df.attrs["docx_metadata"] = metadata
+
+    return df

--- a/backend/shared/file_formats.py
+++ b/backend/shared/file_formats.py
@@ -39,6 +39,7 @@ class FileFormat(str, Enum):
     IIF = "iif"
     PDF = "pdf"
     ODS = "ods"
+    DOCX = "docx"
     UNKNOWN = "unknown"
 
 
@@ -202,6 +203,19 @@ FORMAT_PROFILES: dict[FileFormat, FormatProfile] = {
         label="ODS (.ods)",
         parse_supported=True,
     ),
+    FileFormat.DOCX: FormatProfile(
+        format=FileFormat.DOCX,
+        extensions=frozenset({".docx"}),
+        content_types=frozenset(
+            {
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "application/octet-stream",
+            }
+        ),
+        magic_bytes=(XLSX_MAGIC,),  # DOCX is also ZIP-based
+        label="Word (.docx)",
+        parse_supported=True,
+    ),
 }
 
 
@@ -260,13 +274,20 @@ def detect_format(
 
     # 2. Magic byte detection
     if file_bytes and len(file_bytes) >= 4:
-        # ZIP-based formats (XLSX and ODS share PK\x03\x04 signature) need disambiguation
+        # ZIP-based formats (XLSX, ODS, DOCX share PK\x03\x04 signature) need disambiguation
         if file_bytes[:4] == XLSX_MAGIC:
+            from shared.docx_parser import _is_docx_zip
             from shared.ods_parser import _is_ods_zip
 
             if _is_ods_zip(file_bytes):
                 return FormatDetectionResult(
                     format=FileFormat.ODS,
+                    confidence="high",
+                    source="magic",
+                )
+            if _is_docx_zip(file_bytes):
+                return FormatDetectionResult(
+                    format=FileFormat.DOCX,
                     confidence="high",
                     source="magic",
                 )
@@ -317,6 +338,7 @@ def is_format_enabled(fmt: FileFormat) -> bool:
     Returns True if no flag exists for the format (opt-in disabling only).
     """
     from config import (
+        FORMAT_DOCX_ENABLED,
         FORMAT_IIF_ENABLED,
         FORMAT_ODS_ENABLED,
         FORMAT_OFX_ENABLED,
@@ -330,6 +352,7 @@ def is_format_enabled(fmt: FileFormat) -> bool:
         FileFormat.IIF: FORMAT_IIF_ENABLED,
         FileFormat.OFX: FORMAT_OFX_ENABLED,
         FileFormat.QBO: FORMAT_QBO_ENABLED,
+        FileFormat.DOCX: FORMAT_DOCX_ENABLED,
     }
 
     return _FLAG_MAP.get(fmt, True)
@@ -342,4 +365,4 @@ def get_active_format_labels() -> list[str]:
 
 def get_active_extensions_display() -> str:
     """Return a display string like 'CSV (.csv), TSV (.tsv), Text (.txt), Excel (.xlsx, .xls), QBO, or OFX' for error messages."""
-    return "CSV (.csv), TSV (.tsv), Text (.txt), Excel (.xlsx, .xls), ODS (.ods), QBO (.qbo), OFX (.ofx), IIF (.iif), or PDF (.pdf)"
+    return "CSV (.csv), TSV (.tsv), Text (.txt), Excel (.xlsx, .xls), ODS (.ods), Word (.docx), QBO (.qbo), OFX (.ofx), IIF (.iif), or PDF (.pdf)"

--- a/backend/shared/helpers.py
+++ b/backend/shared/helpers.py
@@ -346,6 +346,13 @@ async def validate_file_size(file: UploadFile) -> bytes:
                 status_code=400,
                 detail="File content does not match ODS format. Please verify the file is a valid OpenDocument Spreadsheet.",
             )
+    elif ext == ".docx":
+        if not file_bytes.startswith(_XLSX_MAGIC):
+            log_secure_operation("magic_byte_mismatch", "File has .docx extension but invalid ZIP signature")
+            raise HTTPException(
+                status_code=400,
+                detail="File content does not match DOCX format. Please verify the file is a valid Word document.",
+            )
     elif ext == ".pdf":
         if not file_bytes.startswith(b"%PDF"):
             log_secure_operation("magic_byte_mismatch", "File has .pdf extension but missing %PDF signature")
@@ -650,6 +657,13 @@ def _parse_ods(file_bytes: bytes, filename: str) -> pd.DataFrame:
     return parse_ods(file_bytes, filename)
 
 
+def _parse_docx(file_bytes: bytes, filename: str) -> pd.DataFrame:
+    """Parse DOCX bytes into a DataFrame via shared.docx_parser."""
+    from shared.docx_parser import parse_docx
+
+    return parse_docx(file_bytes, filename)
+
+
 def _parse_excel(file_bytes: bytes, filename: str) -> pd.DataFrame:
     """Parse Excel (.xlsx/.xls) bytes into a DataFrame.
 
@@ -858,6 +872,8 @@ def parse_uploaded_file_by_format(
                 df = _parse_pdf(file_bytes, filename)
             elif detected.format == FileFormat.ODS:
                 df = _parse_ods(file_bytes, filename)
+            elif detected.format == FileFormat.DOCX:
+                df = _parse_docx(file_bytes, filename)
             elif detected.format == FileFormat.UNKNOWN:
                 filename_lower = (filename or "").lower()
                 if filename_lower.endswith((".xlsx", ".xls")):

--- a/backend/tests/test_docx_parser.py
+++ b/backend/tests/test_docx_parser.py
@@ -1,0 +1,353 @@
+"""
+Tests for shared.docx_parser — DOCX File Parsing & ZIP Disambiguation.
+
+Tests cover:
+- DOCX parsing (valid file, multi-table, metadata attachment)
+- ZIP disambiguation (_is_docx_zip for DOCX vs XLSX vs ODS)
+- Error handling (corrupt, no tables, single-row table)
+- Integration with parse_uploaded_file_by_format()
+- Format detection integration
+"""
+
+import io
+import zipfile
+
+import pandas as pd
+import pytest
+from fastapi import HTTPException
+
+from shared.docx_parser import DocxMetadata, _is_docx_zip, parse_docx
+
+# =============================================================================
+# Helpers — Build minimal DOCX and XLSX ZIPs in memory
+# =============================================================================
+
+
+def _build_docx_with_table(
+    headers: list[str] | None = None,
+    rows: list[list[str]] | None = None,
+) -> bytes:
+    """Build a minimal DOCX file with one table using python-docx."""
+    from docx import Document
+
+    if headers is None:
+        headers = ["Account", "Debit", "Credit"]
+    if rows is None:
+        rows = [
+            ["1000 - Cash", "50000", "0"],
+            ["2000 - AP", "0", "30000"],
+            ["3000 - Equity", "0", "20000"],
+        ]
+
+    doc = Document()
+    table = doc.add_table(rows=1 + len(rows), cols=len(headers))
+
+    # Header row
+    for i, h in enumerate(headers):
+        table.rows[0].cells[i].text = h
+
+    # Data rows
+    for row_idx, row_data in enumerate(rows):
+        for col_idx, val in enumerate(row_data):
+            table.rows[row_idx + 1].cells[col_idx].text = val
+
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
+def _build_docx_no_tables() -> bytes:
+    """Build a DOCX file with only paragraphs, no tables."""
+    from docx import Document
+
+    doc = Document()
+    doc.add_paragraph("This document has no tables.")
+    doc.add_paragraph("Just some text content.")
+
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
+def _build_docx_multi_table() -> bytes:
+    """Build a DOCX file with multiple tables."""
+    from docx import Document
+
+    doc = Document()
+
+    # First table: small header-only table
+    t1 = doc.add_table(rows=1, cols=2)
+    t1.rows[0].cells[0].text = "Title"
+    t1.rows[0].cells[1].text = "Value"
+
+    doc.add_paragraph("Some text between tables.")
+
+    # Second table: actual data table
+    t2 = doc.add_table(rows=3, cols=3)
+    t2.rows[0].cells[0].text = "Account"
+    t2.rows[0].cells[1].text = "Debit"
+    t2.rows[0].cells[2].text = "Credit"
+    t2.rows[1].cells[0].text = "1000"
+    t2.rows[1].cells[1].text = "100"
+    t2.rows[1].cells[2].text = "0"
+    t2.rows[2].cells[0].text = "2000"
+    t2.rows[2].cells[1].text = "0"
+    t2.rows[2].cells[2].text = "100"
+
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
+def _build_xlsx_zip() -> bytes:
+    """Build a minimal XLSX file as bytes."""
+    buf = io.BytesIO()
+    df = pd.DataFrame({"Col1": [1, 2], "Col2": [3, 4]})
+    df.to_excel(buf, index=False, engine="openpyxl")
+    return buf.getvalue()
+
+
+def _build_raw_zip_with_word_dir() -> bytes:
+    """Build a raw ZIP with word/ directory (DOCX-like)."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("word/document.xml", "<root/>")
+        zf.writestr("[Content_Types].xml", "<root/>")
+    return buf.getvalue()
+
+
+def _build_raw_zip_with_xl_dir() -> bytes:
+    """Build a raw ZIP with xl/ directory (XLSX-like)."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("xl/workbook.xml", "<root/>")
+        zf.writestr("[Content_Types].xml", "<root/>")
+    return buf.getvalue()
+
+
+# =============================================================================
+# _is_docx_zip() — ZIP disambiguation
+# =============================================================================
+
+
+class TestIsDocxZip:
+    """ZIP content inspection for DOCX vs XLSX disambiguation."""
+
+    def test_docx_with_word_dir(self):
+        docx_bytes = _build_raw_zip_with_word_dir()
+        assert _is_docx_zip(docx_bytes) is True
+
+    def test_xlsx_with_xl_dir(self):
+        xlsx_bytes = _build_raw_zip_with_xl_dir()
+        assert _is_docx_zip(xlsx_bytes) is False
+
+    def test_real_docx_file(self):
+        docx_bytes = _build_docx_with_table()
+        assert _is_docx_zip(docx_bytes) is True
+
+    def test_real_xlsx_file(self):
+        xlsx_bytes = _build_xlsx_zip()
+        assert _is_docx_zip(xlsx_bytes) is False
+
+    def test_invalid_zip_returns_false(self):
+        assert _is_docx_zip(b"not a zip file at all") is False
+
+    def test_empty_zip(self):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            pass  # empty ZIP
+        assert _is_docx_zip(buf.getvalue()) is False
+
+    def test_zip_with_both_word_and_xl_is_not_docx(self):
+        """ZIP with both word/ and xl/ directories — xl/ takes precedence."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("word/document.xml", "<root/>")
+            zf.writestr("xl/workbook.xml", "<root/>")
+        assert _is_docx_zip(buf.getvalue()) is False
+
+
+# =============================================================================
+# parse_docx() — Core parsing
+# =============================================================================
+
+
+class TestParseDocx:
+    """DOCX file parsing via python-docx."""
+
+    def test_parse_valid_single_table(self):
+        docx_bytes = _build_docx_with_table()
+        df = parse_docx(docx_bytes, "test.docx")
+        assert len(df) == 3
+        assert "Account" in df.columns
+        assert "Debit" in df.columns
+        assert "Credit" in df.columns
+
+    def test_data_values_correct(self):
+        docx_bytes = _build_docx_with_table()
+        df = parse_docx(docx_bytes, "test.docx")
+        assert df.iloc[0]["Account"] == "1000 - Cash"
+        assert df.iloc[0]["Debit"] == "50000"
+        assert df.iloc[1]["Credit"] == "30000"
+
+    def test_metadata_attached(self):
+        docx_bytes = _build_docx_with_table()
+        df = parse_docx(docx_bytes, "test.docx")
+        metadata = df.attrs.get("docx_metadata")
+        assert metadata is not None
+        assert isinstance(metadata, DocxMetadata)
+        assert metadata.table_count == 1
+        assert metadata.table_index == 0
+        assert metadata.original_row_count == 3
+        assert metadata.original_col_count == 3
+
+    def test_metadata_is_frozen(self):
+        docx_bytes = _build_docx_with_table()
+        df = parse_docx(docx_bytes, "test.docx")
+        metadata = df.attrs["docx_metadata"]
+        with pytest.raises(AttributeError):
+            metadata.table_count = 99
+
+    def test_no_tables_raises_400(self):
+        docx_bytes = _build_docx_no_tables()
+        with pytest.raises(HTTPException) as exc_info:
+            parse_docx(docx_bytes, "no_tables.docx")
+        assert exc_info.value.status_code == 400
+        assert "no tables" in exc_info.value.detail
+
+    def test_multi_table_skips_header_only(self):
+        """First table has only headers (1 row), parser should pick second table."""
+        docx_bytes = _build_docx_multi_table()
+        df = parse_docx(docx_bytes, "multi.docx")
+        # Second table has Account/Debit/Credit
+        assert "Account" in df.columns
+        assert len(df) == 2
+        metadata = df.attrs["docx_metadata"]
+        assert metadata.table_count == 2
+        assert metadata.table_index == 1  # 0-based, second table
+
+    def test_corrupt_file_raises_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            parse_docx(b"not a docx file", "corrupt.docx")
+        assert exc_info.value.status_code == 400
+        assert "could not be opened" in exc_info.value.detail
+
+    def test_returns_dataframe(self):
+        docx_bytes = _build_docx_with_table()
+        result = parse_docx(docx_bytes, "test.docx")
+        assert isinstance(result, pd.DataFrame)
+
+    def test_empty_headers_get_placeholder(self):
+        """Columns with empty header text should get 'Column N' placeholders."""
+        docx_bytes = _build_docx_with_table(
+            headers=["Account", "", "Balance"],
+            rows=[["1000", "", "500"]],
+        )
+        df = parse_docx(docx_bytes, "test.docx")
+        assert "Column 2" in df.columns
+
+    def test_single_row_table_returns_empty_df(self):
+        """Table with only headers (no data rows) should return empty DataFrame."""
+        docx_bytes = _build_docx_with_table(headers=["A", "B"], rows=[])
+        df = parse_docx(docx_bytes, "single_row.docx")
+        assert len(df) == 0
+        assert list(df.columns) == ["A", "B"]
+
+
+# =============================================================================
+# Format detection integration
+# =============================================================================
+
+
+class TestDocxFormatDetection:
+    """DOCX detection via detect_format() and file_formats module."""
+
+    def test_detect_by_extension(self):
+        from shared.file_formats import FileFormat, detect_format
+
+        result = detect_format(filename="data.docx")
+        assert result.format == FileFormat.DOCX
+        assert result.confidence == "high"
+        assert result.source == "extension"
+
+    def test_detect_docx_by_magic_bytes(self):
+        from shared.file_formats import FileFormat, detect_format
+
+        docx_bytes = _build_docx_with_table()
+        result = detect_format(file_bytes=docx_bytes)
+        assert result.format == FileFormat.DOCX
+        assert result.source == "magic"
+
+    def test_detect_xlsx_by_magic_bytes_not_docx(self):
+        from shared.file_formats import FileFormat, detect_format
+
+        xlsx_bytes = _build_xlsx_zip()
+        result = detect_format(file_bytes=xlsx_bytes)
+        assert result.format == FileFormat.XLSX
+        assert result.source == "magic"
+
+    def test_extension_overrides_zip_inspection(self):
+        """Extension has higher priority than magic bytes."""
+        from shared.file_formats import FileFormat, detect_format
+
+        xlsx_bytes = _build_xlsx_zip()
+        result = detect_format(filename="report.docx", file_bytes=xlsx_bytes)
+        assert result.format == FileFormat.DOCX
+        assert result.source == "extension"
+
+    def test_docx_content_type_detection(self):
+        from shared.file_formats import FileFormat, detect_format
+
+        result = detect_format(content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+        assert result.format == FileFormat.DOCX
+        assert result.source == "content_type"
+
+
+# =============================================================================
+# Profile assertions
+# =============================================================================
+
+
+class TestDocxProfile:
+    """DOCX profile in FORMAT_PROFILES."""
+
+    def test_docx_parse_supported(self):
+        from shared.file_formats import FORMAT_PROFILES, FileFormat
+
+        profile = FORMAT_PROFILES[FileFormat.DOCX]
+        assert profile.parse_supported is True
+
+    def test_docx_content_types(self):
+        from shared.file_formats import FORMAT_PROFILES, FileFormat
+
+        profile = FORMAT_PROFILES[FileFormat.DOCX]
+        assert "application/vnd.openxmlformats-officedocument.wordprocessingml.document" in profile.content_types
+        assert "application/octet-stream" in profile.content_types
+
+    def test_docx_extension(self):
+        from shared.file_formats import FORMAT_PROFILES, FileFormat
+
+        profile = FORMAT_PROFILES[FileFormat.DOCX]
+        assert ".docx" in profile.extensions
+
+    def test_docx_label(self):
+        from shared.file_formats import FORMAT_PROFILES, FileFormat
+
+        profile = FORMAT_PROFILES[FileFormat.DOCX]
+        assert profile.label == "Word (.docx)"
+
+    def test_docx_in_allowed_extensions(self):
+        from shared.file_formats import ALLOWED_EXTENSIONS
+
+        assert ".docx" in ALLOWED_EXTENSIONS
+
+    def test_docx_in_allowed_content_types(self):
+        from shared.file_formats import ALLOWED_CONTENT_TYPES
+
+        assert "application/vnd.openxmlformats-officedocument.wordprocessingml.document" in ALLOWED_CONTENT_TYPES
+
+    def test_display_includes_docx(self):
+        from shared.file_formats import get_active_extensions_display
+
+        display = get_active_extensions_display()
+        assert ".docx" in display

--- a/backend/tests/test_file_formats.py
+++ b/backend/tests/test_file_formats.py
@@ -39,7 +39,7 @@ class TestFileFormatEnum:
         assert FileFormat.CSV.value == "csv"
 
     def test_all_members_present(self):
-        expected = {"csv", "xlsx", "xls", "tsv", "txt", "qbo", "ofx", "iif", "pdf", "ods", "unknown"}
+        expected = {"csv", "xlsx", "xls", "tsv", "txt", "qbo", "ofx", "iif", "pdf", "ods", "docx", "unknown"}
         actual = {f.value for f in FileFormat}
         assert actual == expected
 
@@ -94,11 +94,23 @@ class TestAllowedSets:
     """ALLOWED_EXTENSIONS and ALLOWED_CONTENT_TYPES must match helpers.py originals."""
 
     def test_allowed_extensions_match(self):
-        """Must contain exactly the 10 active extensions."""
-        assert ALLOWED_EXTENSIONS == {".csv", ".tsv", ".txt", ".xlsx", ".xls", ".ods", ".qbo", ".ofx", ".iif", ".pdf"}
+        """Must contain exactly the 11 active extensions."""
+        assert ALLOWED_EXTENSIONS == {
+            ".csv",
+            ".tsv",
+            ".txt",
+            ".xlsx",
+            ".xls",
+            ".ods",
+            ".docx",
+            ".qbo",
+            ".ofx",
+            ".iif",
+            ".pdf",
+        }
 
     def test_allowed_content_types_match(self):
-        """Must contain the 12 MIME types from all active profiles."""
+        """Must contain the 13 MIME types from all active profiles."""
         expected = {
             "text/csv",
             "application/csv",
@@ -107,6 +119,7 @@ class TestAllowedSets:
             "application/vnd.ms-excel",
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             "application/vnd.oasis.opendocument.spreadsheet",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "application/octet-stream",
             "application/x-ofx",
             "application/ofx",

--- a/frontend/src/__tests__/fileFormats.test.ts
+++ b/frontend/src/__tests__/fileFormats.test.ts
@@ -7,21 +7,22 @@ import {
 } from '@/utils/fileFormats'
 
 describe('fileFormats constants', () => {
-  it('ACCEPTED_FILE_EXTENSIONS has 10 entries', () => {
-    expect(ACCEPTED_FILE_EXTENSIONS).toEqual(['.csv', '.tsv', '.txt', '.xlsx', '.xls', '.ods', '.qbo', '.ofx', '.iif', '.pdf'])
+  it('ACCEPTED_FILE_EXTENSIONS has 11 entries', () => {
+    expect(ACCEPTED_FILE_EXTENSIONS).toEqual(['.csv', '.tsv', '.txt', '.xlsx', '.xls', '.ods', '.docx', '.qbo', '.ofx', '.iif', '.pdf'])
   })
 
   it('ACCEPTED_FILE_EXTENSIONS_STRING matches HTML accept format', () => {
-    expect(ACCEPTED_FILE_EXTENSIONS_STRING).toBe('.csv,.tsv,.txt,.xlsx,.xls,.ods,.qbo,.ofx,.iif,.pdf')
+    expect(ACCEPTED_FILE_EXTENSIONS_STRING).toBe('.csv,.tsv,.txt,.xlsx,.xls,.ods,.docx,.qbo,.ofx,.iif,.pdf')
   })
 
-  it('ACCEPTED_MIME_TYPES includes 12 types', () => {
-    expect(ACCEPTED_MIME_TYPES).toHaveLength(12)
+  it('ACCEPTED_MIME_TYPES includes 13 types', () => {
+    expect(ACCEPTED_MIME_TYPES).toHaveLength(13)
     expect(ACCEPTED_MIME_TYPES).toContain('text/csv')
     expect(ACCEPTED_MIME_TYPES).toContain('text/tab-separated-values')
     expect(ACCEPTED_MIME_TYPES).toContain('text/plain')
     expect(ACCEPTED_MIME_TYPES).toContain('application/vnd.ms-excel')
     expect(ACCEPTED_MIME_TYPES).toContain('application/vnd.oasis.opendocument.spreadsheet')
+    expect(ACCEPTED_MIME_TYPES).toContain('application/vnd.openxmlformats-officedocument.wordprocessingml.document')
     expect(ACCEPTED_MIME_TYPES).toContain('application/x-ofx')
     expect(ACCEPTED_MIME_TYPES).toContain('application/ofx')
     expect(ACCEPTED_MIME_TYPES).toContain('application/x-iif')
@@ -34,6 +35,8 @@ describe('fileFormats constants', () => {
     expect(ACCEPTED_FORMATS_LABEL).toContain('Text')
     expect(ACCEPTED_FORMATS_LABEL).toContain('.xlsx')
     expect(ACCEPTED_FORMATS_LABEL).toContain('ODS')
+    expect(ACCEPTED_FORMATS_LABEL).toContain('Word')
+    expect(ACCEPTED_FORMATS_LABEL).toContain('.docx')
     expect(ACCEPTED_FORMATS_LABEL).toContain('QBO')
     expect(ACCEPTED_FORMATS_LABEL).toContain('OFX')
     expect(ACCEPTED_FORMATS_LABEL).toContain('IIF')
@@ -119,6 +122,18 @@ describe('isAcceptedFileType', () => {
 
   it('accepts ODS by extension when MIME is wrong', () => {
     expect(isAcceptedFileType(makeFile('data.ods', 'application/json'))).toBe(true)
+  })
+
+  it('accepts DOCX by MIME type', () => {
+    expect(isAcceptedFileType(makeFile('doc.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'))).toBe(true)
+  })
+
+  it('accepts DOCX by extension when MIME is empty', () => {
+    expect(isAcceptedFileType(makeFile('report.docx', ''))).toBe(true)
+  })
+
+  it('accepts DOCX by extension when MIME is wrong', () => {
+    expect(isAcceptedFileType(makeFile('data.docx', 'application/json'))).toBe(true)
   })
 
   it('accepts octet-stream (common browser behavior for CSV)', () => {

--- a/frontend/src/utils/fileFormats.ts
+++ b/frontend/src/utils/fileFormats.ts
@@ -6,10 +6,10 @@
  */
 
 /** Accepted file extensions (with leading dot, lowercase). */
-export const ACCEPTED_FILE_EXTENSIONS = ['.csv', '.tsv', '.txt', '.xlsx', '.xls', '.ods', '.qbo', '.ofx', '.iif', '.pdf'] as const
+export const ACCEPTED_FILE_EXTENSIONS = ['.csv', '.tsv', '.txt', '.xlsx', '.xls', '.ods', '.docx', '.qbo', '.ofx', '.iif', '.pdf'] as const
 
 /** Comma-separated string for HTML `<input accept="">` attributes. */
-export const ACCEPTED_FILE_EXTENSIONS_STRING = '.csv,.tsv,.txt,.xlsx,.xls,.ods,.qbo,.ofx,.iif,.pdf'
+export const ACCEPTED_FILE_EXTENSIONS_STRING = '.csv,.tsv,.txt,.xlsx,.xls,.ods,.docx,.qbo,.ofx,.iif,.pdf'
 
 /** Accepted MIME types (matches backend ALLOWED_CONTENT_TYPES). */
 export const ACCEPTED_MIME_TYPES = [
@@ -20,6 +20,7 @@ export const ACCEPTED_MIME_TYPES = [
   'application/vnd.ms-excel',
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   'application/vnd.oasis.opendocument.spreadsheet',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   'application/octet-stream',
   'application/x-ofx',
   'application/ofx',
@@ -28,7 +29,7 @@ export const ACCEPTED_MIME_TYPES = [
 ] as const
 
 /** Human-readable label for error messages and UI text. */
-export const ACCEPTED_FORMATS_LABEL = 'CSV, TSV, Text, Excel (.xlsx, .xls), ODS (.ods), QBO, OFX, IIF, or PDF'
+export const ACCEPTED_FORMATS_LABEL = 'CSV, TSV, Text, Excel (.xlsx, .xls), ODS (.ods), Word (.docx), QBO, OFX, IIF, or PDF'
 
 /**
  * Check whether a File object has an accepted type.
@@ -38,5 +39,5 @@ export function isAcceptedFileType(file: File): boolean {
   const validTypes: readonly string[] = ACCEPTED_MIME_TYPES
   if (validTypes.includes(file.type)) return true
   const ext = file.name.toLowerCase().split('.').pop()
-  return ext === 'csv' || ext === 'tsv' || ext === 'txt' || ext === 'xlsx' || ext === 'xls' || ext === 'ods' || ext === 'qbo' || ext === 'ofx' || ext === 'iif' || ext === 'pdf'
+  return ext === 'csv' || ext === 'tsv' || ext === 'txt' || ext === 'xlsx' || ext === 'xls' || ext === 'ods' || ext === 'docx' || ext === 'qbo' || ext === 'ofx' || ext === 'iif' || ext === 'pdf'
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -53,6 +53,32 @@
 > Sprints 586–591 archived to `tasks/archive/sprints-586-591-details.md`.
 > Sprints 592–595 archived to `tasks/archive/sprints-592-595-details.md`.
 
+### Sprint 597: DOCX File Format Support
+**Status:** COMPLETE
+**Goal:** Add Word document (.docx) as an 11th supported file format for trial balance uploads
+
+**Changes:**
+- [x] `python-docx>=1.1.0` added to `backend/requirements.txt`
+- [x] `FileFormat.DOCX` enum + `FormatProfile` in `shared/file_formats.py`
+- [x] ZIP disambiguation: `_is_docx_zip()` checks for `word/` directory
+- [x] `shared/docx_parser.py` — extracts tables from DOCX via python-docx
+- [x] Parser dispatch in `shared/helpers.py` (`_parse_docx` wrapper + magic byte validation)
+- [x] `FORMAT_DOCX_ENABLED` feature flag in `config.py` (default: true)
+- [x] Frontend: `.docx` extension, MIME type, label in `utils/fileFormats.ts`
+- [x] Backend tests: `test_docx_parser.py` (29 tests — disambiguation, parsing, detection, profile)
+- [x] Updated `test_file_formats.py` (11 extensions, 13 MIME types)
+- [x] Updated `fileFormats.test.ts` (11 entries, 13 types, DOCX acceptance)
+- [x] Tier gating: paid tiers only (same as PDF/OFX/IIF/QBO/ODS)
+
+**Review:**
+- 89 backend tests pass (test_docx_parser + test_file_formats), 27 ODS tests unaffected
+- 27 frontend fileFormats tests pass
+- `npm run build` clean — all pages compile
+- DOCX parsing extracts first table with data rows; skips header-only tables
+- ZIP disambiguation: ODS (mimetype/content.xml) > DOCX (word/) > XLSX (default)
+
+---
+
 ### Sprint 596: UnverifiedCTA — Explicit Verification Prompt on All Tool Pages
 **Status:** COMPLETE
 **Goal:** Replace silent content gating with an explicit "Verify Your Email" card so unverified users understand why tool pages appear blank


### PR DESCRIPTION
## Summary
- Adds Word document (.docx) as the 11th supported file format for trial balance uploads
- Extracts tabular data from DOCX tables via `python-docx` with ZIP disambiguation (ODS > DOCX > XLSX)
- Feature-flagged (`FORMAT_DOCX_ENABLED`), tier-gated (paid tiers only), fully tested

## Changes
- **New:** `backend/shared/docx_parser.py` — DOCX table extraction, `_is_docx_zip()` disambiguation, `DocxMetadata`
- **New:** `backend/tests/test_docx_parser.py` — 29 tests (disambiguation, parsing, detection, profile)
- **Modified:** `file_formats.py`, `helpers.py`, `config.py`, `fileFormats.ts` + tests

## Test plan
- [x] 89 backend tests pass (test_docx_parser + test_file_formats)
- [x] 27 ODS parser tests unaffected (no regression in ZIP disambiguation)
- [x] 27 frontend fileFormats tests pass
- [x] `npm run build` clean — all pages compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)