### PR TITLE
Sprint 677: dead-code hygiene + route-wiring guardrail + deprecation register

### DIFF
--- a/backend/bank_reconciliation_memo_generator.py
+++ b/backend/bank_reconciliation_memo_generator.py
@@ -962,8 +962,6 @@ def generate_bank_rec_memo(
     story.append(LedgerRule(doc.width))
 
     risk_tier = str(composite.get("risk_tier", "low")).lower() if composite else "low"
-    rec_diff = summary.get("reconciling_difference", 0)
-    match_rate = matched / total_txns if total_txns > 0 else 0
 
     base_tier_label, _ = RISK_TIER_DISPLAY.get(risk_tier, ("LOW", ClassicalColors.SAGE))
     score_val = composite.get("score", 0) if composite else 0

--- a/backend/je_testing_engine.py
+++ b/backend/je_testing_engine.py
@@ -946,7 +946,6 @@ def test_unbalanced_entries(
             ungrouped.append(e)
 
     flagged: list[FlaggedEntry] = []
-    total_groups = len(groups)
 
     for group_key, group_entries in groups.items():
         total_debit = sum((e.debit for e in group_entries), Decimal("0"))

--- a/backend/je_testing_memo_generator.py
+++ b/backend/je_testing_memo_generator.py
@@ -322,11 +322,9 @@ def _build_preparer_analysis(
     Shows top 5 preparers by flagged entry count.
     """
     test_results = result.get("test_results", [])
-    total_entries = result.get("composite_score", {}).get("total_entries", 0)
 
     # Collect all flagged entries with preparer info
     preparer_flagged: Counter[str] = Counter()
-    preparer_total: Counter[str] = Counter()
     total_flagged_with_preparer = 0
     total_flagged_count = 0
 

--- a/backend/routes/three_way_match.py
+++ b/backend/routes/three_way_match.py
@@ -60,9 +60,11 @@ async def audit_three_way_match(
 
     enforce_tool_access(current_user, "three_way_match", db)
 
-    po_mapping = parse_json_mapping(po_column_mapping, "twm_po")
-    inv_mapping = parse_json_mapping(invoice_column_mapping, "twm_invoice")
-    rec_mapping = parse_json_mapping(receipt_column_mapping, "twm_receipt")
+    # parse_json_mapping has a log_secure_operation side effect; returns ignored
+    # until column-override wiring is implemented for three-way-match.
+    _ = parse_json_mapping(po_column_mapping, "twm_po")
+    _ = parse_json_mapping(invoice_column_mapping, "twm_invoice")
+    _ = parse_json_mapping(receipt_column_mapping, "twm_receipt")
 
     log_secure_operation(
         "three_way_match_upload",

--- a/backend/sampling_memo_generator.py
+++ b/backend/sampling_memo_generator.py
@@ -370,10 +370,6 @@ def _build_evaluation_next_steps(
             "apply to errors already identified:"
         )
 
-    pop_type = ""
-    if design_result:
-        pop_type = design_result.get("population_type", "").upper()
-
     # Build cross-reference step body based on population type
     cross_ref_body = (
         f"Cross-reference the {errors_found} identified errors to the related testing "

--- a/backend/shared/drill_down.py
+++ b/backend/shared/drill_down.py
@@ -77,7 +77,6 @@ def build_drill_down_table(
 
     # Auto-compute column widths proportional to header text length (BUG-003 fix)
     if col_widths is None:
-        n_cols = len(headers)
         header_lengths = [max(len(str(h)), 4) for h in headers]
         total_length = sum(header_lengths)
         min_col = doc_width * 0.08  # minimum 8% per column

--- a/backend/shared/tb_diagnostic_constants.py
+++ b/backend/shared/tb_diagnostic_constants.py
@@ -601,9 +601,7 @@ def compute_tb_diagnostic_score(
     # decomposition visually sums to the displayed total.
     capped = min(score, 100)
     if score > 100 and factors:
-        raw_sum = sum(pts for _, pts in factors)
         # Walk backwards (lowest-priority factors last) and trim.
-        excess = raw_sum - capped
         reconciled: list[tuple[str, int]] = []
         # Accumulate from the top; once we've consumed the cap, zero the rest.
         running = 0

--- a/docs/runbooks/deprecations.md
+++ b/docs/runbooks/deprecations.md
@@ -1,0 +1,30 @@
+# Deprecation Register
+
+> Central index for production code paths and fields that are formally
+> deprecated but still present for compatibility. Every entry must have
+> an owner and a removal trigger so deprecations do not linger indefinitely.
+>
+> Added in Sprint 677 (dead-code hygiene).
+
+## How to use this register
+
+- Add an entry the moment a code path is marked deprecated (docstring,
+  `@deprecated`, feature flag, or runtime warning).
+- Keep the **removal trigger** concrete: a callsite-count threshold, a
+  downstream migration, or a calendar date. "Someday" is not a trigger.
+- Move an entry to **Removed** once the code is deleted (keep for one
+  sprint for traceability, then prune).
+
+## Active Deprecations
+
+| Component / File | Deprecation reason | Owner | Removal trigger | Target sprint/date | Status |
+|------------------|-------------------|-------|-----------------|-------------------|--------|
+| `backend/excel_generator.py` (`prepared_by`, `reviewed_by`, `workpaper_date`, `include_signoff`) | Workpaper sign-off rendering moved to engagement-layer flow in Sprint 7; fields retained for backward-compatible callers that still set `include_signoff=True` | IntegratorLead | Zero external callers setting `include_signoff=True` across three consecutive nightly reports | Review 2026-Q3 | Active — gated (default off) |
+| `backend/pdf/orchestrator.py` (`include_signoff` path through `render_workpaper_signoff`) | Same Sprint 7 migration — PDF signoff section is dead unless explicitly opted into by the caller | IntegratorLead | Concurrent removal with `excel_generator.py` signoff block | Review 2026-Q3 | Active — gated (default off) |
+| `backend/shared/schemas.py` workpaper signoff fields (`prepared_by`, `reviewed_by`, `workpaper_date`, `include_signoff` in `ExportRequest`) | Schema fields retained to avoid breaking serialized requests while `include_signoff` is still a valid toggle | IntegratorLead | Concurrent removal with generator + orchestrator sign-off blocks | Review 2026-Q3 | Active — schema-present, default off |
+| `backend/shared/parsing_helpers.py::safe_float` | Deprecated for monetary values per Sprint 340+ Decimal migration; float precision is unsafe for currency arithmetic. `safe_decimal` is the canonical replacement | IntegratorLead | Zero callers in monetary paths; retain for non-monetary numeric parsing (ratios, rates, etc.) | Ongoing hygiene | Active — non-monetary uses allowed |
+| `frontend/src/utils/motionTokens.ts::DISTANCE` | Entrance distances migrated to `lift` in `@/lib/motion`; `DISTANCE` retained only for internal tool-state transitions that predate the migration | IntegratorLead | Remaining internal callers inside `motionTokens.ts` refactored to `lift`/spring tokens | Post-design-lock (est. Sprint 700 window) | Active — internal-only |
+
+## Removed (historical, prune after one sprint)
+
+_None at Sprint 677._

--- a/scripts/check_route_wiring.py
+++ b/scripts/check_route_wiring.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Dead-route guardrail for backend/routes/*.py modules.
+
+A route module is considered "wired" when it is imported either:
+    1. Directly in backend/routes/__init__.py (registered in all_routers), or
+    2. By a known aggregator module that is itself imported in __init__.py.
+
+Aggregators include sub-routers from audit.py, export.py, engagements.py -- these
+are the known router-composition files that mount sub-routers on a parent
+router before the parent is registered via __init__.py.
+
+Usage:
+    python scripts/check_route_wiring.py
+
+Exit codes:
+    0 -- all route modules are wired (pass)
+    1 -- one or more route modules are truly unreferenced (fail)
+    2 -- cannot locate backend/routes/ (environment error)
+
+Sprint 677: dead-code hygiene pass.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROUTES_DIR = REPO_ROOT / "backend" / "routes"
+
+AGGREGATOR_MODULES: tuple[str, ...] = (
+    "audit.py",
+    "export.py",
+    "engagements.py",
+)
+
+IMPORT_PATTERN = re.compile(
+    r"^\s*(?:from\s+routes\.(?P<mod1>[A-Za-z_][A-Za-z0-9_]*)"
+    r"|import\s+routes\.(?P<mod2>[A-Za-z_][A-Za-z0-9_]*))",
+    re.MULTILINE,
+)
+
+
+def _collect_imported_modules(py_file: Path) -> set[str]:
+    """Return the set of routes.<name> modules imported by a given file."""
+    text = py_file.read_text(encoding="utf-8")
+    names: set[str] = set()
+    for match in IMPORT_PATTERN.finditer(text):
+        name = match.group("mod1") or match.group("mod2")
+        if name:
+            names.add(name)
+    return names
+
+
+def main() -> int:
+    if not ROUTES_DIR.is_dir():
+        print(f"ERROR: routes directory not found: {ROUTES_DIR}", file=sys.stderr)
+        return 2
+
+    init_file = ROUTES_DIR / "__init__.py"
+    if not init_file.is_file():
+        print(f"ERROR: routes/__init__.py not found: {init_file}", file=sys.stderr)
+        return 2
+
+    all_modules: set[str] = {
+        p.stem for p in ROUTES_DIR.glob("*.py") if p.name != "__init__.py"
+    }
+    aggregator_stems: set[str] = {Path(a).stem for a in AGGREGATOR_MODULES}
+
+    init_imports = _collect_imported_modules(init_file)
+
+    aggregator_imports: set[str] = set()
+    for agg_name in AGGREGATOR_MODULES:
+        agg_path = ROUTES_DIR / agg_name
+        if agg_path.is_file():
+            aggregator_imports |= _collect_imported_modules(agg_path)
+
+    # A module is wired if it is:
+    #   - imported directly from routes/__init__.py, OR
+    #   - imported by a known aggregator that is itself wired in __init__.py.
+    wired: set[str] = set(init_imports) | set(aggregator_imports)
+
+    # Aggregators themselves must be imported from __init__.py. We don't
+    # treat them as orphaned even if their sub-modules are imported only
+    # by the aggregator, but we DO require the aggregator to be wired.
+    unreferenced: set[str] = set()
+    for mod in sorted(all_modules):
+        if mod in wired:
+            continue
+        # An aggregator is "wired" via init_imports only.
+        if mod in aggregator_stems and mod in init_imports:
+            continue
+        unreferenced.add(mod)
+
+    print("Paciolus route wiring check")
+    print("=" * 40)
+    print(f"Route modules scanned:       {len(all_modules)}")
+    print(f"Imported by __init__.py:     {len(init_imports & all_modules)}")
+    print(f"Imported by aggregators:     {len(aggregator_imports & all_modules)}")
+    print(f"Aggregators checked:         {', '.join(sorted(aggregator_stems))}")
+    print()
+
+    if unreferenced:
+        print(f"FAIL -- {len(unreferenced)} unreferenced route module(s):")
+        for mod in sorted(unreferenced):
+            print(f"  - routes/{mod}.py")
+        print()
+        print("Either register the module in routes/__init__.py,")
+        print("import it from a known aggregator, or delete it.")
+        return 1
+
+    print("PASS -- all route modules are wired.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -128,6 +128,38 @@ The nightly Coverage Sentinel's three worst 0%-coverage files turned out to have
 
 ---
 
+### Sprint 677: Dead-code hygiene + route-wiring guardrail + deprecation register
+**Status:** COMPLETE
+**Source:** Targeted audit directive 2026-04-18 — safe dead-code pass, no behavior change
+
+**Changes:**
+- [x] Remove 11 unused locals flagged by ruff F841 across 7 production files:
+  - `backend/bank_reconciliation_memo_generator.py` (rec_diff, match_rate)
+  - `backend/je_testing_engine.py` (total_groups)
+  - `backend/je_testing_memo_generator.py` (total_entries, preparer_total)
+  - `backend/routes/three_way_match.py` (po_mapping, inv_mapping, rec_mapping — switched to `_ = ...` to preserve the `log_secure_operation` side effect inside `parse_json_mapping`)
+  - `backend/sampling_memo_generator.py` (pop_type — both assignments unused)
+  - `backend/shared/drill_down.py` (n_cols)
+  - `backend/shared/tb_diagnostic_constants.py` (excess, and its only-feeder raw_sum)
+- [x] Add `scripts/check_route_wiring.py` — scans `backend/routes/*.py`, flags modules not imported by `routes/__init__.py` or by the known aggregators (`audit.py`, `export.py`, `engagements.py`); exits non-zero on true orphans
+- [x] Add `docs/runbooks/deprecations.md` — deprecation register with Active / Removed sections. Seeded with: `excel_generator.py` signoff fields, `pdf/orchestrator.py` signoff gating, `shared/schemas.py` signoff fields, `shared/parsing_helpers.py::safe_float` (monetary-unsafe), `frontend/src/utils/motionTokens.ts::DISTANCE`
+
+**Verification:**
+- `cd backend && python -m ruff check . --select F401,F841` on the seven target files: `All checks passed!` (target scope clean)
+- `python scripts/check_route_wiring.py`: 58 modules scanned, 48 via `__init__.py`, 10 via aggregators, PASS
+- Targeted pytest: `test_bank_rec_memo.py`, `test_je_testing_engine.py`, `test_je_testing_memo.py`, `test_three_way_match.py`, `test_sampling_memo.py`, `test_drill_down.py`, `test_diagnostics_api.py` → **315 passed, 1 warning in 10.53s**
+- `test_contra_and_detection_fixes.py` (exercises `compute_tb_diagnostic_score`) → **69 passed in 0.82s**
+- Backend smoke: `python -c "from main import app; ..."` → 239 routes registered, no regression
+
+**Review:**
+- `three_way_match` column mappings are intentionally discarded today (override wiring is a pre-existing gap). The `_ = ...` assignments keep `log_secure_operation` firing so the audit trail still shows receipt of the caller's JSON payload, and the inline comment flags the call site for whoever picks the wiring up.
+- `raw_sum` in `tb_diagnostic_constants.py` was the sole feeder of the removed `excess`; the trimming algorithm that follows uses `capped` and `running` directly, so removing both cleans the function rather than leaving a dangling `raw_sum` warning for the next pass.
+- `scripts/check_route_wiring.py` is wired to be CI-safe: no third-party deps, pure-stdlib regex, aggregator allowlist is explicit and easy to extend when a new aggregator pattern appears.
+- The remaining 23 F841 warnings in `backend/tests/*.py` and 3 in `generate_sample_reports.py` are explicitly **out of scope** — cleaning test fixtures risks hiding intent (e.g., `user = make_user(...)` in webhook fixtures is descriptive even when the handle isn't referenced) and warrants a separate test-hygiene sprint.
+- Residuals: `routes/three_way_match.py` override plumbing is now a documented follow-up rather than a silent drop; `backend/tests` F841 cleanup tracked for a future hygiene pass.
+
+---
+
 ### Sprint 611: ExportShare Object Store Migration
 **Status:** PENDING — CEO-gated (bucket provision)
 **Source:** Critic — DB bloat risk


### PR DESCRIPTION
## Summary

Safe, surgical dead-code hygiene pass — no behavior changes, no API contract changes, no endpoint additions/removals, no auth or security primitive changes.

Three concurrent deliverables:
1. Remove 11 confirmed unused locals (ruff F841) in 7 production files.
2. Add a CI-safe route-wiring guardrail: `scripts/check_route_wiring.py`.
3. Add a formal deprecation register: `docs/runbooks/deprecations.md`.

## What was removed / fixed

Production unused locals (F841) — all pure assignments with no side effects, except three_way_match where the call-side-effect is preserved:

| File | Removed | Notes |
|------|---------|-------|
| `backend/bank_reconciliation_memo_generator.py` | `rec_diff`, `match_rate` | Pure assignments |
| `backend/je_testing_engine.py` | `total_groups` | `len(groups)` — pure |
| `backend/je_testing_memo_generator.py` | `total_entries`, `preparer_total` | `.get()` + `Counter()` — pure |
| `backend/routes/three_way_match.py` | `po_mapping`, `inv_mapping`, `rec_mapping` | **Kept call, dropped binding** via `_ = parse_json_mapping(...)`. `parse_json_mapping` has a `log_secure_operation` side effect; retaining it preserves the audit-trail. Column-override wiring is a pre-existing gap; flagged inline. |
| `backend/sampling_memo_generator.py` | `pop_type` (both assignments) | Variable never referenced |
| `backend/shared/drill_down.py` | `n_cols` | `len(headers)` — pure |
| `backend/shared/tb_diagnostic_constants.py` | `excess`, `raw_sum` | `raw_sum` was `excess`'s only feeder; the trim algorithm uses `capped`/`running` directly. |

## Why behavior is unchanged

- No code paths were re-structured. Every removal is a literal assignment deletion or (for `three_way_match`) a binding-only change that retains the RHS call.
- `parse_json_mapping` in `routes/three_way_match.py` is a special case: its return value was already being ignored before this PR. The mapping parameters are declared on the endpoint but are not propagated into `_analyze()`. Converting to `_ = ...` preserves the `log_secure_operation` logging that was already firing — nothing changes at runtime.
- No conditionals reference any of the removed names (verified by ruff F841 + manual grep).

## Route-wiring guardrail

`scripts/check_route_wiring.py` (stdlib-only, no third-party deps):
- Treats a route module as wired if imported by `backend/routes/__init__.py` **or** by a known aggregator (`audit.py`, `export.py`, `engagements.py`).
- Aggregator allowlist lives at the top of the script — explicit and easy to extend.
- Exits **0** on pass, **1** on true orphans, **2** on environment errors.
- Current run: `58 scanned, 48 wired via __init__, 10 via aggregators — PASS`.
- Does **not** flag `audit_diagnostics.py`, `audit_flux.py`, `audit_pipeline.py`, `audit_preview.py`, `audit_upload.py`, `engagements_analytics.py`, `engagements_exports.py`, `export_diagnostics.py`, `export_memos.py`, `export_testing.py` — these are correctly detected as aggregator sub-routers.

## Deprecation register

New `docs/runbooks/deprecations.md` with explicit owners and removal triggers. Seeded from known deprecations:
- `excel_generator.py` / `pdf/orchestrator.py` / `shared/schemas.py` Sprint 7 signoff fields (gated by `include_signoff`, default off)
- `shared/parsing_helpers.py::safe_float` (monetary-unsafe; `safe_decimal` is canonical)
- `frontend/src/utils/motionTokens.ts::DISTANCE` (`@deprecated` annotation already present)

## Verification commands + results

```
$ cd backend && python -m ruff check . --select F401,F841
  (target-scope files)  All checks passed!
  (full backend) 34 remaining — all in backend/tests/*.py and generate_sample_reports.py → out of scope

$ python scripts/check_route_wiring.py
  Route modules scanned:       58
  Imported by __init__.py:     48
  Imported by aggregators:     10
  PASS -- all route modules are wired.
  (exit 0)

$ cd backend && python -m pytest \
    tests/test_bank_rec_memo.py tests/test_je_testing_engine.py \
    tests/test_je_testing_memo.py tests/test_three_way_match.py \
    tests/test_sampling_memo.py tests/test_drill_down.py \
    tests/test_diagnostics_api.py -x --no-header -q
  315 passed, 1 warning in 10.53s

$ cd backend && python -m pytest tests/test_contra_and_detection_fixes.py --no-header -q
  69 passed in 0.82s

$ cd backend && python -c "from main import app; print('Backend OK — routes:', len(app.routes))"
  Backend OK — routes: 239
```

## Follow-ups deferred intentionally

- **`backend/tests/*.py` F841 cleanup (23 warnings)** — deliberately out of scope. Test fixtures like `user = make_user(...)` are descriptive even when the handle is unreferenced; stripping them risks obscuring test intent and warrants a dedicated test-hygiene sprint.
- **`generate_sample_reports.py` F841 (3 warnings)** — non-production dev utility; not on the critical path.
- **`routes/three_way_match.py` column-mapping override plumbing** — now a documented follow-up (inline comment + todo.md Review section) rather than a silent drop. Deserves its own sprint to wire `po_mapping` / `inv_mapping` / `rec_mapping` through into the parser detections.

## Test plan

- [ ] Verify `python scripts/check_route_wiring.py` exits 0 on CI.
- [ ] Spot-check that bank-reconciliation, JE, three-way-match, sampling memo generation still runs end-to-end in a dev server.
- [ ] Confirm the `docs/runbooks/deprecations.md` register is discoverable in the runbooks index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)