### PR TITLE
Sprint 673: pooler-aware pg_stat_ssl skip removes DB_TLS_OVERRIDE need

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -31,6 +31,22 @@ from config import (
 )
 from security_utils import log_secure_operation
 
+
+def _is_pooled_hostname(database_url: str) -> bool:
+    """Return True if DATABASE_URL hostname looks like a transparent pooler endpoint.
+
+    Transparent poolers (e.g., Neon's `-pooler` hostnames) terminate TLS at the
+    pool layer. `pg_stat_ssl` reports the pooler-to-backend hop, not the
+    client-to-pooler hop, so the view returns ssl=false even when the
+    client-to-pooler connection IS encrypted. Client-to-pooler TLS is still
+    enforced separately by the `sslmode` check in `config.py`.
+    """
+    from urllib.parse import urlparse
+
+    host = (urlparse(database_url).hostname or "").lower()
+    return "-pooler" in host
+
+
 # Create engine with dialect-specific configuration
 _is_sqlite = DATABASE_URL.startswith("sqlite")
 
@@ -263,9 +279,18 @@ def init_db() -> None:
 
     if dialect_name == "postgresql":
         try:
+            pooled = _is_pooled_hostname(DATABASE_URL)
             with engine.connect() as conn:
                 pg_version = conn.execute(text("SELECT version()")).scalar()
-                ssl_row = conn.execute(text("SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()")).fetchone()
+                # Transparent poolers terminate TLS at the pool layer, so
+                # pg_stat_ssl reports the pooler-to-backend hop, not the
+                # client-to-pooler hop. Skip the assertion on pooled hosts;
+                # client-to-pooler TLS is enforced by the sslmode check in
+                # config.py.
+                if pooled:
+                    ssl_row = None
+                else:
+                    ssl_row = conn.execute(text("SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()")).fetchone()
                 ssl_active = bool(ssl_row and ssl_row[0])
             logger.info(
                 "PostgreSQL: version=%s, pool_size=%d, max_overflow=%d, recycle=%ds, tls=%s",
@@ -273,9 +298,15 @@ def init_db() -> None:
                 DB_POOL_SIZE,
                 DB_MAX_OVERFLOW,
                 DB_POOL_RECYCLE,
-                "active" if ssl_active else "INACTIVE",
+                "pooler-skip" if pooled else ("active" if ssl_active else "INACTIVE"),
             )
-            if ssl_active:
+            if pooled:
+                log_secure_operation(
+                    "db_tls_pooler_skip",
+                    "pg_stat_ssl assertion skipped for -pooler hostname "
+                    "(transparent pooler TLS blindspot; sslmode enforced in config)",
+                )
+            elif ssl_active:
                 log_secure_operation("db_tls_verified", "PostgreSQL TLS active at startup")
             elif DB_TLS_OVERRIDE_VALID:
                 # Break-glass exception: TLS not active but documented override exists

--- a/backend/tests/test_db_tls_enforcement.py
+++ b/backend/tests/test_db_tls_enforcement.py
@@ -134,6 +134,85 @@ class TestRuntimeTLSEnforcement:
             init_db()  # Should not raise
 
 
+class TestPoolerHostnameSkip:
+    """Sprint 673: transparent poolers terminate TLS at the pool layer, so
+    pg_stat_ssl reports the pooler-to-backend hop and always returns ssl=false.
+    Detect `-pooler` in the hostname and skip the assertion in that case.
+    """
+
+    def test_pooler_hostname_skips_pg_stat_ssl_even_when_required(self):
+        """`-pooler` host + DB_TLS_REQUIRED=true + ssl=false → no crash, no query."""
+        mock_engine = _make_pg_engine_mock(ssl_active=False)
+        # .example is an IANA-reserved TLD that never resolves — keeps
+        # TruffleHog's Postgres detector from "verifying" the URL.
+        pooler_url = "postgresql://tb-test-pooler.example:5432/db?sslmode=require"
+
+        with (
+            patch("database.engine", mock_engine),
+            patch("database.DATABASE_URL", pooler_url),
+            patch("database.DB_TLS_REQUIRED", True),
+            patch("database.DB_TLS_OVERRIDE_VALID", False),
+            patch("database.DB_TLS_OVERRIDE_TICKET", ""),
+            patch("database.Base") as mock_base,
+            patch("database.log_secure_operation") as mock_log,
+        ):
+            mock_base.metadata.create_all = MagicMock()
+
+            from database import init_db
+
+            init_db()  # Must NOT raise even though ssl_active=False
+
+            # The pooler-skip secure event was emitted
+            skip_events = [
+                call for call in mock_log.call_args_list if call.args and call.args[0] == "db_tls_pooler_skip"
+            ]
+            assert skip_events, "expected db_tls_pooler_skip event"
+
+            # pg_stat_ssl was never queried on the pooled connection
+            conn = mock_engine.connect.return_value
+            queries = [str(c.args[0]) for c in conn.execute.call_args_list]
+            assert not any("pg_stat_ssl" in q for q in queries), (
+                f"pg_stat_ssl should be skipped on pooler hostname; saw: {queries}"
+            )
+
+    def test_direct_hostname_still_runs_pg_stat_ssl(self):
+        """Non-pooler host → existing assertion runs, ssl_active=True logs verified."""
+        mock_engine = _make_pg_engine_mock(ssl_active=True)
+        direct_url = "postgresql://tb-test.example:5432/db?sslmode=require"
+
+        with (
+            patch("database.engine", mock_engine),
+            patch("database.DATABASE_URL", direct_url),
+            patch("database.DB_TLS_REQUIRED", True),
+            patch("database.DB_TLS_OVERRIDE_VALID", False),
+            patch("database.DB_TLS_OVERRIDE_TICKET", ""),
+            patch("database.Base") as mock_base,
+            patch("database.log_secure_operation") as mock_log,
+        ):
+            mock_base.metadata.create_all = MagicMock()
+
+            from database import init_db
+
+            init_db()
+
+            conn = mock_engine.connect.return_value
+            queries = [str(c.args[0]) for c in conn.execute.call_args_list]
+            assert any("pg_stat_ssl" in q for q in queries), (
+                "pg_stat_ssl assertion must still run for non-pooler hostnames"
+            )
+            mock_log.assert_any_call("db_tls_verified", "PostgreSQL TLS active at startup")
+
+    def test_is_pooled_hostname_helper_recognises_pooler_suffix(self):
+        """Direct unit test for the hostname helper."""
+        from database import _is_pooled_hostname
+
+        assert _is_pooled_hostname("postgresql://tb-abc-pooler.example:5432/db")
+        assert _is_pooled_hostname("postgresql://tb-abc-pooler.example/db?sslmode=require")
+        assert not _is_pooled_hostname("postgresql://tb-abc.example:5432/db")
+        assert not _is_pooled_hostname("sqlite:///./test.db")
+        assert not _is_pooled_hostname("")
+
+
 class TestBreakGlassOverride:
     """DB_TLS_OVERRIDE allows temporary bypass with ticket + expiration."""
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -67,18 +67,24 @@
 ---
 
 ### Sprint 673: Remove DB_TLS_OVERRIDE via pooler-aware pg_stat_ssl skip
-**Status:** PENDING — engineering-owned, **time-fused (2026-05-09)**
+**Status:** CODE-COMPLETE — pending deploy + CEO env-var removal
 **Source:** Council Review 2026-04-16 — Critic (time-fused architectural debt) + Executor (front-run launch week)
 **Why now:** `DB_TLS_OVERRIDE=NEON-POOLER-PGSSL-BLINDSPOT:2026-05-09` expires in 23 days. Without the proper fix landed first, the override must either be renewed (kicks the can) or allowed to expire (hard-fails production startup during Phase 4 launch window). Fixing before Phase 4 removes one ticking clock from launch week.
-**File:** `backend/database.py:268`
+**File:** `backend/database.py`
 **Problem:** Production startup runs a `pg_stat_ssl` check to confirm the DB connection is encrypted. Neon's pooled endpoint (`-pooler` hostname) is a transparent connection pooler — the underlying connection IS TLS-encrypted, but `pg_stat_ssl` reports the pooler-to-backend hop, not the client-to-pooler hop. The check therefore returns `ssl=false` on a correctly encrypted connection, forcing the current override.
 **Changes:**
-- [ ] Detect `-pooler` in `DATABASE_URL` hostname at the TLS verification point (`backend/database.py:268`)
-- [ ] On pooled hostnames: skip the `pg_stat_ssl` assertion and log an info-level notice that the pooler-blindspot path was taken
-- [ ] On direct hostnames: retain the assertion (Neon direct endpoint, RDS, local postgres all continue to verify)
-- [ ] Add a unit test covering both branches (pooled hostname skips, direct hostname asserts)
-- [ ] Deploy; verify Render startup logs show the new pooler-aware notice and no override warning
-- [ ] Remove `DB_TLS_OVERRIDE` from Render env vars once startup is confirmed green
-- [ ] If `DB_TLS_OVERRIDE` handling path in `backend/config.py` exists solely for this case, remove it
+- [x] Detect `-pooler` in `DATABASE_URL` hostname via new `_is_pooled_hostname()` helper (`backend/database.py`)
+- [x] On pooled hostnames: skip the `pg_stat_ssl` assertion, log `tls=pooler-skip`, emit `db_tls_pooler_skip` secure event (sslmode still enforced in config.py)
+- [x] On direct hostnames: retain the assertion (Neon direct endpoint, RDS, local postgres all continue to verify)
+- [x] Unit tests cover all branches: pooler host with ssl_active=False doesn't crash, direct host with ssl_active=True still logs `db_tls_verified`, helper recognises pooler suffix (18/18 tests pass)
+- [ ] **CEO deploy step:** Deploy; verify Render startup logs show `tls=pooler-skip` and no override warning
+- [ ] **CEO env-var step:** Remove `DB_TLS_OVERRIDE` from Render env vars once startup is confirmed green
+- [x] `DB_TLS_OVERRIDE` config path kept intact — it's a general break-glass used by both the `pg_stat_ssl` check AND the `sslmode` connection-string check in `config.py`; not pooler-specific, so deletion would lose a legitimate escape hatch.
+
+**Review:**
+- New helper `_is_pooled_hostname()` lives alongside imports in `backend/database.py`; it's a parse-and-substring test with no DB coupling (trivially unit-testable).
+- The pooled branch short-circuits BEFORE the four-way `ssl_active / DB_TLS_OVERRIDE_VALID / DB_TLS_REQUIRED / else` logic, so `DB_TLS_REQUIRED=true` + pooler host no longer crashes startup.
+- Secure event `db_tls_pooler_skip` added — distinct from `db_tls_verified` and `db_tls_override` so log audits can tell "TLS is actually on, just invisible" apart from "TLS is off, break-glass approved".
+- Existing 15 TLS tests still pass unchanged; 3 new tests added (pooler skip, direct still runs, helper unit).
 
 ---


### PR DESCRIPTION
## Summary
- Detects `-pooler` in `DATABASE_URL.hostname` via new `_is_pooled_hostname()` helper in `backend/database.py`; on pooled hosts the `pg_stat_ssl` assertion is skipped and a distinct `db_tls_pooler_skip` secure event is emitted.
- Direct hostnames (Neon direct endpoint, RDS, local postgres) still run the full assertion unchanged.
- `DB_TLS_OVERRIDE` config path kept intact — it's a general break-glass used by the `sslmode` check in `config.py` too, not pooler-specific.
- 3 new tests in `test_db_tls_enforcement.py` (pooler host with ssl_active=False doesn't crash; direct host still logs `db_tls_verified`; helper unit). 18/18 TLS tests pass locally.

## Why now
`DB_TLS_OVERRIDE=NEON-POOLER-PGSSL-BLINDSPOT:2026-05-09` expires in 23 days — right in the Phase 4 launch window. Council Review 2026-04-16 flagged this as time-fused architectural debt; fixing before launch removes one ticking clock.

## CEO follow-up (after merge + deploy)
- [ ] Deploy, verify Render startup logs show `tls=pooler-skip` and no override warning
- [ ] Remove `DB_TLS_OVERRIDE` from Render env vars once startup is confirmed green

## Test plan
- [ ] Full backend suite clean on Py 3.11 / 3.12 / PG 15 in CI
- [ ] After deploy, grep Render logs for `db_tls_pooler_skip` event
- [ ] Confirm removing `DB_TLS_OVERRIDE` env var doesn't regress startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)