### PR TITLE
fix: attach exc_info to cleanup_scheduler failure log for Sentry tracebacks

### DIFF
--- a/backend/cleanup_scheduler.py
+++ b/backend/cleanup_scheduler.py
@@ -176,6 +176,7 @@ def _run_cleanup_job(
     t0 = time.perf_counter()
     records_processed = 0
     error_msg: str | None = None
+    caught_exc: BaseException | None = None
     db = SessionLocal()
 
     try:
@@ -192,6 +193,12 @@ def _run_cleanup_job(
         from shared.log_sanitizer import sanitize_exception
 
         error_msg = sanitize_exception(exc, context="scheduled cleanup")
+        # Preserve the exception so the final logger.error can emit the full
+        # traceback via exc_info. The sanitized message still drives the
+        # user-visible telemetry payload; the traceback is for ops triage
+        # (Sentry, structured log sinks) — scheduled-job inputs are internal,
+        # no PII leaks.
+        caught_exc = exc
     finally:
         db.close()
 
@@ -207,7 +214,7 @@ def _run_cleanup_job(
     )
 
     if error_msg:
-        logger.error("Cleanup job failed: %s", telemetry.to_log_dict())
+        logger.error("Cleanup job failed: %s", telemetry.to_log_dict(), exc_info=caught_exc)
     elif records_processed > 0:
         logger.info("Cleanup job completed: %s", telemetry.to_log_dict())
     else:

--- a/backend/tests/test_cleanup_scheduler.py
+++ b/backend/tests/test_cleanup_scheduler.py
@@ -94,6 +94,38 @@ class TestRunCleanupJob:
         mock_session.close.assert_called_once()
         assert "Cleanup job failed" in caplog.text
 
+    def test_failure_log_includes_traceback_exc_info(self, caplog):
+        """Sanitized telemetry goes to user-visible logs, but the full
+        exception (with traceback) is attached via exc_info so Sentry and
+        other structured-log sinks can capture the stack trace.
+
+        Regression guard — without this, scheduled-job failures surface in
+        Sentry as just "InternalError: scheduled cleanup failed" with no
+        traceback, defeating triage.
+        """
+        from cleanup_scheduler import _run_cleanup_job
+
+        def failing_func(db):
+            raise RuntimeError("boom-with-traceback")
+
+        mock_session = MagicMock()
+
+        with (
+            patch("database.SessionLocal", return_value=mock_session),
+            caplog.at_level(logging.ERROR, logger="cleanup_scheduler"),
+        ):
+            _run_cleanup_job("failing_job", failing_func)
+
+        error_records = [r for r in caplog.records if "Cleanup job failed" in r.getMessage()]
+        assert error_records, "expected a 'Cleanup job failed' error record"
+        record = error_records[0]
+        assert record.exc_info is not None, "exc_info must be attached for Sentry traceback"
+        exc_type, exc_value, _tb = record.exc_info
+        assert exc_type is RuntimeError
+        assert "boom-with-traceback" in str(exc_value)
+        # Sanitized message preserved in the telemetry payload
+        assert "RuntimeError: scheduled cleanup failed" in caplog.text
+
     def test_session_always_closed_on_success(self):
         """Session is closed even when cleanup returns 0."""
         from cleanup_scheduler import _run_cleanup_job


### PR DESCRIPTION
## Summary
- Observed today: Sentry received \`{'job_name': 'dunning_grace_period', 'error': 'InternalError: scheduled cleanup failed'}\` — no file, no line, no stack. Useless for triage.
- Root cause: \`_run_cleanup_job\` sanitizes the exception into a generic string and logs with \`logger.error\` **without \`exc_info\`**, so Sentry and other structured-log sinks never see the traceback.
- Fix: stash the caught exception and pass it via \`exc_info=caught_exc\` on the final error log. Sanitized message still drives the telemetry payload (safe for user-visible logs). Raw exception object is safe to retain because scheduled-job inputs are internal — no PII leak path.
- Regression guard test added — asserts \`record.exc_info\` is populated on failure records.

## Why this is not a sprint
No new behavior, no feature, no user-facing change. Pure observability fix with one-file scope and a guard test. Classified as hotfix per CLAUDE.md.

## Follow-up (not this PR)
Once this lands and redeploys, the next \`dunning_grace_period\` failure event in Sentry will carry a stack trace. Then we can diagnose the actual \`InternalError\` root cause (likely pooler reset, enum drift, or tx-aborted state).

## Test plan
- [ ] Backend suite green on Py 3.11 / 3.12 / PG 15
- [ ] Post-deploy: confirm next scheduled-job failure in Sentry includes a traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)