### PR TITLE
Sprint 740: rollback before lock release in _run_cleanup_job (Sprint 732 step 3 fix)

### DIFF
--- a/backend/cleanup_scheduler.py
+++ b/backend/cleanup_scheduler.py
@@ -211,11 +211,29 @@ def _run_cleanup_job(
             if not acquired:
                 return  # Another worker holds the lock
 
-            result = cleanup_func(db)
-            if is_retention and isinstance(result, dict):
-                records_processed = sum(result.values())
-            else:
-                records_processed = int(str(result))
+            try:
+                result = cleanup_func(db)
+                if is_retention and isinstance(result, dict):
+                    records_processed = sum(result.values())
+                else:
+                    records_processed = int(str(result))
+            except Exception:
+                # Sprint 740: rollback BEFORE the with_scheduler_lock finally
+                # block executes its `DELETE FROM scheduler_locks`. If the
+                # cleanup_func body left the session in an aborted-transaction
+                # state (Postgres SQLSTATE 25P02, in_failed_sql_transaction),
+                # the lock-release DELETE on that same session fails too — and
+                # the 25P02 cascade propagates out, masking the original
+                # exception class in `caught_exc.orig` / `__cause__`.
+                #
+                # Pre-Sprint-740 this masked all real cleanup failures behind
+                # the generic `psycopg2.errors.InFailedSqlTransaction` cascade
+                # symptom, defeating Sprint 732's leaf-class observability.
+                # The rollback here resets the session so the lock release
+                # runs cleanly and the original exception's class surfaces in
+                # `error_orig_fqn` for triage.
+                db.rollback()
+                raise
     except Exception as exc:
         from shared.log_sanitizer import sanitize_exception
 

--- a/backend/tests/test_cleanup_scheduler.py
+++ b/backend/tests/test_cleanup_scheduler.py
@@ -240,7 +240,13 @@ class TestRunCleanupJob:
             _run_cleanup_job("failing_job", failing_func)
 
         # Both rollback and close must run, with rollback first.
-        mock_session.rollback.assert_called_once()
+        # Sprint 740: rollback is now called twice on the cleanup-failure path —
+        # once inside the with-block before the lock-release DELETE (Sprint 740,
+        # to break the Postgres SQLSTATE 25P02 cascade), and once again in the
+        # outer finally before close (Sprint 711, defensive cleanup hygiene).
+        # The Sprint 711 invariant tested here is "ANY rollback must precede
+        # close" — the FIRST rollback call (Sprint 740's) satisfies that.
+        assert mock_session.rollback.call_count >= 1, "rollback must run on failure"
         mock_session.close.assert_called_once()
         rollback_call_index = mock_session.method_calls.index(
             next(c for c in mock_session.method_calls if c[0] == "rollback")
@@ -265,6 +271,71 @@ class TestRunCleanupJob:
             _run_cleanup_job("failing_job", failing_func)
 
         mock_session.close.assert_called_once()
+
+    def test_session_rollback_runs_before_lock_release_on_cleanup_failure(self, caplog):
+        """Sprint 740: when ``cleanup_func`` raises, ``db.rollback()`` MUST run
+        BEFORE ``with_scheduler_lock``'s finally block executes
+        ``DELETE FROM scheduler_locks``. This ordering pins the Sprint 740 fix.
+
+        Pre-Sprint-740 behavior (the bug Sprint 732 step 2c surfaced):
+        a ``cleanup_func`` body that left the session in an aborted-transaction
+        state (Postgres SQLSTATE 25P02 — ``in_failed_sql_transaction``)
+        cascaded into the lock-release DELETE failing on the same aborted
+        session. The resulting ``psycopg2.errors.InFailedSqlTransaction``
+        propagated out as the visible exception, **masking the original
+        cleanup_func exception class** in ``caught_exc.orig`` and
+        ``error_orig_fqn``. Sprint 732 step 2b's leaf-class observability
+        was capturing the cascade symptom, not the actual root failure.
+
+        Sprint 740 fixes this by adding an inner try/except inside the
+        with-block in ``_run_cleanup_job``: any cleanup_func exception
+        triggers ``db.rollback()`` before the with_scheduler_lock finally
+        runs, so the lock-release DELETE executes on a clean session and
+        the original exception class surfaces in the log.
+
+        This test mocks the session and asserts the call ordering. A
+        regression that moves the rollback after the lock release (or
+        removes it entirely) fails here loudly.
+        """
+        from cleanup_scheduler import _run_cleanup_job
+
+        def failing_func(db):
+            raise RuntimeError("sprint-740-original-cleanup-failure")
+
+        mock_session = MagicMock()
+
+        with (
+            patch("database.SessionLocal", return_value=mock_session),
+            caplog.at_level(logging.ERROR, logger="cleanup_scheduler"),
+        ):
+            _run_cleanup_job("ordering_test_job", failing_func)
+
+        # Find the index of the FIRST rollback call — should be Sprint 740's
+        # rollback inside the with-block (Sprint 711's outer-finally rollback
+        # also fires later, but the FIRST one must precede the DELETE).
+        rollback_indices = [i for i, c in enumerate(mock_session.method_calls) if c[0] == "rollback"]
+        assert rollback_indices, "Sprint 740: rollback must be called when cleanup_func raises"
+        first_rollback_idx = rollback_indices[0]
+
+        # Find the index of the DELETE FROM scheduler_locks call (lock release
+        # in with_scheduler_lock's finally block).
+        delete_idx = None
+        for i, c in enumerate(mock_session.method_calls):
+            if c[0] == "execute" and c.args and "DELETE FROM scheduler_locks" in str(c.args[0]):
+                delete_idx = i
+                break
+        assert delete_idx is not None, "lock-release DELETE must still execute even on cleanup failure"
+
+        assert first_rollback_idx < delete_idx, (
+            f"Sprint 740 contract violation: rollback (idx={first_rollback_idx}) must run BEFORE "
+            f"the with_scheduler_lock finally's DELETE FROM scheduler_locks (idx={delete_idx}). "
+            "If this assertion fails, the Postgres SQLSTATE 25P02 cascade returns and the "
+            "original cleanup exception class gets masked behind InFailedSqlTransaction."
+        )
+
+        # The original RuntimeError class must surface in the log (post-fix the
+        # log line carries the actual root exception, not the cascade symptom).
+        assert "RuntimeError" in caplog.text
 
     def test_retention_dict_summing(self):
         """is_retention=True sums dict values for records_deleted."""

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -72,7 +72,7 @@
 > Sprints 733–737 archived to `tasks/archive/sprints-733-737-details.md`.
 
 ### Sprint 732: cleanup_scheduler recurring InternalError triage
-**Status:** **STEP 2 COMPLETE 2026-04-28 16:08 UTC — root cause identified, Step 3 fix pending.** Initial post-Sprint-737-deploy silence (13:00–16:08 UTC, ~3h) was deployment-churn artifact: each merged PR (#117 13:00, #120 13:47, #119 14:13, #121 15:08) reset the cleanup_scheduler's 60-min interval timer, and the first post-deploy cycle on Sprint 739's deploy at 15:08 UTC fired at 16:08 UTC and **hit the failure with the new `error_orig_fqn` field populated**. The verification-window approach paid off — silence was coincidental (deploy churn, not structural fix), pattern resumed once a deploy had a clean 60-min window. Sprint 737 was NOT the fix.
+**Status:** **STEPS 1-3 COMPLETE 2026-04-28 — Sprint 740 ships the structural fix; awaits next post-deploy cycle to surface the actual root psycopg2 class for Sprint 741.** Initial post-Sprint-737-deploy silence (13:00–16:08 UTC, ~3h) was deployment-churn artifact: each merged PR (#117 13:00, #120 13:47, #119 14:13, #121 15:08) reset the cleanup_scheduler's 60-min interval timer, and the first post-deploy cycle on Sprint 739's deploy at 15:08 UTC fired at 16:08 UTC and **hit the failure with the new `error_orig_fqn` field populated**. The verification-window approach paid off — silence was coincidental (deploy churn, not structural fix), pattern resumed once a deploy had a clean 60-min window. Sprint 737 was NOT the fix. Sprint 740 (immediately below) addresses the cascade-masking that hid the real root class; Sprint 741 will address whatever Sprint 740 unmasks.
 
 **Leaf class identified (16:08:55 UTC `reset_upload_quotas` + 16:09:28 UTC `dunning_grace_period`):**
 ```
@@ -171,6 +171,30 @@ Write Alembic migrations for the documented drift in `PRE_EXISTING_DRIFT_TABLES`
 **Verification:**
 - 29/29 `test_cleanup_scheduler.py` tests passing.
 - Production deploy after Sprint 739 lands: zero `Bulk upload cleanup failed` log entries on the next 30-min cycle window.
+
+---
+
+### Sprint 740: rollback before lock release in `_run_cleanup_job` (Sprint 732 Step 3 fix)
+**Status:** COMPLETE 2026-04-28. 3-line fix added to `_run_cleanup_job` + 1 new contract test pinning the rollback-ordering invariant. 30/30 cleanup_scheduler tests passing locally. Ships the structural fix Sprint 732 Step 3 was waiting on.
+**Priority:** P2 (cleanup-scheduler is failing every ~60 min in production with masked-symptom 25P02; Sprint 740 unmasks the real root cause for the next investigation sprint).
+**Source:** Sprint 732 Step 2c (2026-04-28 16:08 UTC) identified the leaf class as `psycopg2.errors.InFailedSqlTransaction` (SQLSTATE 25P02). Investigation revealed this was a cascade symptom — the cleanup_func body fails first (real root, masked), session enters aborted state, `with_scheduler_lock`'s finally executes `DELETE FROM scheduler_locks` on the same aborted session, that DELETE fails with 25P02, and the 25P02 propagates out as the visible exception.
+
+**The fix:** wrap `cleanup_func(db)` in a try/except inside the `with with_scheduler_lock(...)` block. On any exception, call `db.rollback()` BEFORE re-raising. The lock-release DELETE in `with_scheduler_lock`'s finally then runs on a clean session, the DELETE succeeds, and the original `cleanup_func` exception class propagates out unmasked.
+
+**Side benefit beyond stability:** Sprint 732 step 2b's leaf-class observability fields (`error_orig_fqn`, `error_cause_fqn`, `error_orig_pgcode`) now capture the ACTUAL root psycopg2 class instead of the cascade symptom. Sprint 740's first post-deploy cleanup cycle will reveal what's truly failing inside the cleanup_func body — the data Sprint 732 was originally chasing.
+
+**What landed:**
+- `backend/cleanup_scheduler.py::_run_cleanup_job` — inner try/except around `cleanup_func(db)` invocation; rollback-then-raise on exception. ~10 lines added (mostly comment explaining the cascade and why this ordering matters).
+- `backend/tests/test_cleanup_scheduler.py::test_session_rollback_runs_before_lock_release_on_cleanup_failure` — new contract test mocks the session and asserts the FIRST rollback call's index < the DELETE FROM scheduler_locks call's index. A regression that moves rollback after the lock release fails this test loudly.
+- Existing `test_session_rollback_before_close_on_failure` updated: it asserted `rollback.assert_called_once()`; Sprint 740 makes rollback called twice (Sprint 740's inner + Sprint 711's outer-finally). Test now asserts `call_count >= 1` — the original "rollback before close" semantic intent is preserved.
+
+**Verification:**
+- 30/30 cleanup_scheduler tests passing locally.
+- Post-Sprint-740 production deploy + 1h: pull `error_orig_fqn` from the next cleanup cycle's failure log. Expected: a non-cascade psycopg2 class (likely `psycopg2.errors.SerializationFailure`, `psycopg2.OperationalError` with pgcode `08006` matching Sentry's SSLEOFError signal, or something genuinely surprising). That class names the real root for **Sprint 741** — the actual structural fix to the cleanup_func body's failing statement.
+
+**Out of scope:**
+- The actual root-cause fix for whatever cleanup_func is doing wrong — that's Sprint 741, contingent on Sprint 740's first post-deploy log read.
+- Approach 2 from the close-out doc (separate session for lock vs cleanup) — not adopted; Approach 1 (inner rollback) is sufficient and 1/3 the diff.
 
 ---
 


### PR DESCRIPTION
## Summary

Sprint 732 step 2c identified the leaf class as `psycopg2.errors.InFailedSqlTransaction` (SQLSTATE 25P02). Investigation revealed this is a **cascade symptom**, not the actual root failure:

1. `cleanup_func(db)` raises some real exception (unknown — masked)
2. Session enters Postgres aborted-transaction state
3. `with_scheduler_lock`'s finally executes `DELETE FROM scheduler_locks` on that same aborted session
4. The DELETE fails with 25P02 (`in_failed_sql_transaction`)
5. The 25P02 propagates out as the visible exception
6. **The original `cleanup_func` exception class is masked** behind the cascade — invisible in `caught_exc.orig` and `error_orig_fqn`

## Fix

Wrap `cleanup_func(db)` in a try/except inside the `with with_scheduler_lock(...)` block. On any exception, call `db.rollback()` BEFORE re-raising. The lock-release DELETE in `with_scheduler_lock`'s finally then runs on a clean session, the DELETE succeeds, and the original `cleanup_func` exception propagates out unmasked.

```python
with with_scheduler_lock(job_name, db) as acquired:
    if not acquired:
        return

    try:
        result = cleanup_func(db)
        ...
    except Exception:
        db.rollback()    # ← Sprint 740: clean session before lock release
        raise
```

## Side benefit beyond stability

Sprint 732 step 2b's leaf-class observability fields (`error_orig_fqn`, `error_cause_fqn`, `error_orig_pgcode`) now capture the ACTUAL root psycopg2 class instead of the cascade symptom. **Sprint 740's first post-deploy cleanup cycle will reveal what's truly failing** inside the cleanup_func body — the data Sprint 732 was originally chasing.

## Implementation

- `backend/cleanup_scheduler.py::_run_cleanup_job` — inner try/except around cleanup_func invocation; rollback-then-raise on exception
- `backend/tests/test_cleanup_scheduler.py::test_session_rollback_runs_before_lock_release_on_cleanup_failure` — new contract test asserting the FIRST rollback call's `method_calls` index is BEFORE the DELETE FROM scheduler_locks call's index. A regression that moves rollback after lock release fails this test loudly.
- Existing `test_session_rollback_before_close_on_failure` updated: asserted `rollback.assert_called_once()` pre-Sprint-740; now asserts `call_count >= 1` (Sprint 740 makes rollback called twice — its own + Sprint 711's outer-finally rollback). Sprint 711's "rollback before close" semantic intent is preserved.

## Test plan
- [x] 30/30 cleanup_scheduler tests passing locally
- [ ] CI green (full backend + frontend suite)
- [ ] Post-deploy + 1h: pull `error_orig_fqn` from next cleanup cycle's failure log. Expected: a non-cascade psycopg2 class (`SerializationFailure`, `OperationalError` with pgcode `08006` matching Sentry's `SSLEOFError` signal, or something genuinely surprising). That class names the real root for **Sprint 741** — the actual structural fix to whatever's failing in the cleanup_func body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)