### PR TITLE
Sprint 739: remove orphaned bulk_upload_cleanup job (post-Sprint-720 dead code)

### DIFF
--- a/backend/cleanup_scheduler.py
+++ b/backend/cleanup_scheduler.py
@@ -387,30 +387,6 @@ def _job_expired_export_shares() -> None:
     _run_cleanup_job("expired_export_shares", purge_expired_export_shares)
 
 
-def _job_bulk_upload_cleanup() -> None:
-    """Evict stale in-memory bulk upload jobs (2h TTL + hard cap).
-
-    AUDIT-06 FIX 3: DB-locked to prevent multi-worker duplication.
-    """
-    from database import SessionLocal
-
-    db = SessionLocal()
-    try:
-        with with_scheduler_lock("bulk_upload_cleanup", db) as acquired:
-            if not acquired:
-                return
-
-            from routes.bulk_upload import _evict_stale_jobs
-
-            _evict_stale_jobs()
-    except Exception as exc:
-        from shared.log_sanitizer import sanitize_exception
-
-        logger.error("Bulk upload cleanup failed: %s", sanitize_exception(exc, context="bulk upload cleanup"))
-    finally:
-        db.close()
-
-
 def _job_team_activity_cleanup() -> None:
     """Purge team activity logs older than 90 days."""
 
@@ -632,13 +608,6 @@ def init_scheduler() -> None:
         hours=24,
         id="team_activity_cleanup",
         jitter=120,
-    )
-    _scheduler.add_job(
-        _job_bulk_upload_cleanup,
-        "interval",
-        minutes=30,
-        id="bulk_upload_cleanup",
-        jitter=30,
     )
     _scheduler.add_job(
         _job_expired_upload_dedup,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -138,3 +138,24 @@ Write Alembic migrations for the documented drift in `PRE_EXISTING_DRIFT_TABLES`
 
 ---
 
+### Sprint 739: Remove orphaned `bulk_upload_cleanup` job (post-Sprint-720 dead code)
+**Status:** COMPLETE 2026-04-28. Deleted `_job_bulk_upload_cleanup` (~22 lines) + its scheduler registration (~7 lines) from `backend/cleanup_scheduler.py`. 29/29 cleanup_scheduler tests passing post-deletion. Production verification post-deploy: `Bulk upload cleanup failed: ImportError` log pattern should drop to zero firings.
+**Priority:** P3 (production noise; not customer-facing). Surfaced during Sprint 732 Step 2c log analysis 2026-04-28.
+**Source:** Sprint 720's `bulk_job_store` refactor removed `_evict_stale_jobs` from `routes/bulk_upload.py` (the new store handles eviction internally — `routes/bulk_upload.py:74` comment: *"bulk_job_store handles eviction itself (Redis TTL or in-memory LRU+age cap); no explicit _evict_stale_jobs call needed"*). The cleanup_scheduler call site at `cleanup_scheduler.py:403` was orphaned with `from routes.bulk_upload import _evict_stale_jobs`, raising `ImportError` on every scheduled run since Sprint 720's deploy. Render logs confirm firings going back at least 11:54 UTC 2026-04-28 today (and through Sprint 732 Step 2c's window).
+
+**What landed:**
+- Deleted `_job_bulk_upload_cleanup` function from `backend/cleanup_scheduler.py:390-411`.
+- Removed scheduler registration block at `cleanup_scheduler.py:636-642` (the `_scheduler.add_job(_job_bulk_upload_cleanup, ...)` entry).
+- Net: ~30 lines removed; no replacement needed (per Sprint 720's own design).
+
+**Why it took 8 sprints to surface:** the failure log message starts with "Bulk upload cleanup failed", not "Cleanup job failed" — Sprint 732's investigation queries filtered for the latter. Sprint 732 Step 2c's broader cleanup_scheduler-logger query caught it.
+
+**Out of scope:**
+- No regression test added — the absence of the schedule registration *is* the test. Adding `_scheduler.add_job(_job_bulk_upload_cleanup, ...)` back would fail because the function doesn't exist.
+
+**Verification:**
+- 29/29 `test_cleanup_scheduler.py` tests passing.
+- Production deploy after Sprint 739 lands: zero `Bulk upload cleanup failed` log entries on the next 30-min cycle window.
+
+---
+


### PR DESCRIPTION
## Summary

Surfaced during Sprint 732 Step 2c log analysis: a broader `cleanup_scheduler` Loki query (vs. the narrower "Cleanup job failed" pattern Sprint 732 was investigating) caught a separate, pre-existing failure pattern firing 4× per cycle every ~30 min since **Sprint 720's deploy**:

```
Bulk upload cleanup failed: ImportError: bulk upload cleanup failed
```

## Root cause

Sprint 720's `bulk_job_store` refactor removed `_evict_stale_jobs` from `routes/bulk_upload.py` because the new store handles eviction internally (Redis TTL + in-memory LRU+age cap). The comment at `routes/bulk_upload.py:74` documents the design:

> Sprint 720: bulk_job_store handles eviction itself (Redis TTL or in-memory LRU+age cap); no explicit _evict_stale_jobs call needed.

But `backend/cleanup_scheduler.py::_job_bulk_upload_cleanup` was orphaned — it still tried `from routes.bulk_upload import _evict_stale_jobs` on every scheduled invocation. Each of 4 gunicorn workers hit the same import failure independently every ~30 minutes for weeks.

## Fix

Delete the dead code per Sprint 720's already-documented design:

- Removed `_job_bulk_upload_cleanup` function (`cleanup_scheduler.py:390-411`, ~22 lines).
- Removed its `_scheduler.add_job(...)` registration (`cleanup_scheduler.py:636-642`, ~7 lines).
- Net ~30 lines deleted; no replacement needed.

## Why no regression test

The absence of the schedule registration *is* the test. The function no longer exists, so any future "re-add" attempt would fail at the AST level before the scheduler could pick it up.

## Test plan

- [x] `pytest backend/tests/test_cleanup_scheduler.py` — 29/29 passing
- [ ] CI green (full backend + frontend suite)
- [ ] Post-deploy Render log query: zero `Bulk upload cleanup failed` entries on the next 30-min scheduler cycle (previously: 4 per cycle)

## Why it took 8 sprints to surface

Sprint 732's investigation queries filtered for the original `Cleanup job failed` pattern (the `sqlalchemy.exc.InternalError` cleanup_scheduler bug). The Bulk upload cleanup error message starts with "Bulk upload cleanup failed" instead of "Cleanup job failed" — different log path, same logger, distinct text. Sprint 732 Step 2c's broader cleanup_scheduler-logger query caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)