### PR TITLE
Sprint 732 step 1: cleanup_scheduler observability fix

### DIFF
--- a/backend/cleanup_scheduler.py
+++ b/backend/cleanup_scheduler.py
@@ -74,6 +74,14 @@ class CleanupTelemetry:
     duration_ms: float
     records_processed: int
     error: str | None = field(default=None)
+    # Sprint 732: fully-qualified exception type (e.g.
+    # ``sqlalchemy.exc.InternalError``) to disambiguate the bare class
+    # name in `error`. ``sanitize_exception`` strips the actual message
+    # to keep PII / secrets out of logs, so the class name alone was
+    # ambiguous — Python, SQLAlchemy, and psycopg2 all expose
+    # ``InternalError`` types. The FQN is module-path metadata, not a
+    # message, so it carries no PII risk.
+    error_type_fqn: str | None = field(default=None)
 
     def to_log_dict(self) -> dict:
         """Return a dict suitable for structured logging."""
@@ -86,6 +94,8 @@ class CleanupTelemetry:
         }
         if self.error is not None:
             d["error"] = self.error
+        if self.error_type_fqn is not None:
+            d["error_type_fqn"] = self.error_type_fqn
         return d
 
 
@@ -221,12 +231,18 @@ def _run_cleanup_job(
     duration_ms = (time.perf_counter() - t0) * 1000
     _last_run_times[job_name] = started_at
 
+    error_type_fqn: str | None = None
+    if caught_exc is not None:
+        # e.g. "sqlalchemy.exc.InternalError" or "psycopg2.errors.SerializationFailure"
+        error_type_fqn = f"{type(caught_exc).__module__}.{type(caught_exc).__name__}"
+
     telemetry = CleanupTelemetry(
         job_name=job_name,
         started_at=started_at.isoformat(),
         duration_ms=duration_ms,
         records_processed=records_processed,
         error=error_msg,
+        error_type_fqn=error_type_fqn,
     )
 
     if error_msg:

--- a/backend/tests/test_cleanup_scheduler.py
+++ b/backend/tests/test_cleanup_scheduler.py
@@ -125,6 +125,11 @@ class TestRunCleanupJob:
         assert "boom-with-traceback" in str(exc_value)
         # Sanitized message preserved in the telemetry payload
         assert "RuntimeError: scheduled cleanup failed" in caplog.text
+        # Sprint 732: error_type_fqn disambiguates bare class names —
+        # SQLAlchemy / psycopg2 / Python all expose `InternalError`. The FQN
+        # is module-path metadata, no PII risk.
+        assert "error_type_fqn" in caplog.text
+        assert "builtins.RuntimeError" in caplog.text
 
     def test_session_always_closed_on_success(self):
         """Session is closed even when cleanup returns 0."""

--- a/tasks/archive/sprints-715-729-details.md
+++ b/tasks/archive/sprints-715-729-details.md
@@ -1,0 +1,141 @@
+# Sprints 715–729 Details
+
+> Archived from `tasks/todo.md` Active Phase on 2026-04-27.
+
+---
+
+### Sprint 728: ISA 520 Expectation-Formation Workflow (parent — 728a/b/c)
+**Status:** COMPLETE 2026-04-26 — all three sub-sprints landed atomically per the CEO-approved plan `tasks/sprint-plan-728-729.md`.
+**Priority:** P3 (post-launch product gap; differentiator).
+**Source:** Agent sweep 2026-04-24, punch list 4.1 + Accounting Methodology Audit.
+
+Architecture decision (CEO-confirmed 2026-04-26): **snapshot model.** New entity holds *audit decisions* (expectation, threshold, corroboration, result, conclusion); flux / ratio / multi-period TB engines stay zero-storage. ISA 520 §A4–A8 frames this as a workpaper of decisions, not a database join.
+
+#### Sprint 728a — Backend core
+**Status:** COMPLETE 2026-04-26.
+**Delivered:**
+- `backend/analytical_expectations_model.py` — new `AnalyticalExpectation` entity (FK → engagements, soft-delete, JSON tag list, expected XOR range, threshold XOR percent, result status enum).
+- `backend/analytical_expectations_manager.py` — CRUD manager with engagement-scoped multi-tenant ownership; pure-function `evaluate_status(actual, expected, threshold) → (variance, status)` reused later by 728c tool wiring.
+- `backend/migrations/alembic/versions/f2a8e7d6c5b4_add_analytical_expectations.py` — Alembic migration; chains off prior head `e1a2b3c4d5f6`; upgrade + downgrade exercised end-to-end.
+- `backend/schemas/analytical_expectation_schemas.py` — Pydantic Create/Update/Response.
+- `backend/routes/analytical_expectations.py` — 5 CRUD endpoints (`POST` + `GET` list on `/engagements/{id}/analytical-expectations`, `GET` + `PATCH` + `DELETE` on `/analytical-expectations/{id}`); registered in `routes/__init__.py`.
+- `backend/analytical_expectation_memo_generator.py` — ISA 520 workpaper PDF (cover, engagement overview, expectations table grouped by target type, authoritative references, sign-off block with DRAFT watermark when items remain unevaluated). Enterprise branding via `apply_pdf_branding`.
+- `backend/routes/engagements_exports.py` — added `POST /engagements/{id}/export/analytical-expectations`.
+- `backend/engagement_manager.py` — completion gate updated; engagements with non-archived `NOT_EVALUATED` expectations are blocked from completion (conditional — engagements with no expectations stay un-gated).
+- `docs/04-compliance/isa-520-coverage.md` — methodology coverage doc.
+- 6 test files, +61 tests covering model schema/defaults/soft-delete, manager CRUD/validation/`evaluate_status`, route happy-path + ownership + CSRF, memo PDF render, completion-gate matrix, export route.
+
+**Verification:** Full backend `pytest` 8386 passed; the 4 unrelated failures in `test_security_hardening_2026_04_20.py` are pre-existing (`STRIPE_PUBLISHABLE_KEY` is `pk_test_*` while `IS_PRODUCTION=true` in dev env — clears once Sprint 447 cutover lands). Alembic upgrade head + downgrade -1 verified end-to-end against SQLite.
+
+**Out of scope (carried to 728b/c):**
+- Frontend section, capture form, hook (728b).
+- Flux / ratio / multi-period TB engine wiring + auto-persist of result on tool run (728c).
+
+#### Sprint 728b — Frontend
+**Status:** COMPLETE 2026-04-26.
+**Delivered:**
+- `frontend/src/types/analytical-expectations.ts` — types + label/color maps mirroring backend schemas.
+- `frontend/src/hooks/useAnalyticalExpectations.ts` — fetch / create / update / archive hook (paginated list).
+- `frontend/src/components/engagement/AnalyticalExpectationsPanel.tsx` — full list + create modal + capture-actual inline form + re-evaluate button + archive. Form enforces XOR (value vs range, amount vs percent) with inline validation.
+- `frontend/src/app/(workspace)/portfolio/[clientId]/workspace/[engagementId]/page.tsx` — added `expectations` tab between `follow-up` and `workpaper` in the workspace detail page; wires hook + panel + PDF download via `apiDownload` + `downloadBlob`.
+- `frontend/src/__tests__/AnalyticalExpectationsPanel.test.tsx` — 8 component tests covering empty state, status badges, status counts, capture-actual flow, clear-result, archive, and modal open.
+
+**Verification:** TypeScript typecheck clean (`npx tsc --noEmit`), 8 component tests passing, `npm run build` succeeds.
+
+#### Sprint 728c — Tool wiring
+**Status:** COMPLETE 2026-04-26.
+**Delivered:**
+- `backend/shared/expectation_evaluation.py` — `evaluate_expectations_against_measurements(...)` matches measurements (typed `[(target_type, target_label, actual)]` triples) to NOT_EVALUATED expectations on the engagement, computes variance + status via the pure `evaluate_status` from 728a, persists the result via the manager (so the audit-trail log fires consistently), and returns evaluation records the route surfaces inline. Three extractors: `extract_flux_measurements` (emits BALANCE+ACCOUNT+FLUX_LINE per item), `extract_multi_period_measurements` (BALANCE+ACCOUNT per movement), `extract_ratio_measurements` (RATIO; accepts dict or list shape).
+- `backend/routes/audit_flux.py` — calls helper after `run_flux_analysis` when `engagement_id` is present; returns `expectations_evaluated` array in the response.
+- `backend/routes/multi_period.py` — same wiring on `/audit/compare-periods` and `/audit/compare-three-way`.
+- `backend/routes/trends.py` — `/clients/{id}/industry-ratios` now accepts optional `engagement_id` query param; auto-evaluates ratio-typed expectations when present.
+- `backend/shared/diagnostic_response_schemas.py` — new `ExpectationEvaluationResponse` Pydantic model added as `expectations_evaluated: list[ExpectationEvaluationResponse] = []` to `FluxAnalysisResponse`, `MovementSummaryResponse`, `ThreeWayMovementSummaryResponse`. `IndustryRatiosResponse` (defined in `routes/trends.py`) extended similarly.
+- 17 tests across 2 new files: `test_expectation_evaluation.py` (15 tests — extractors + evaluator covering match cases, case-insensitive labels, target-type mismatches, already-evaluated no-op, ownership, first-match-wins) + `test_multi_period_expectation_wiring.py` (2 tests — route emits `expectations_evaluated` when `engagement_id` is supplied; field is empty when absent).
+
+**Verification:** Sprint 728c-targeted tests + adjacent — 45 passing.
+
+**Pattern note:** Engines stay zero-storage. The route layer is the only place that knows about engagements + expectations. Adding wiring to a new tool = (a) accept `engagement_id` (already true for the engagement-aware tools); (b) extract measurements via the appropriate helper; (c) call `evaluate_expectations_against_measurements`; (d) embed result in the response. No engine changes required.
+
+
+---
+
+### Sprint 729: ISA 450 SUM Schedule (parent — 729a/b/c)
+**Status:** COMPLETE 2026-04-26 — all three sub-sprints landed atomically per the CEO-approved plan `tasks/sprint-plan-728-729.md`.
+**Priority:** P3 (post-launch product gap; differentiator).
+**Source:** Agent sweep 2026-04-24, punch list 4.2 + Accounting Methodology Audit.
+
+Architecture decision: **snapshot model.** Because `AdjustingEntry` is in-memory (zero-storage dataclass per `backend/adjusting_entries.py`) and sampling output is ephemeral, the original "auto-aggregate from passed AJEs / sample projections" plan was infeasible without breaking zero-storage. CEO confirmed 2026-04-26: SUM is a CPA-captured workpaper of decisions, with 729c capture helpers added for ergonomics.
+
+#### Sprint 729a — Backend core
+**Status:** COMPLETE 2026-04-26.
+**Delivered:**
+- `backend/uncorrected_misstatements_model.py` — `UncorrectedMisstatement` entity (FK → engagements CASCADE, `MisstatementSourceType` / `MisstatementClassification` / `MisstatementDisposition` enums, signed F/S impacts, `accounts_affected_json`, soft-delete).
+- `backend/uncorrected_misstatements_manager.py` — CRUD manager + pure-function `compute_materiality_bucket(driver, overall, performance, trivial)` returning the four-bucket enum + `compute_sum_schedule(...)` aggregation (factual+judgmental subtotal vs projected subtotal per ISA 450 §A4 grouping; aggregate driver = `max(|net_income|, |net_assets|)`).
+- `backend/migrations/alembic/versions/a3b4c5d6e7f8_add_uncorrected_misstatements.py` — chains off `f2a8e7d6c5b4`. Upgrade + downgrade verified end-to-end.
+- `backend/schemas/uncorrected_misstatement_schemas.py` — Create/Update/Response/SumSchedule schemas with `AccountAffected` row.
+- `backend/routes/uncorrected_misstatements.py` — 6 endpoints (CRUD + `GET /engagements/{id}/sum-schedule` aggregation); registered.
+- `backend/sum_schedule_memo_generator.py` — ISA 450 workpaper PDF (cover, overview, classification-grouped tables, aggregate evaluation with bucket box colored by severity, AU-C/ISA/AS 2810 references, sign-off with DRAFT watermark for unreviewed items).
+- `backend/routes/engagements_exports.py` — added `POST /engagements/{id}/export/sum-schedule`.
+- `backend/engagement_manager.py` — completion gate now also requires (a) all SUM items have non-`NOT_YET_REVIEWED` disposition, (b) if aggregate is in `MATERIAL` bucket, at least one item must carry `cpa_notes` (override documentation per ISA 450 §11). Gate ordering preserved: follow-up → ISA 520 → ISA 450.
+- `docs/04-compliance/isa-450-coverage.md` — coverage doc with bucket-boundary table and architectural-decision rationale.
+- 6 test files, +69 tests covering schema, defaults, soft-delete, manager CRUD/validation, bucket boundaries (parametrized including signed/zero/equal-to), aggregation correctness, gate-helper functions, route happy-path + 404, memo render (empty + 3-classification + MATERIAL warning + cross-tenant), completion-gate matrix (no-items / pending / dispositioned / MATERIAL-no-override / MATERIAL-with-override / archived / 520-before-450 ordering), export route happy-path + 404.
+
+**Verification:** Sprint 729a + memo-boundary scanner + adjacent completion-gate tests — 110 passing.
+
+**Out of scope (carried to 729b/c):**
+- Frontend SUM page + capture form (729b).
+- Capture-helper buttons on AJE workflow + sampling tool (729c).
+
+#### Sprint 729b — Frontend
+**Status:** COMPLETE 2026-04-26.
+**Delivered:**
+- `frontend/src/types/uncorrected-misstatements.ts` — types + label maps + `BUCKET_TONE` mapping (sage / clay-soft / clay).
+- `frontend/src/hooks/useUncorrectedMisstatements.ts` — fetch SUM schedule + create/update/archive (mutations re-fetch the schedule so aggregate/bucket update live).
+- `frontend/src/components/engagement/SumSchedulePanel.tsx` — bucket box (color from `BUCKET_TONE`; MATERIAL warning copy when bucket is `material`), materiality cascade reference, per-row classification/source/description/F-S-impact display, disposition select, archive action, three-variant capture form with auto-classification helper (sample-projection → projected, AJE-passed → judgmental).
+- Workspace detail page now exposes a `sum` tab between `expectations` and `workpaper`; wires the hook + panel + PDF download.
+- `frontend/src/__tests__/SumSchedulePanel.test.tsx` — 8 component tests covering empty state, bucket-box label, MATERIAL warning, item rows, disposition mutation, archive, modal open, download disabled state.
+
+**Verification:** TypeScript typecheck clean, 8 component tests passing, `npm run build` succeeds.
+
+#### Sprint 729c — Capture helpers
+**Status:** COMPLETE 2026-04-26.
+**Delivered:**
+- Refactored `frontend/src/components/engagement/SumSchedulePanel.tsx` — extracted the inline `CreateMisstatementModal` to its own file `CreateMisstatementModal.tsx` with an `initialValues` prop so it can be reused with pre-filled data. SumSchedulePanel itself shrank to ~306 LoC (was 553).
+- `frontend/src/components/engagement/CaptureToSumButton.tsx` — new component that takes either `prefillFromAdjustingEntry={…}` or `prefillFromSampleProjection={…}` and opens the modal with computed initial values (largest AJE line becomes the canonical account; sample projection emits `source_type=sample_projection`, `classification=projected`, UEL → account amount). Default labels "Add to SUM" / "Capture as SUM projection" / "Capture to SUM".
+- `frontend/src/components/adjustments/AdjustmentSection.tsx` + `AdjustmentList.tsx` — pass-through `engagementId` prop. When supplied and an AJE is in `rejected` (passed) status, the row renders an "Add to SUM" button next to "Re-open" / "View Details" / "Delete".
+- 7 new component tests (`__tests__/CaptureToSumButton.test.tsx`) — default label, AJE label, projection label, modal pre-fill from AJE (source_reference contains reference + description), largest-line wins, sample-projection pre-fill (source_reference contains UEL).
+
+**Out of scope (deferred):**
+- Sampling-tool wiring at the route level: the sampling tool's frontend doesn't yet have a UI surface that consumes UEL > tolerable; the `CaptureToSumButton` is ready to drop in there once that surface lands. Pattern is the same as AJE wiring — pass `engagementId` + `prefillFromSampleProjection`.
+- Engagement-id propagation into the AJE workflow's parent page: callers of `<AdjustmentSection />` now have an opt-in `engagementId` prop. Wiring it from a specific audit page (`/tools/...` or workspace context) is a one-line change at each call site; deferred until product wires the AJE workflow into engagement-aware pages explicitly.
+
+**Verification:** TypeScript typecheck clean; 30 frontend tests passing across CaptureToSumButton + AdjustmentList + AdjustmentSection + SumSchedulePanel; `npm run build` succeeds.
+
+
+---
+
+### Sprint 715: SendGrid 403 root-cause investigation (24h post-deploy watch)
+**Status:** COMPLETE 2026-04-26.
+**Priority:** P2 (observability follow-up).
+**Source:** Sprint 713 Bug C review — the fix caught the exception but did not investigate the root cause.
+
+**Investigation outcome:** Render logs over the 48h post-deploy window (2026-04-24 14:29 UTC → 2026-04-26 21:35 UTC) contain **zero matches** for `SendGrid`, `HTTPError`, `email_error`, `Verification email`, `Background … send failed`, and **zero requests** to `/auth/register`, `/auth/forgot-password`, `/contact`. Phase 3 functional validation hasn't exercised email paths yet, so the 403 trigger condition was never met. No root cause to chase.
+
+**Secondary finding (fixed in this sprint):** While tracing the warn-path, discovered `shared/background_email.py` was logging `"Background <label> send failed: unknown"` because it read a non-existent `result.error` attribute. `EmailResult` exposes `success`/`message`/`message_id` — the SendGrid status code lives in `result.message`. Sprint 713's existing test only asserted `len(warning_records) >= 1`, never inspected the message text, so the regression slipped through. **If a 403 had occurred in the past 48h, the log line would not have surfaced the status code** — the warn-path Sprint 713 added was effectively non-investigable.
+
+**Fix:**
+- `backend/shared/background_email.py`: read `result.message` (the canonical attribute), with `"unknown"` only as the empty-string fallback.
+- `backend/tests/test_sprint_713_sentry_sweep.py::test_background_email_logs_warning_not_error_on_failure`: strengthened to assert the warning is emitted by `shared.background_email`, contains the label, contains `"403"`, and does **not** fall back to `"unknown"`. Future regressions of this shape will fail the test.
+
+**Out of scope (deferred):**
+- Proactive SendGrid suppression-list sync (no infra justification until 403 volume is meaningful).
+- Email deliverability SLA tracking.
+- Cleanup_scheduler `InternalError: scheduled cleanup failed` on `reset_upload_quotas` and `dunning_grace_period`, observed every ~1h during this investigation. Unrelated system, separate signal — captured as a follow-up below.
+
+**Verification:** `pytest tests/test_sprint_713_sentry_sweep.py tests/test_email_verification.py tests/test_contact_api.py tests/test_no_helpers_reexports.py tests/test_refactor_2026_04_20.py tests/test_log_sanitizer.py` — 106 passed.
+
+**Review:** Sprint reframed from "find the 403 root cause" to "verify there *is* a 403 to investigate, then make the warn-path actually surface the status code when one happens". Net delta: 1 LoC fix in production code, +12 LoC of test assertions that prevent the silent-failure shape from re-emerging. Commit SHA recorded at commit time.
+
+
+---
+

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -67,142 +67,11 @@
 > Sprints 716–720 archived to `tasks/archive/sprints-716-720-details.md`.
 > Sprints 721–725 archived to `tasks/archive/sprints-721-725-details.md`.
 > Sprints 726–731 archived to `tasks/archive/sprints-726-731-details.md`.
-
-### Sprint 728: ISA 520 Expectation-Formation Workflow (parent — 728a/b/c)
-**Status:** COMPLETE 2026-04-26 — all three sub-sprints landed atomically per the CEO-approved plan `tasks/sprint-plan-728-729.md`.
-**Priority:** P3 (post-launch product gap; differentiator).
-**Source:** Agent sweep 2026-04-24, punch list 4.1 + Accounting Methodology Audit.
-
-Architecture decision (CEO-confirmed 2026-04-26): **snapshot model.** New entity holds *audit decisions* (expectation, threshold, corroboration, result, conclusion); flux / ratio / multi-period TB engines stay zero-storage. ISA 520 §A4–A8 frames this as a workpaper of decisions, not a database join.
-
-#### Sprint 728a — Backend core
-**Status:** COMPLETE 2026-04-26.
-**Delivered:**
-- `backend/analytical_expectations_model.py` — new `AnalyticalExpectation` entity (FK → engagements, soft-delete, JSON tag list, expected XOR range, threshold XOR percent, result status enum).
-- `backend/analytical_expectations_manager.py` — CRUD manager with engagement-scoped multi-tenant ownership; pure-function `evaluate_status(actual, expected, threshold) → (variance, status)` reused later by 728c tool wiring.
-- `backend/migrations/alembic/versions/f2a8e7d6c5b4_add_analytical_expectations.py` — Alembic migration; chains off prior head `e1a2b3c4d5f6`; upgrade + downgrade exercised end-to-end.
-- `backend/schemas/analytical_expectation_schemas.py` — Pydantic Create/Update/Response.
-- `backend/routes/analytical_expectations.py` — 5 CRUD endpoints (`POST` + `GET` list on `/engagements/{id}/analytical-expectations`, `GET` + `PATCH` + `DELETE` on `/analytical-expectations/{id}`); registered in `routes/__init__.py`.
-- `backend/analytical_expectation_memo_generator.py` — ISA 520 workpaper PDF (cover, engagement overview, expectations table grouped by target type, authoritative references, sign-off block with DRAFT watermark when items remain unevaluated). Enterprise branding via `apply_pdf_branding`.
-- `backend/routes/engagements_exports.py` — added `POST /engagements/{id}/export/analytical-expectations`.
-- `backend/engagement_manager.py` — completion gate updated; engagements with non-archived `NOT_EVALUATED` expectations are blocked from completion (conditional — engagements with no expectations stay un-gated).
-- `docs/04-compliance/isa-520-coverage.md` — methodology coverage doc.
-- 6 test files, +61 tests covering model schema/defaults/soft-delete, manager CRUD/validation/`evaluate_status`, route happy-path + ownership + CSRF, memo PDF render, completion-gate matrix, export route.
-
-**Verification:** Full backend `pytest` 8386 passed; the 4 unrelated failures in `test_security_hardening_2026_04_20.py` are pre-existing (`STRIPE_PUBLISHABLE_KEY` is `pk_test_*` while `IS_PRODUCTION=true` in dev env — clears once Sprint 447 cutover lands). Alembic upgrade head + downgrade -1 verified end-to-end against SQLite.
-
-**Out of scope (carried to 728b/c):**
-- Frontend section, capture form, hook (728b).
-- Flux / ratio / multi-period TB engine wiring + auto-persist of result on tool run (728c).
-
-#### Sprint 728b — Frontend
-**Status:** COMPLETE 2026-04-26.
-**Delivered:**
-- `frontend/src/types/analytical-expectations.ts` — types + label/color maps mirroring backend schemas.
-- `frontend/src/hooks/useAnalyticalExpectations.ts` — fetch / create / update / archive hook (paginated list).
-- `frontend/src/components/engagement/AnalyticalExpectationsPanel.tsx` — full list + create modal + capture-actual inline form + re-evaluate button + archive. Form enforces XOR (value vs range, amount vs percent) with inline validation.
-- `frontend/src/app/(workspace)/portfolio/[clientId]/workspace/[engagementId]/page.tsx` — added `expectations` tab between `follow-up` and `workpaper` in the workspace detail page; wires hook + panel + PDF download via `apiDownload` + `downloadBlob`.
-- `frontend/src/__tests__/AnalyticalExpectationsPanel.test.tsx` — 8 component tests covering empty state, status badges, status counts, capture-actual flow, clear-result, archive, and modal open.
-
-**Verification:** TypeScript typecheck clean (`npx tsc --noEmit`), 8 component tests passing, `npm run build` succeeds.
-
-#### Sprint 728c — Tool wiring
-**Status:** COMPLETE 2026-04-26.
-**Delivered:**
-- `backend/shared/expectation_evaluation.py` — `evaluate_expectations_against_measurements(...)` matches measurements (typed `[(target_type, target_label, actual)]` triples) to NOT_EVALUATED expectations on the engagement, computes variance + status via the pure `evaluate_status` from 728a, persists the result via the manager (so the audit-trail log fires consistently), and returns evaluation records the route surfaces inline. Three extractors: `extract_flux_measurements` (emits BALANCE+ACCOUNT+FLUX_LINE per item), `extract_multi_period_measurements` (BALANCE+ACCOUNT per movement), `extract_ratio_measurements` (RATIO; accepts dict or list shape).
-- `backend/routes/audit_flux.py` — calls helper after `run_flux_analysis` when `engagement_id` is present; returns `expectations_evaluated` array in the response.
-- `backend/routes/multi_period.py` — same wiring on `/audit/compare-periods` and `/audit/compare-three-way`.
-- `backend/routes/trends.py` — `/clients/{id}/industry-ratios` now accepts optional `engagement_id` query param; auto-evaluates ratio-typed expectations when present.
-- `backend/shared/diagnostic_response_schemas.py` — new `ExpectationEvaluationResponse` Pydantic model added as `expectations_evaluated: list[ExpectationEvaluationResponse] = []` to `FluxAnalysisResponse`, `MovementSummaryResponse`, `ThreeWayMovementSummaryResponse`. `IndustryRatiosResponse` (defined in `routes/trends.py`) extended similarly.
-- 17 tests across 2 new files: `test_expectation_evaluation.py` (15 tests — extractors + evaluator covering match cases, case-insensitive labels, target-type mismatches, already-evaluated no-op, ownership, first-match-wins) + `test_multi_period_expectation_wiring.py` (2 tests — route emits `expectations_evaluated` when `engagement_id` is supplied; field is empty when absent).
-
-**Verification:** Sprint 728c-targeted tests + adjacent — 45 passing.
-
-**Pattern note:** Engines stay zero-storage. The route layer is the only place that knows about engagements + expectations. Adding wiring to a new tool = (a) accept `engagement_id` (already true for the engagement-aware tools); (b) extract measurements via the appropriate helper; (c) call `evaluate_expectations_against_measurements`; (d) embed result in the response. No engine changes required.
-
----
-
-### Sprint 729: ISA 450 SUM Schedule (parent — 729a/b/c)
-**Status:** COMPLETE 2026-04-26 — all three sub-sprints landed atomically per the CEO-approved plan `tasks/sprint-plan-728-729.md`.
-**Priority:** P3 (post-launch product gap; differentiator).
-**Source:** Agent sweep 2026-04-24, punch list 4.2 + Accounting Methodology Audit.
-
-Architecture decision: **snapshot model.** Because `AdjustingEntry` is in-memory (zero-storage dataclass per `backend/adjusting_entries.py`) and sampling output is ephemeral, the original "auto-aggregate from passed AJEs / sample projections" plan was infeasible without breaking zero-storage. CEO confirmed 2026-04-26: SUM is a CPA-captured workpaper of decisions, with 729c capture helpers added for ergonomics.
-
-#### Sprint 729a — Backend core
-**Status:** COMPLETE 2026-04-26.
-**Delivered:**
-- `backend/uncorrected_misstatements_model.py` — `UncorrectedMisstatement` entity (FK → engagements CASCADE, `MisstatementSourceType` / `MisstatementClassification` / `MisstatementDisposition` enums, signed F/S impacts, `accounts_affected_json`, soft-delete).
-- `backend/uncorrected_misstatements_manager.py` — CRUD manager + pure-function `compute_materiality_bucket(driver, overall, performance, trivial)` returning the four-bucket enum + `compute_sum_schedule(...)` aggregation (factual+judgmental subtotal vs projected subtotal per ISA 450 §A4 grouping; aggregate driver = `max(|net_income|, |net_assets|)`).
-- `backend/migrations/alembic/versions/a3b4c5d6e7f8_add_uncorrected_misstatements.py` — chains off `f2a8e7d6c5b4`. Upgrade + downgrade verified end-to-end.
-- `backend/schemas/uncorrected_misstatement_schemas.py` — Create/Update/Response/SumSchedule schemas with `AccountAffected` row.
-- `backend/routes/uncorrected_misstatements.py` — 6 endpoints (CRUD + `GET /engagements/{id}/sum-schedule` aggregation); registered.
-- `backend/sum_schedule_memo_generator.py` — ISA 450 workpaper PDF (cover, overview, classification-grouped tables, aggregate evaluation with bucket box colored by severity, AU-C/ISA/AS 2810 references, sign-off with DRAFT watermark for unreviewed items).
-- `backend/routes/engagements_exports.py` — added `POST /engagements/{id}/export/sum-schedule`.
-- `backend/engagement_manager.py` — completion gate now also requires (a) all SUM items have non-`NOT_YET_REVIEWED` disposition, (b) if aggregate is in `MATERIAL` bucket, at least one item must carry `cpa_notes` (override documentation per ISA 450 §11). Gate ordering preserved: follow-up → ISA 520 → ISA 450.
-- `docs/04-compliance/isa-450-coverage.md` — coverage doc with bucket-boundary table and architectural-decision rationale.
-- 6 test files, +69 tests covering schema, defaults, soft-delete, manager CRUD/validation, bucket boundaries (parametrized including signed/zero/equal-to), aggregation correctness, gate-helper functions, route happy-path + 404, memo render (empty + 3-classification + MATERIAL warning + cross-tenant), completion-gate matrix (no-items / pending / dispositioned / MATERIAL-no-override / MATERIAL-with-override / archived / 520-before-450 ordering), export route happy-path + 404.
-
-**Verification:** Sprint 729a + memo-boundary scanner + adjacent completion-gate tests — 110 passing.
-
-**Out of scope (carried to 729b/c):**
-- Frontend SUM page + capture form (729b).
-- Capture-helper buttons on AJE workflow + sampling tool (729c).
-
-#### Sprint 729b — Frontend
-**Status:** COMPLETE 2026-04-26.
-**Delivered:**
-- `frontend/src/types/uncorrected-misstatements.ts` — types + label maps + `BUCKET_TONE` mapping (sage / clay-soft / clay).
-- `frontend/src/hooks/useUncorrectedMisstatements.ts` — fetch SUM schedule + create/update/archive (mutations re-fetch the schedule so aggregate/bucket update live).
-- `frontend/src/components/engagement/SumSchedulePanel.tsx` — bucket box (color from `BUCKET_TONE`; MATERIAL warning copy when bucket is `material`), materiality cascade reference, per-row classification/source/description/F-S-impact display, disposition select, archive action, three-variant capture form with auto-classification helper (sample-projection → projected, AJE-passed → judgmental).
-- Workspace detail page now exposes a `sum` tab between `expectations` and `workpaper`; wires the hook + panel + PDF download.
-- `frontend/src/__tests__/SumSchedulePanel.test.tsx` — 8 component tests covering empty state, bucket-box label, MATERIAL warning, item rows, disposition mutation, archive, modal open, download disabled state.
-
-**Verification:** TypeScript typecheck clean, 8 component tests passing, `npm run build` succeeds.
-
-#### Sprint 729c — Capture helpers
-**Status:** COMPLETE 2026-04-26.
-**Delivered:**
-- Refactored `frontend/src/components/engagement/SumSchedulePanel.tsx` — extracted the inline `CreateMisstatementModal` to its own file `CreateMisstatementModal.tsx` with an `initialValues` prop so it can be reused with pre-filled data. SumSchedulePanel itself shrank to ~306 LoC (was 553).
-- `frontend/src/components/engagement/CaptureToSumButton.tsx` — new component that takes either `prefillFromAdjustingEntry={…}` or `prefillFromSampleProjection={…}` and opens the modal with computed initial values (largest AJE line becomes the canonical account; sample projection emits `source_type=sample_projection`, `classification=projected`, UEL → account amount). Default labels "Add to SUM" / "Capture as SUM projection" / "Capture to SUM".
-- `frontend/src/components/adjustments/AdjustmentSection.tsx` + `AdjustmentList.tsx` — pass-through `engagementId` prop. When supplied and an AJE is in `rejected` (passed) status, the row renders an "Add to SUM" button next to "Re-open" / "View Details" / "Delete".
-- 7 new component tests (`__tests__/CaptureToSumButton.test.tsx`) — default label, AJE label, projection label, modal pre-fill from AJE (source_reference contains reference + description), largest-line wins, sample-projection pre-fill (source_reference contains UEL).
-
-**Out of scope (deferred):**
-- Sampling-tool wiring at the route level: the sampling tool's frontend doesn't yet have a UI surface that consumes UEL > tolerable; the `CaptureToSumButton` is ready to drop in there once that surface lands. Pattern is the same as AJE wiring — pass `engagementId` + `prefillFromSampleProjection`.
-- Engagement-id propagation into the AJE workflow's parent page: callers of `<AdjustmentSection />` now have an opt-in `engagementId` prop. Wiring it from a specific audit page (`/tools/...` or workspace context) is a one-line change at each call site; deferred until product wires the AJE workflow into engagement-aware pages explicitly.
-
-**Verification:** TypeScript typecheck clean; 30 frontend tests passing across CaptureToSumButton + AdjustmentList + AdjustmentSection + SumSchedulePanel; `npm run build` succeeds.
-
----
-
-### Sprint 715: SendGrid 403 root-cause investigation (24h post-deploy watch)
-**Status:** COMPLETE 2026-04-26.
-**Priority:** P2 (observability follow-up).
-**Source:** Sprint 713 Bug C review — the fix caught the exception but did not investigate the root cause.
-
-**Investigation outcome:** Render logs over the 48h post-deploy window (2026-04-24 14:29 UTC → 2026-04-26 21:35 UTC) contain **zero matches** for `SendGrid`, `HTTPError`, `email_error`, `Verification email`, `Background … send failed`, and **zero requests** to `/auth/register`, `/auth/forgot-password`, `/contact`. Phase 3 functional validation hasn't exercised email paths yet, so the 403 trigger condition was never met. No root cause to chase.
-
-**Secondary finding (fixed in this sprint):** While tracing the warn-path, discovered `shared/background_email.py` was logging `"Background <label> send failed: unknown"` because it read a non-existent `result.error` attribute. `EmailResult` exposes `success`/`message`/`message_id` — the SendGrid status code lives in `result.message`. Sprint 713's existing test only asserted `len(warning_records) >= 1`, never inspected the message text, so the regression slipped through. **If a 403 had occurred in the past 48h, the log line would not have surfaced the status code** — the warn-path Sprint 713 added was effectively non-investigable.
-
-**Fix:**
-- `backend/shared/background_email.py`: read `result.message` (the canonical attribute), with `"unknown"` only as the empty-string fallback.
-- `backend/tests/test_sprint_713_sentry_sweep.py::test_background_email_logs_warning_not_error_on_failure`: strengthened to assert the warning is emitted by `shared.background_email`, contains the label, contains `"403"`, and does **not** fall back to `"unknown"`. Future regressions of this shape will fail the test.
-
-**Out of scope (deferred):**
-- Proactive SendGrid suppression-list sync (no infra justification until 403 volume is meaningful).
-- Email deliverability SLA tracking.
-- Cleanup_scheduler `InternalError: scheduled cleanup failed` on `reset_upload_quotas` and `dunning_grace_period`, observed every ~1h during this investigation. Unrelated system, separate signal — captured as a follow-up below.
-
-**Verification:** `pytest tests/test_sprint_713_sentry_sweep.py tests/test_email_verification.py tests/test_contact_api.py tests/test_no_helpers_reexports.py tests/test_refactor_2026_04_20.py tests/test_log_sanitizer.py` — 106 passed.
-
-**Review:** Sprint reframed from "find the 403 root cause" to "verify there *is* a 403 to investigate, then make the warn-path actually surface the status code when one happens". Net delta: 1 LoC fix in production code, +12 LoC of test assertions that prevent the silent-failure shape from re-emerging. Commit SHA recorded at commit time.
-
----
+> Sprints 715–729 archived to `tasks/archive/sprints-715-729-details.md`.
 
 ### Sprint 732: cleanup_scheduler recurring InternalError triage
-**Status:** PENDING — discovered during Sprint 715 log review, not yet investigated.
-**Priority:** P2 (silent recurring failure on production scheduled jobs; no user-facing impact today, but `dunning_grace_period` is the path that auto-cancels delinquent subscriptions, so a sustained outage means dunning escalation never advances).
+**Status:** STEP 1 COMPLETE 2026-04-27 — observability fix shipped; awaiting next ~1h of Render logs to identify the actual underlying exception class.
+**Priority:** P2 → P1 once Phase 4.1 lands (silent recurring failure on `dunning_grace_period` blocks delinquent-subscription auto-cancellation, which becomes customer-visible the moment real money flows).
 **Source:** Sprint 715 Render-log sweep 2026-04-26.
 
 **Observed signal (2026-04-25 to 2026-04-26 in Render logs, srv-d6ie9l56ubrc73c7eq2g):**
@@ -210,19 +79,26 @@ Architecture decision: **snapshot model.** Because `AdjustingEntry` is in-memory
 ERROR cleanup_scheduler  Cleanup job failed: {... 'job_name': 'reset_upload_quotas',  'error': 'InternalError: scheduled cleanup failed'}
 ERROR cleanup_scheduler  Cleanup job failed: {... 'job_name': 'dunning_grace_period', 'error': 'InternalError: scheduled cleanup failed'}
 ```
-Both jobs fire roughly every hour; each invocation completes in 30–80ms with `records_processed: 0` and the same `InternalError`. The error message itself (`"scheduled cleanup failed"`) is the wrapper's outer string — the actual underlying exception (likely a SQLAlchemy/DB error) is being swallowed before the structured-log emission.
+Both jobs fire roughly every hour; each invocation completes in 30–80ms with `records_processed: 0` and the same `InternalError`. **Diagnosis (2026-04-27):** the bare class name `InternalError` is ambiguous — Python's `builtins`, `sqlalchemy.exc`, and `psycopg2` all expose it. `cleanup_scheduler._run_cleanup_job` was using `sanitize_exception(exc, context="scheduled cleanup")` (correct PII-safe choice) but that strips both the message and the module path, leaving the log fingerprint useless for triage.
 
-**Scope:**
-- Locate the scheduler's exception handler (`backend/cleanup_scheduler.py` or wherever the wrapper lives) and confirm it catches `Exception` then re-raises a generic `InternalError`. Surface the original exception class + message into the structured log line (mirror the `result.message` lesson from Sprint 715 — never log a sentinel without the underlying detail).
-- Re-pull logs after the observability fix lands, identify the actual root cause for each job, fix.
-- Add coverage so this can't re-surface silently: a test that runs each cleanup job against a SQLite fixture and asserts no `InternalError` is raised.
-- Verify dunning escalation behavior end-to-end on a staging-equivalent fixture (subscription past grace period → cancellation triggered) once the underlying bug is known.
+**Step 1 — Observability fix (DONE):**
+- `backend/cleanup_scheduler.py::CleanupTelemetry` — added `error_type_fqn` field (e.g. `sqlalchemy.exc.InternalError`, `psycopg2.errors.SerializationFailure`). Module-path metadata only; no PII risk.
+- `_run_cleanup_job` populates `error_type_fqn` from `caught_exc` so the structured log carries the disambiguating fingerprint without leaking exception messages.
+- `tests/test_cleanup_scheduler.py::test_failure_log_includes_traceback_exc_info` extended to assert `error_type_fqn` appears with the FQN (`builtins.RuntimeError` for the test's deliberate `RuntimeError`). 28/28 cleanup-scheduler tests passing.
 
-**Effort estimate:** 1 sprint, possibly 2 if the underlying bug is non-trivial (e.g., a missing migration or a connection-pool exhaustion). Step 1 (observability) is mechanical; step 2 (fix) depends on what the unwrapped error reveals.
+**Step 2 — Root cause investigation (NEXT):**
+- After this commit lands on Render and the next 1–2 cleanup cycles fire, pull Render logs filtered to `error_type_fqn` and read the qualified class name.
+- Cross-check with Sentry (the wrapper already calls `sentry_sdk.capture_exception(exc)`; we should already have the full traceback there for the past 48h's worth of failures).
+- Most likely candidates given the 30–80ms latency + 0 records processed: SQLAlchemy session/connection-pool issue (e.g., `sqlalchemy.exc.InternalError` wrapping a `psycopg2.OperationalError`), or a Postgres SSL handshake failure (Sentry shows recurring `SSLEOFError` on `urllib3.connectionpool` in the same window — possibly the same root).
 
-**Why pending (not "now"):** This is a real production issue but it's been failing silently for at least 48h and has not produced user-visible symptoms. Sprint 728 + 729 are the user-directed work. Slot 732 in after the current directive completes.
+**Step 3 — Fix + coverage (AFTER step 2):**
+- Land the underlying fix per the unwrapped class.
+- Add an integration test that runs each cleanup job against a SQLite fixture and asserts no exception escapes the wrapper.
+- Verify dunning escalation end-to-end on a staging-equivalent fixture (subscription past grace period → cancellation triggered).
 
-**Pre-requisites:** None — diagnosable from logs once the wrapper unmasks the underlying exception.
+**Effort estimate:** 0.5 sprint for step 1 (DONE), 0.5–1 sprint for step 2+3 depending on what the unwrapped error reveals. Total ≤1.5 sprints.
+
+**Pre-requisites:** Step 1 deployed to Render — triggers automatically on PR merge to main.
 
 ---
 


### PR DESCRIPTION
## Summary

Step 1 of Sprint 732 — surface the qualified exception type (`error_type_fqn`) in `cleanup_scheduler` logs so the next 1–2 production cleanup cycles emit a fingerprint we can actually triage.

**Background.** Sprint 715's log review found `cleanup_scheduler` emitting `\"InternalError: scheduled cleanup failed\"` every ~1h on production with no underlying class info. Diagnosis: `sanitize_exception(exc, context=\"scheduled cleanup\")` correctly strips the message for PII safety but also strips the module path — and `InternalError` exists in `builtins`, `sqlalchemy.exc`, and `psycopg2`. The bare class name was useless for triage.

**This change is observability-only.** No behavior change to the cleanup jobs themselves. The fingerprint is module-path metadata, not exception-message content, so it carries no PII risk.

## What ships

- `CleanupTelemetry` — new `error_type_fqn` field (e.g. `sqlalchemy.exc.InternalError`)
- `_run_cleanup_job` — populates the field from `caught_exc`
- `test_failure_log_includes_traceback_exc_info` — extended to assert presence + correct FQN string
- 28/28 cleanup_scheduler tests passing
- `tasks/todo.md` — Sprint 732 status updated to STEP 1 COMPLETE; step 2/3 plan recorded
- `tasks/archive/sprints-715-729-details.md` — archives 9 completed sprints from Active Phase per the commit-msg hook gate

## Why this is launch-relevant

The `dunning_grace_period` cleanup job is what auto-cancels delinquent subscriptions. It's been silently failing on production for at least 48h. **The moment Phase 4.1 lands and real customers start failing payment, this becomes customer-visible** — delinquent subs won't auto-cancel, dunning escalation never advances. Step 1 here is a 1-day unblocker; step 2 (root cause + fix) lands once we have the qualified FQN from production logs.

## Test plan

- [x] Local pytest cleanup_scheduler suite: 28 passing
- [ ] Merge to main → Render auto-deploys
- [ ] Wait ~1–2 cleanup cycles (~1h post-deploy)
- [ ] Pull Render logs with `text: [\"error_type_fqn\"]` to identify the underlying class
- [ ] Cross-check Sentry — full tracebacks should be there for the past 48h via `sentry_sdk.capture_exception(exc)` (Sprint 711 Bug 2)
- [ ] Open Sprint 732 follow-up PR with the actual fix once we know what `InternalError` actually is

🤖 Generated with [Claude Code](https://claude.com/claude-code)