### PR TITLE
Sprints 733 + 735: webhook test gap fill + require_client_owner adoption

### DIFF
--- a/backend/routes/diagnostics.py
+++ b/backend/routes/diagnostics.py
@@ -22,6 +22,7 @@ from shared.filenames import (
     get_filename_display,
     hash_filename,
 )
+from shared.helpers import require_client_owner
 from shared.monetary import quantize_monetary
 from shared.rate_limits import RATE_LIMIT_WRITE, limiter
 
@@ -287,14 +288,12 @@ async def save_diagnostic_summary(
 
 @router.get("/diagnostics/summary/{client_id}/previous", response_model=Optional[DiagnosticSummaryResponse])
 async def get_previous_diagnostic_summary(
-    client_id: int, current_user: User = Depends(require_current_user), db: Session = Depends(get_db)
+    client_id: int,
+    current_user: User = Depends(require_current_user),
+    db: Session = Depends(get_db),
+    _client: Client = Depends(require_client_owner),
 ) -> DiagnosticSummaryResponse | None:
     """Get the most recent diagnostic summary for a client."""
-    client = db.query(Client).filter(Client.id == client_id, Client.user_id == current_user.id).first()
-
-    if not client:
-        raise HTTPException(status_code=404, detail="Client not found")
-
     summary = (
         db.query(DiagnosticSummary)
         .filter(
@@ -318,13 +317,9 @@ async def get_diagnostic_history(
     limit: int = Query(default=10, ge=1, le=50),
     current_user: User = Depends(require_current_user),
     db: Session = Depends(get_db),
+    client: Client = Depends(require_client_owner),
 ) -> dict[str, object]:
     """Get diagnostic summary history for a client."""
-    client = db.query(Client).filter(Client.id == client_id, Client.user_id == current_user.id).first()
-
-    if not client:
-        raise HTTPException(status_code=404, detail="Client not found")
-
     summaries = (
         db.query(DiagnosticSummary)
         .filter(

--- a/backend/routes/prior_period.py
+++ b/backend/routes/prior_period.py
@@ -20,6 +20,7 @@ from database import get_db
 from models import Client, DiagnosticSummary, PeriodType, User
 from prior_period_comparison import compare_periods
 from shared.diagnostic_response_schemas import PeriodComparisonResponse
+from shared.helpers import require_client_owner
 from shared.rate_limits import RATE_LIMIT_AUDIT, RATE_LIMIT_WRITE, limiter
 
 router = APIRouter(tags=["prior_period"])
@@ -125,14 +126,10 @@ async def save_prior_period(
     period_data: PeriodSaveRequest,
     current_user: User = Depends(require_current_user),
     db: Session = Depends(get_db),
+    _client: Client = Depends(require_client_owner),
 ) -> dict[str, object]:
     """Save current audit data as a prior period for future comparison."""
     log_secure_operation("save_period", f"User {current_user.id} saving period for client {client_id}")
-
-    client = db.query(Client).filter(Client.id == client_id, Client.user_id == current_user.id).first()
-
-    if not client:
-        raise HTTPException(status_code=404, detail="Client not found")
 
     db_summary = DiagnosticSummary(
         client_id=client_id,
@@ -193,14 +190,10 @@ async def list_prior_periods(
     limit: int = Query(default=20, ge=1, le=100),
     current_user: User = Depends(require_current_user),
     db: Session = Depends(get_db),
+    _client: Client = Depends(require_client_owner),
 ) -> list[PeriodListItemResponse]:
     """List saved prior periods for a client."""
     log_secure_operation("list_periods", f"User {current_user.id} listing periods for client {client_id}")
-
-    client = db.query(Client).filter(Client.id == client_id, Client.user_id == current_user.id).first()
-
-    if not client:
-        raise HTTPException(status_code=404, detail="Client not found")
 
     periods = (
         db.query(DiagnosticSummary)

--- a/backend/routes/trends.py
+++ b/backend/routes/trends.py
@@ -19,6 +19,7 @@ from ratio_engine import (
     TrendAnalyzer,
 )
 from security_utils import log_secure_operation
+from shared.helpers import require_client_owner
 
 router = APIRouter(tags=["trends"])
 
@@ -137,14 +138,10 @@ def get_client_trends(
     limit: int = Query(default=12, ge=2, le=36, description="Number of periods to analyze"),
     current_user: User = Depends(require_current_user),
     db: Session = Depends(get_db),
+    client: Client = Depends(require_client_owner),
 ) -> dict[str, Any]:
     """Get trend analysis for a client's historical diagnostic data."""
     log_secure_operation("trend_analysis_request", f"User {current_user.id} requesting trends for client {client_id}")
-
-    client = db.query(Client).filter(Client.id == client_id, Client.user_id == current_user.id).first()
-
-    if not client:
-        raise HTTPException(status_code=404, detail="Client not found")
 
     summaries = _get_client_summaries(db, client_id, current_user.id, period_type, limit)
 
@@ -174,6 +171,7 @@ def get_client_industry_ratios(
     engagement_id: Optional[int] = Query(default=None),
     current_user: User = Depends(require_current_user),
     db: Session = Depends(get_db),
+    client: Client = Depends(require_client_owner),
 ) -> dict[str, Any]:
     """Get industry-specific ratios for a client."""
     from industry_ratios import calculate_industry_ratios, get_available_industries
@@ -181,11 +179,6 @@ def get_client_industry_ratios(
     log_secure_operation(
         "industry_ratios_request", f"User {current_user.id} requesting industry ratios for client {client_id}"
     )
-
-    client = db.query(Client).filter(Client.id == client_id, Client.user_id == current_user.id).first()
-
-    if not client:
-        raise HTTPException(status_code=404, detail="Client not found")
 
     latest_summary = (
         db.query(DiagnosticSummary)
@@ -257,6 +250,7 @@ def get_client_rolling_analysis(
     period_type: Optional[str] = Query(default=None, description="Filter by period type: monthly, quarterly, annual"),
     current_user: User = Depends(require_current_user),
     db: Session = Depends(get_db),
+    client: Client = Depends(require_client_owner),
 ) -> dict[str, Any]:
     """Get rolling window analysis for a client's historical data."""
     log_secure_operation(
@@ -265,11 +259,6 @@ def get_client_rolling_analysis(
 
     if window is not None and window not in [3, 6, 12]:
         raise HTTPException(status_code=400, detail="Invalid window size. Must be 3, 6, or 12 months.")
-
-    client = db.query(Client).filter(Client.id == client_id, Client.user_id == current_user.id).first()
-
-    if not client:
-        raise HTTPException(status_code=404, detail="Client not found")
 
     summaries = _get_client_summaries(db, client_id, current_user.id, period_type, 36)
 

--- a/backend/shared/helpers.py
+++ b/backend/shared/helpers.py
@@ -133,8 +133,47 @@ def require_client(
     current_user: User = Depends(require_current_user),
     db: Session = Depends(get_db),
 ) -> Client:
-    """FastAPI dependency: resolve a ``Client`` by id or raise 404."""
+    """FastAPI dependency: resolve a ``Client`` by id or raise 404.
+
+    Org-scoped — grants access to the direct owner *and* to any active
+    member of the same organization. Use this for routes where the client
+    is shared across an org (metadata, settings).
+    """
     client = get_accessible_client(current_user, client_id, db)
+    if not client:
+        raise HTTPException(status_code=404, detail="Client not found")
+    return client
+
+
+def require_client_owner(
+    client_id: int = PathParam(..., description="The ID of the client"),
+    current_user: User = Depends(require_current_user),
+    db: Session = Depends(get_db),
+) -> Client:
+    """FastAPI dependency: resolve a ``Client`` by id with **direct-ownership
+    only** authorization (no organization-scoped sharing). Raises 404 if the
+    caller is not the direct owner, even if they're an active member of the
+    same organization as the owner.
+
+    Sprint 735: introduced for diagnostic / trends / prior-period routes that
+    historically used inline ``db.query(Client).filter(Client.id == ...,
+    Client.user_id == current_user.id).first()`` to enforce direct-only
+    access. Adopting the existing ``require_client`` helper there would have
+    silently broadened authorization to org members (since ``require_client``
+    calls ``get_accessible_client`` → ``is_authorized_for_client`` which
+    OR-checks org membership) — a real behavior change, not a syntax cleanup.
+
+    This helper preserves the existing direct-ownership semantics. If product
+    later decides to open diagnostic outputs to org teammates, migrate routes
+    from ``require_client_owner`` to ``require_client`` explicitly with
+    customer comms — don't merge the two helpers silently.
+
+    Why a fourth helper despite the "prefer moving code, avoid new abstractions"
+    rule (``tasks/todo.md`` 2026-04-20 deferred-items entry): the rule's escape
+    valve is "revisit only if a fourth helper joins them." This is that fourth
+    helper. The alternative was a hidden behavior change in 7 endpoints.
+    """
+    client = db.query(Client).filter(Client.id == client_id, Client.user_id == current_user.id).first()
     if not client:
         raise HTTPException(status_code=404, detail="Client not found")
     return client

--- a/backend/tests/test_billing_webhooks_routes.py
+++ b/backend/tests/test_billing_webhooks_routes.py
@@ -151,6 +151,103 @@ class TestWebhookErrorClassification:
         assert response.status_code == 500
 
     @pytest.mark.asyncio
+    async def test_missing_signature_header_returns_400(self, mock_stripe):
+        """POST without ``stripe-signature`` header returns 400 (bad request,
+        not retryable). Sprint 733: explicit unit coverage for the early-return
+        branch at ``billing.py:365``. Previously only exercised by integration-level
+        tests; this asserts ``construct_event`` is never even called when the
+        header is absent (signature is the gate, not an after-the-fact check).
+        """
+        from main import app
+
+        with (
+            patch("billing.stripe_client.is_stripe_enabled", return_value=True),
+            patch("billing.stripe_client.get_stripe", return_value=mock_stripe),
+            patch("config.STRIPE_WEBHOOK_SECRET", "FAKE_WEBHOOK_SECRET_FOR_TESTING"),
+        ):
+            async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+                response = await client.post(
+                    "/billing/webhook",
+                    content=b'{"type":"checkout.session.completed"}',
+                    headers={"content-type": "application/json"},
+                    # No stripe-signature header
+                )
+
+        assert response.status_code == 400
+        assert "Missing stripe-signature header" in response.json()["detail"]
+        # construct_event must NOT be called when sig header is absent —
+        # signature verification is the gate, not an after-the-fact check.
+        mock_stripe.Webhook.construct_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_event_returns_200_without_double_processing(self, mock_stripe, db_session):
+        """Duplicate webhook event ID returns 200 silently and does NOT invoke
+        ``process_webhook_event`` a second time.
+
+        Sprint 733: critical for Stripe retry semantics. The dedup INSERT is
+        wrapped in ``try: db.flush() except IntegrityError`` (``billing.py:402-408``);
+        if this regresses, duplicate Stripe deliveries get processed twice and
+        side effects (subscription updates, refunds, etc.) double-run. The
+        existing ``test_db_dedup_error_returns_500`` covers the *generic* DB
+        error path; this one covers the specifically-handled IntegrityError
+        path that should return success-without-action.
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        from database import get_db
+        from main import app
+
+        mock_stripe.Webhook.construct_event.return_value = _make_event(event_id="evt_dup_test_733")
+
+        with (
+            patch("billing.stripe_client.is_stripe_enabled", return_value=True),
+            patch("billing.stripe_client.get_stripe", return_value=mock_stripe),
+            patch("config.STRIPE_WEBHOOK_SECRET", "FAKE_WEBHOOK_SECRET_FOR_TESTING"),
+            patch("billing.webhook_handler.process_webhook_event", return_value=True) as mock_process,
+            patch.object(db_session, "flush", side_effect=IntegrityError("duplicate", {}, Exception("orig"))),
+        ):
+            app.dependency_overrides[get_db] = lambda: db_session
+            try:
+                async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+                    response = await client.post(
+                        "/billing/webhook",
+                        content=b'{"type":"checkout.session.completed"}',
+                        headers={
+                            "stripe-signature": "t=123,v1=sig",
+                            "content-type": "application/json",
+                        },
+                    )
+            finally:
+                app.dependency_overrides.pop(get_db, None)
+
+        assert response.status_code == 200
+        # Critical assertion: process_webhook_event must NOT be called when
+        # the dedup INSERT detects a duplicate. If this assertion regresses,
+        # Stripe retries cause double-processing of subscription/payment events.
+        mock_process.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stripe_disabled_returns_200_short_circuit(self):
+        """When ``is_stripe_enabled()`` returns False, the webhook short-circuits
+        to 200 without any verification or processing.
+
+        Sprint 733 (bonus): documents the production safe-mode where Stripe is
+        intentionally disabled (e.g., during the pre-cutover window). Returns
+        200 so Stripe doesn't mark the endpoint unreachable and back off.
+        """
+        from main import app
+
+        with patch("billing.stripe_client.is_stripe_enabled", return_value=False):
+            async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+                response = await client.post(
+                    "/billing/webhook",
+                    content=b'{"type":"anything"}',
+                    headers={"content-type": "application/json"},
+                )
+
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
     async def test_db_dedup_error_returns_500(self, mock_stripe, db_session):
         """DB error during dedup insert returns 500 (operational, retryable)."""
         from database import get_db

--- a/backend/tests/test_refactor_2026_04_20.py
+++ b/backend/tests/test_refactor_2026_04_20.py
@@ -134,6 +134,7 @@ class TestHelpersReExports:
             parse_json_list,
             parse_json_mapping,
             require_client,
+            require_client_owner,  # Sprint 735
             try_parse_risk,
             try_parse_risk_band,
         )
@@ -146,6 +147,7 @@ class TestHelpersReExports:
             is_authorized_for_client,
             get_accessible_client,
             require_client,
+            require_client_owner,
             try_parse_risk,
             try_parse_risk_band,
         ):

--- a/backend/tests/test_sprint_735_require_client_owner.py
+++ b/backend/tests/test_sprint_735_require_client_owner.py
@@ -1,0 +1,136 @@
+"""Sprint 735: ``require_client_owner`` direct-only authorization contract.
+
+Sprint 735 introduced ``require_client_owner`` alongside the existing
+``require_client``. The two helpers must have *different* authorization
+scope: ``require_client`` grants org-scoped access, ``require_client_owner``
+grants direct-ownership only.
+
+This test pins both contracts so a future "let's just merge them" cleanup
+attempt fails loudly. Path B in Sprint 735 was the conscious decision to
+keep diagnostic / trends / prior-period routes direct-only — merging the
+helpers later would silently broaden authorization on those routes.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from fastapi import HTTPException
+
+from models import Client
+from organization_model import OrganizationMember, OrgRole
+from shared.helpers import require_client, require_client_owner
+
+
+def _make_org(db, owner, name: str = "Sprint 735 Org"):
+    """Create an Organization with `owner` as OWNER member; mirrors
+    ``test_refactor_2026_04_20._make_org``."""
+    from organization_model import Organization
+
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower().strip()).strip("-")[:90]
+    org = Organization(name=name, slug=slug, owner_user_id=owner.id)
+    db.add(org)
+    db.flush()
+    membership = OrganizationMember(organization_id=org.id, user_id=owner.id, role=OrgRole.OWNER)
+    db.add(membership)
+    owner.organization_id = org.id
+    db.flush()
+    return org
+
+
+def _make_client(db, owner, name: str = "Sprint 735 Client"):
+    client = Client(name=name, user_id=owner.id)
+    db.add(client)
+    db.flush()
+    return client
+
+
+class TestRequireClientOwnerDirectOnly:
+    """Sprint 735's new helper must NOT grant org-scoped access — that's
+    what ``require_client`` is for. This is the one assertion that prevents
+    a future regression where the two helpers get accidentally unified."""
+
+    def test_direct_owner_gets_client(self, db_session, make_user):
+        """Owner of the client gets the client back."""
+        owner = make_user(email="owner_735_direct@example.com")
+        client = _make_client(db_session, owner)
+
+        result = require_client_owner(client_id=client.id, current_user=owner, db=db_session)
+
+        assert result.id == client.id
+        assert result.user_id == owner.id
+
+    def test_unrelated_user_raises_404(self, db_session, make_user):
+        """A user with no relationship to the owner gets 404."""
+        owner = make_user(email="owner_735_unrelated@example.com")
+        stranger = make_user(email="stranger_735@example.com")
+        client = _make_client(db_session, owner)
+
+        with pytest.raises(HTTPException) as exc_info:
+            require_client_owner(client_id=client.id, current_user=stranger, db=db_session)
+
+        assert exc_info.value.status_code == 404
+        assert "Client not found" in str(exc_info.value.detail)
+
+    def test_org_teammate_also_raises_404(self, db_session, make_user):
+        """**The key Sprint 735 contract:** an active org-member of the
+        client's owner does NOT get access via ``require_client_owner``,
+        even though they would via ``require_client``. This pins the
+        direct-only semantics so merging the helpers later requires
+        an explicit policy decision (and customer comms)."""
+        owner = make_user(email="owner_735_team@example.com")
+        org = _make_org(db_session, owner)
+        teammate = make_user(email="teammate_735@example.com")
+
+        # Add teammate to the same org (active membership)
+        membership = OrganizationMember(organization_id=org.id, user_id=teammate.id, role=OrgRole.MEMBER)
+        db_session.add(membership)
+        teammate.organization_id = org.id
+        db_session.flush()
+
+        client = _make_client(db_session, owner)
+
+        with pytest.raises(HTTPException) as exc_info:
+            require_client_owner(client_id=client.id, current_user=teammate, db=db_session)
+
+        assert exc_info.value.status_code == 404, (
+            "Sprint 735 contract violation: org teammate should NOT get access via "
+            "require_client_owner. Use require_client (org-scoped) for routes that "
+            "should grant teammate access. If this assertion is failing because "
+            "policy changed and teammates should now see diagnostic outputs, that "
+            "is a NEW sprint with explicit customer comms — not a refactor."
+        )
+
+
+class TestRequireClientOrgScoped:
+    """Companion contract: ``require_client`` MUST grant org-scoped access.
+    If this regresses to direct-only, clients.py and settings.py silently
+    lose org-teammate functionality."""
+
+    def test_org_teammate_gets_client_via_require_client(self, db_session, make_user):
+        """Active org-member of the client's owner gets the client back
+        via ``require_client``. This is the behavior that Sprint 735's
+        ``require_client_owner`` deliberately does NOT inherit."""
+        owner = make_user(email="owner_req_client@example.com")
+        org = _make_org(db_session, owner)
+        teammate = make_user(email="teammate_req_client@example.com")
+
+        membership = OrganizationMember(organization_id=org.id, user_id=teammate.id, role=OrgRole.MEMBER)
+        db_session.add(membership)
+        teammate.organization_id = org.id
+        db_session.flush()
+
+        client = _make_client(db_session, owner)
+
+        # Sanity: direct owner still gets the client
+        owner_result = require_client(client_id=client.id, current_user=owner, db=db_session)
+        assert owner_result.id == client.id
+
+        # Key assertion: teammate ALSO gets the client (org-scoped behavior)
+        teammate_result = require_client(client_id=client.id, current_user=teammate, db=db_session)
+        assert teammate_result.id == client.id, (
+            "require_client must be org-scoped — teammate should access "
+            "the owner's client. If this regresses, clients.py and settings.py "
+            "lose teammate visibility for client metadata."
+        )

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -148,18 +148,45 @@ Cover:
 
 ---
 
-### Sprint 735: `require_client` adoption in diagnostics + trends routes
-**Status:** PENDING — pre-4.1 sequence position 3 (after Sprint 733). Gated only on Sprint 732 Step 2 not stealing capacity. Originally gated post-cutover; CEO blocker audit 2026-04-27 reclassified the "muddier incident triage during cutover window" concern as soft (change-management hygiene, not a technical dependency) and accepted the tradeoff. Diagnostics + trends are read-only endpoints — no money flows through them, so a latent issue is recoverable.
+### Sprint 735: `require_client_owner` adoption in diagnostics + trends + prior_period routes
+**Status:** COMPLETE 2026-04-27. **Path B chosen:** added stricter `require_client_owner` dependency that enforces direct-ownership only (no org-scoped sharing) and adopted it across 7 endpoints. Path A would have silently broadened authorization to org members on diagnostic outputs — a real behavior change Codex's "syntax cleanup" framing assumed away. Path B preserves current semantics exactly and pins the contract with new tests so a future "let's just merge the helpers" attempt fails loudly.
 **Priority:** P3.
-**Source:** Refactor pass 2026-04-27.
+**Source:** Refactor pass 2026-04-27. Path B decision documented in conversation transcript and `shared/helpers.py::require_client_owner` docstring.
 
-Adopt the existing `require_client` dependency at call sites in `backend/routes/diagnostics.py` and `backend/routes/trends.py` (and any sibling routes with the same `Client.id == ... user_id == ...` boilerplate). Reduces duplicated query-then-404 patterns at call sites only.
+**Pre-flight call-site map (gap analysis, 2026-04-27):**
+8 candidate endpoints surfaced across 3 files via `Client.id == ... user_id == ...` grep. 7 are GET/POST path-parameter endpoints fitting `require_client_owner`'s `PathParam` shape. The 8th (`diagnostics.py:213::save_diagnostic_summary`) takes `client_id` from request body — out of scope until/unless the request signature is reshaped.
 
-**Constraint:** Use the existing helper in-place. Do **not** move `require_client` / `get_accessible_client` / `is_authorized_for_client` out of `backend/shared/helpers.py` — that move is explicitly rejected in Deferred Items (line 56), and remains rejected unless module scope grows beyond three helpers.
+**Critical decision point surfaced:** `require_client` calls `get_accessible_client` → `is_authorized_for_client` which OR-checks org membership. `clients.py` and `settings.py` already use `require_client` (org-scoped). The 7 candidate endpoints currently use direct-only inline queries. Adopting `require_client` uniformly = behavior change (org members gain access to teammate diagnostic outputs). CEO chose **Path B**: add `require_client_owner` that preserves direct-only behavior. Rationale: behavior change in production should not be an accidental side effect of a refactor sprint; if org-scope policy is later opened to diagnostic outputs, it should be a separate sprint with explicit customer comms.
 
-Add regression tests for tenant isolation + 404 vs 403 response shape parity.
+**What landed:**
 
-**Verification:** No change to any response code, header, or body shape; tenant-isolation tests still pass.
+1. **New helper** `backend/shared/helpers.py::require_client_owner` — direct-ownership-only FastAPI dependency. Docstring documents the Sprint 735 decision and the explicit boundary against `require_client`.
+
+2. **Adopted in 7 endpoints across 3 files:**
+   - `backend/routes/diagnostics.py` — `get_previous_diagnostic_summary` (GET), `get_diagnostic_history` (GET).
+   - `backend/routes/trends.py` — `get_client_trends` (GET), `get_client_industry_ratios` (GET), `get_client_rolling_analysis` (GET).
+   - `backend/routes/prior_period.py` — `save_prior_period` (POST), `list_prior_periods` (GET).
+   - Each endpoint replaced its inline `db.query(Client).filter(Client.id == ..., Client.user_id == current_user.id).first() / if not client: raise 404` block with a `Depends(require_client_owner)` parameter. Endpoints that consumed the `client` object downstream (e.g., for `client.name` in responses) keep the named binding; endpoints that only needed the existence check use `_client` to mark intent.
+
+3. **Contract test** `backend/tests/test_sprint_735_require_client_owner.py` (4 tests):
+   - Direct owner gets the client.
+   - Unrelated user → 404.
+   - **Org teammate of owner → 404** (the key Sprint 735 contract; pinned so a future helper merge fails loudly).
+   - Companion: `require_client` (the existing helper) DOES grant org teammate access, confirming the behavioral split is intentional.
+
+4. **Sprint 724 helper-count tracking** updated in `test_refactor_2026_04_20.py::test_json_form_and_client_access_symbols` to include `require_client_owner`.
+
+**Why a fourth helper despite the "prefer moving code, avoid new abstractions" rule:** The rule's escape valve (`tasks/todo.md` 2026-04-20 deferred-items entry) is "revisit only if a fourth helper joins them." This is that fourth helper. The alternative was a hidden behavior change in 7 endpoints. Documented in the helper's docstring so the next reviewer doesn't try to consolidate it back.
+
+**Verification:**
+- 386 existing tests passing across diagnostic / trend / prior_period / industry test selection (no regression).
+- 4/4 new contract tests passing.
+- No change to any response code, header, or body shape.
+- Authorization semantics preserved exactly: direct owner gets 200, all other users (including org teammates) get 404, identical to the inline-query behavior the endpoints had before.
+
+**Out of scope:**
+- `diagnostics.py:213::save_diagnostic_summary` (client_id from body) — out of scope; would require reshaping the request payload to put client_id in the path. File a separate sprint if appetite emerges.
+- Org-scope policy decision for diagnostic outputs — explicitly NOT decided in Sprint 735. If product wants teammates to see each other's diagnostic outputs, file a separate sprint with explicit framing + customer comms.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -104,21 +104,27 @@ Both jobs fire roughly every hour; each invocation completes in 30–80ms with `
 ---
 
 ### Sprint 733: Stripe webhook unit-coverage gap fill (pre-cutover)
-**Status:** PENDING — pre-4.1 sequence position 2 (after Sprint 737). Gated only on Sprint 732 Step 2 not stealing capacity (independent code paths).
-**Priority:** P2 → bumps to P1 the moment Phase 4.1 cutover schedule firms up. **Must land BEFORE Phase 4.1 (`sk_live_` keys)** — adds the safety net around the handler about to begin processing live revenue.
+**Status:** COMPLETE 2026-04-27. **Revised scope:** 2 real gaps + 1 bonus, not 4. The pre-flight gap analysis discovered `TestWebhookErrorClassification` in `test_billing_webhooks_routes.py` (Sprint 564) already covered 4 of the 5 boundaries Codex's directive listed — only "missing `stripe-signature` header → 400" and "duplicate event-id (IntegrityError) → 200 without double-processing" needed new coverage. Bonus: `is_stripe_enabled() == False` short-circuit. 8/8 webhook tests passing (5 existing + 3 new). No behavior change on `/billing/webhook`.
+**Priority:** P2 → bumps to P1 the moment Phase 4.1 cutover schedule firms up. **Landed BEFORE Phase 4.1 (`sk_live_` keys)** as planned — adds the safety net around the handler about to begin processing live revenue.
 **Source:** Refactor pass 2026-04-27 (Codex directive, scope-revised after Sprint 710/724 + `## Deferred Items` reconciliation).
 
-Add focused unit tests around `routes/billing.py::stripe_webhook` for the four boundaries currently exercised only at route level:
-- missing `Stripe-Signature` header → 400
-- invalid signature (forged HMAC) → 400
-- duplicate event-id claim path → 200, no double-processing
-- downstream operational failure (DB error mid-processing) → 500
+**What landed (2 new tests + 1 bonus):**
+- `test_missing_signature_header_returns_400` — POST without `stripe-signature` header → 400 + asserts `construct_event` is never called when the header is absent (signature is the gate, not an after-the-fact check).
+- `test_duplicate_event_returns_200_without_double_processing` — IntegrityError on dedup INSERT → 200 + asserts `process_webhook_event.call_count == 0`. **Critical for Stripe retry semantics** — if this regresses, duplicate deliveries cause subscription/payment events to double-run.
+- `test_stripe_disabled_returns_200_short_circuit` (bonus) — when `is_stripe_enabled()` returns False, webhook short-circuits to 200 without any verification or processing.
 
-Existing route-level tests (`test_billing_webhooks_routes.py`, `test_webhook_event_ordering.py`, `test_billing_routes.py`) remain untouched.
+**Already covered (no new tests needed):**
+- Invalid JSON payload → 400 (`test_invalid_json_payload_returns_400`)
+- ValueError from process_webhook_event → 400 (`test_handler_value_error_returns_400`)
+- KeyError from process_webhook_event → 400 (`test_handler_key_error_returns_400`)
+- Generic exception from process_webhook_event → 500 (`test_handler_operational_error_returns_500`)
+- DB error during dedup INSERT → 500 (`test_db_dedup_error_returns_500`)
+- Invalid signature (forged HMAC) → 400 (`test_billing_routes.py::test_webhook_invalid_signature`)
+- Valid signature happy path → 200 (`test_billing_routes.py::test_webhook_valid_signature`)
 
 **Out of scope (per Deferred Items policy, line 54):** No handler decomposition. The signature-verify / dedup-claim / error-mapping triad stays in-route until bundled with the deferred webhook-coverage sprint flagged in Sprint 676.
 
-**Verification:** All new tests green; existing 3 webhook test files unchanged; no behavioral change on `/billing/webhook`.
+**Verification:** 8/8 webhook tests passing in isolation. Existing 3 webhook test files structurally unchanged (only `test_billing_webhooks_routes.py` gained 3 new test methods inside the existing `TestWebhookErrorClassification` class). No behavioral change on `/billing/webhook`.
 
 ---
 


### PR DESCRIPTION
## Stacked on PR #117

This PR's base is the #117 branch (`sprint-732-2b-and-736-737-bundle`). When #117 merges to main, GitHub auto-updates this PR's base to main and the diff narrows to just the 2 commits below. **Do not merge this until #117 lands first.**

## Summary

Two follow-up sprints, scoped down from Codex's directive after pre-flight gap analysis surfaced what was actually needed.

### Sprint 733 — webhook test gap fill (`b5b42be4`)

**Original directive:** 4 new tests for stripe_webhook boundaries.
**Actual scope:** 2 real gaps + 1 cheap bonus. The existing `TestWebhookErrorClassification` class in `test_billing_webhooks_routes.py` (Sprint 564) already covered 4 of 5 boundaries. Only "missing stripe-signature header → 400" and "duplicate event-id → 200 without double-processing" needed new coverage.

- `test_missing_signature_header_returns_400` — asserts construct_event is never called when header is absent (signature is the gate, not after-the-fact)
- `test_duplicate_event_returns_200_without_double_processing` — IntegrityError path → 200 + asserts process_webhook_event.call_count == 0. **Critical for Stripe retry semantics** — if this regresses, duplicate deliveries cause subscription/payment events to double-run.
- `test_stripe_disabled_returns_200_short_circuit` (bonus) — documents the `is_stripe_enabled() == False` short-circuit

8/8 webhook tests passing. No behavior change on `/billing/webhook`.

### Sprint 735 — require_client_owner adoption (`42ad1e93`)

**Original directive framing:** "syntax cleanup" — adopt existing `require_client` in 7 endpoints.
**Actual finding:** would silently broaden authorization. `require_client` is org-scoped; the 7 endpoints currently use direct-only inline queries. Path A (adopt require_client) = behavior change; Path B (add stricter helper) preserves current semantics.

**Path B chosen:**
- New helper `shared/helpers.py::require_client_owner` — direct-only FastAPI dependency. Docstring documents the Sprint 735 decision and explicit boundary against `require_client`.
- Adopted in 7 endpoints across diagnostics.py / trends.py / prior_period.py.
- Contract test `test_sprint_735_require_client_owner.py` (4 tests) pins both contracts: `require_client_owner` direct-only (3 assertions including org-teammate → 404) + `require_client` org-scoped (1 assertion).

**Why a fourth helper despite "prefer moving code, avoid new abstractions":** the rule's escape valve is "revisit only if a fourth helper joins them." This is that fourth helper. Alternative was a hidden behavior change in 7 endpoints.

403 tests passing (386 existing + 4 new + 13 helper-existence checks). No regression. No response shape change.

## Behavior compatibility

- **No customer-facing change.** Authorization semantics on the 7 endpoints are preserved exactly: direct owner gets 200, all other users (including org teammates) get 404.
- **No webhook behavior change.** All 8 webhook tests passing including the existing 5; the 3 new tests are pure additive coverage.

## Test plan

- [x] `test_billing_webhooks_routes.py` 8/8 PASSED
- [x] `test_sprint_735_require_client_owner.py` 4/4 PASSED
- [x] Diagnostic/trend/prior_period/industry suite: 386 PASSED (no regression)
- [x] Combined: 403 PASSED
- [ ] CI green (full backend + frontend suite)
- [ ] Once #117 merges, this PR's base auto-updates to main; verify diff narrows to just these 2 commits

## Out of scope, filed for follow-up

- `diagnostics.py:213::save_diagnostic_summary` (client_id from body, not path) — out of scope for require_client_owner's PathParam shape. File a separate sprint if appetite emerges.
- Org-scope policy decision for diagnostic outputs — explicitly NOT decided in Sprint 735. If product wants teammates to see each other's diagnostic outputs, that's a NEW sprint with explicit customer comms, not a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)