### PR TITLE
fix: nightly audit artifacts 2026-04-23 → 2026-04-28 batch + agent sweep reports

### DIFF
--- a/reports/agent-sweep-consolidated-2026-04-24.md
+++ b/reports/agent-sweep-consolidated-2026-04-24.md
@@ -1,0 +1,208 @@
+# Agent Sweep — Consolidated Punch List (2026-04-24)
+
+8 agents dispatched in parallel while CEO ran Phase 3. This is the synthesis.
+
+**Source reports** (all in `reports/`):
+- `audit-project-auditor-2026-04-24.md` — Project Auditor (workflow health: **4.9 / 5.0 🟢**)
+- `audit-security-2026-04-24.md` — Security review (0 Critical / 1 High / 3 Medium / 3 Low / 2 Info)
+- `audit-critic-2026-04-24.md` — BackendCritic (portfolio: **paying debt down**)
+- `audit-scout-2026-04-24.md` — MarketScout (launch-blocker findings)
+- `audit-guardian-2026-04-24.md` — QualityGuardian (failure-mode audit)
+- `audit-accounting-methodology-2026-04-24.md` — Accounting methodology gaps
+- `audit-hallucination-2026-04-24.md` — Copy/doc drift (4 Critical / 10 Medium / 5 Low)
+- `audit-deadcode-2026-04-24.md` — Dead-code sweep (essentially clean)
+
+**Cross-checks performed before publishing:**
+- Sprint 689a–g landed (commit `9cc3171a`, PR #100) → tool-count drift is real
+- `routes/bulk_upload.py:37` module-global → confirmed
+- `billing/webhook_handler.py:978` off-by-one → confirmed (judgment call, not bug)
+
+---
+
+## Tier 1 — Fix BEFORE Stripe live cutover (Phase 4.1)
+
+These are the items where independent agents converge or where the production blast radius is high enough to block the next gate.
+
+### 1.1  Tool-count drift on production marketing/legal surfaces — 🔴 customer-visible
+**Confirmed by Scout + Hallucination Audit + cross-check.** Sprint 689a–g landed but the marketing/legal/checklist flip is half-done.
+
+| File | Line | Wrong | Right |
+|---|---|---|---|
+| `frontend/src/components/marketing/ToolLedger.tsx` | 69 | "Eighteen Tools · One Platform" header | renders 12 cards underneath |
+| `frontend/src/content/tool-ledger.ts` | 155 | `CANONICAL_TOOL_COUNT = 12` runtime assert | should be 18 |
+| `frontend/src/app/(marketing)/pricing/page.tsx` | 381, 402, 482, 608 | "All 18 diagnostic tools" | catalog still 12 |
+| `frontend/src/app/(marketing)/terms/page.tsx` | 616, 621, 626 | "18 tools" — **legal surface** | catalog still 12 |
+| `frontend/src/app/tools/page.tsx` | 47-52 | Test counts: AP=13, Rev=16, AR=11, Pay=11, FA=9, Inv=9 | Actual: 14, 18, 12, 13, 11, 10 |
+| `frontend/src/components/marketing/BottomProof.tsx` | 35, 38, 69 | Three different tool numbers in one component | Pick one |
+| `frontend/src/app/(marketing)/demo/page.tsx` | — | Same 12/18 mismatch | Aligned with ToolLedger |
+| `frontend/src/components/marketing/ToolShowcase.tsx` | — | Same 12/18 mismatch | Aligned |
+| `tasks/ceo-actions.md` | 55 | "12 testing tools" Phase 3 checklist | 18 tools — missing 7 newly-promoted from CEO walkthrough |
+| `CLAUDE.md` | "Key Capabilities" | Test counts and tool count | Sync |
+| `memory/MEMORY.md` | Project Status | "Sprint 689 Path B locked … pre-requisite" | "Sprint 689a–g landed `9cc3171a`" |
+
+**Fix:** ~2-3h coordinated find-replace. Bump `CANONICAL_TOOL_COUNT`, refresh test counts, regenerate `tool-ledger.ts` data, sync protocol docs, update Phase 3 checklist with the 7 new tool names.
+**Why this can't wait:** Stripe live-mode customers will see contradictions on pricing/ToS pages.
+
+### 1.2  AS 1215 fabricated citation across 5 customer-facing files
+**Confirmed by Hallucination Audit + Accounting Methodology Audit.** Backend memos are clean, but the public-facing claim is wrong.
+
+PCAOB AS 1215 is *Audit Documentation*; the correct standard for JE Testing is **AS 2401** (Consideration of Fraud). Files:
+- `CLAUDE.md` — Key Capabilities (private; sets agent context)
+- `features/status.json`
+- `docs/07-user-facing/USER_GUIDE.md`
+- `frontend/src/content/standards-specimen.ts`
+- `frontend/src/app/(marketing)/trust/page.tsx` ← **highest risk; PCAOB-registered firms read this**
+
+**Fix:** Multi-file find/replace `AS 1215` → `AS 2401` (verify each occurrence in context — a few may legitimately reference workpaper-retention rules, in which case AS 1215 is correct there). ~30 min.
+
+### 1.3  CSRF user-binding silently disabled for browser cookie auth — 🔐 H-01
+**Security Review.** `backend/security_middleware.py:485-509` (`_extract_user_id_from_auth`) only reads `Authorization: Bearer`. Production browser path uses HttpOnly cookies → `expected_user_id=None` → CSRF binding short-circuits at line 427 → leaked CSRF token is replayable for any user for 30 min.
+
+**Fix:** Read `ACCESS_COOKIE_NAME` cookie when no Bearer header present. ~1h.
+**Why this can't wait:** Stripe live mode means real-money POSTs are about to fly through this code path.
+
+### 1.4  Bulk upload broken on multi-worker Render — 🚧 production bug
+**Guardian (cross-checked).** `_bulk_jobs` is a module-global `OrderedDict` at `backend/routes/bulk_upload.py:37`. POST hits Worker A; status poll hits Worker B → 404. `asyncio.create_task` is also fire-and-forget, lost on worker recycle.
+
+**Fix options (pick one):**
+- **(A)** Migrate job state to Postgres (job + per-file status rows).
+- **(B)** Document Enterprise tier as "single-worker only" + set `Render: numInstances=1, gunicorn workers=1` via env. Quick mitigation, defers proper fix.
+**Why this can't wait:** CEO is about to test bulk upload in Phase 3; this WILL fail. Either fix or skip the Phase 3 step until fix lands.
+
+### 1.5  Stripe webhook secret-mismatch is silent — operational hazard for Phase 4.1
+**Guardian.** If the test-mode webhook secret gets pasted into live env vars, every webhook returns 400 silently. Customers won't appear in admin dashboard, churn doesn't downgrade, dispute events miss SLA.
+
+**Fix:** Add to Phase 4.1 checklist:
+- Mandatory `stripe trigger checkout.session.completed --api-key <live>` test event before real-money smoke
+- Sentry alert on log message `Webhook signature verification failed`
+- 24h rolling 4xx-rate alert on `/billing/webhook` at >5%
+
+~30 min checklist edit + Sentry alert config.
+
+### 1.6  Off-by-one in stale-event guard — 🐞 ambiguous-time edge case
+**Guardian (cross-checked at `backend/billing/webhook_handler.py:978`).** `if event_time < sub_updated:` — equal-time events bypass the staleness guard. Probability is low but non-zero on second-precision Stripe timestamps.
+
+**Fix:** Change to `<=` and add fixture replay test for equal-time. ~10 min.
+
+---
+
+## Tier 2 — Fix BEFORE first paying customer hits 18 memos / engagement layer
+
+### 2.1  18-memo back-to-back OOM risk
+**Guardian.** ReportLab + openpyxl accumulate in RAM on Render Standard 2 GB. CEO running all 18 memos consecutively in Phase 3 will hit it.
+
+**Fix:** Add `gc.collect()` between memo generations + Render `maxRequestsPerWorker` recycling. ~1h.
+
+### 2.2  PR-T12 / PR-T13 missing from payroll memo `PAYROLL_TEST_DESCRIPTIONS`
+**Accounting Methodology Audit.** Payroll engine ships 13 tests; memo only documents T1–T11. Findings on T12 (Duplicate Names ghost-employee) and T13 (Gross-to-Net Reconciliation) appear in tool output without methodology workpaper entry.
+
+**Fix:** Two-line add to `payroll_testing_memo_generator.py` `PAYROLL_TEST_DESCRIPTIONS`. ~10 min.
+
+### 2.3  ISA 265 boundary language in two memos
+**Accounting Methodology Audit.**
+- `three_way_match_memo_generator.py` — "systemic review of procure-to-pay controls recommended" near deficiency-classification line.
+- `ar_aging_memo_generator.py` — "potential understatement of credit loss expense" is a misstatement conclusion.
+
+**Fix:** Rephrase to anomaly-indicator language. Existing `BANNED_PATTERNS` regex catches the hard cases; soften these. ~30 min.
+
+### 2.4  Per-IP failure tracker is in-memory only — M-03
+**Security Review.** `backend/security_middleware.py:619-674` `_ip_failure_tracker` is a process-local `dict`. Not cross-worker, resets on deploy. Attackers time credential-stuffing to deploy windows. Per-account DB lockout still holds; only the per-IP layer (Sprint 698) is degraded.
+
+**Fix:** Move to Redis using existing slowapi storage URI. ~1.5h.
+
+### 2.5  Share endpoint leaks existence of passcode-protected shares — M-02
+**Security Review.** `backend/routes/export_sharing.py:471-481` returns 403 with "requires a passcode" for protected shares vs 404 for unknown — token-existence enumeration.
+
+**Fix:** Collapse 403 path to 404. ~15 min.
+
+### 2.6  Export-share passcode lockout has no admin unlock
+**Guardian.** If CEO triggers per-IP throttle during Phase 3 export-sharing testing, no recovery path exists.
+
+**Fix:** Add a CEO-only `/admin/unlock-passcode-throttle` endpoint, OR grant CEO IP a bypass for the throttle. ~30 min.
+
+---
+
+## Tier 3 — Pre-Sprint-689-aware cleanup (architectural)
+
+### 3.1  AuditEngineBase only adopted by 3 of 12 testing engines — 🏗️ Critic Veto 8/10
+**BackendCritic.** `engine_framework.py` defines a 10-step pipeline ABC; only JE/AP/Payroll subclass it. The other 9 (Revenue 2,509 LoC, AR 2,179, FA 1,666, Inventory 1,534, 3-way match 1,476, accrual completeness, population profile, sampling, cash flow projector) re-implement the pipeline procedurally.
+
+**Note:** Critic flagged this as "before Sprint 689 lands." 689 already shipped, so this is now retrospective consolidation work.
+
+**Fix:** Convert one engine per sprint. Sequence: Revenue → AR → FA → Inventory → 3-way → remaining 4. ~2-3 sprints.
+
+### 3.2  `shared/helpers.py` re-export shim still owns the call graph — Critic 7/10
+**BackendCritic.** Module was decomposed 2026-04-20 but re-exports 35+ symbols (incl. private `_XLS_MAGIC`, `_parse_csv`, `_log_tool_activity`). 62 call sites use the shim vs 6 direct.
+
+**Fix:** Sweep call sites, update imports, delete shim. ~3h.
+
+### 3.3  `routes/export_diagnostics.py` (689 LoC) has 7 copy-pasted CSV endpoints — Critic 7/10
+**BackendCritic.** Sister `routes/export_testing.py` already collapsed the same pattern via `csv_export_handler()` (Sprints 218-219). Diagnostics didn't get the same treatment.
+
+**Fix:** Apply `csv_export_handler()` pattern. ~2h.
+
+### 3.4  Webhook handler at 57.4% coverage
+**Guardian.** Dispute (`charge.dispute.created`/`closed`), proration, tier upgrade/downgrade, and the off-by-one above are all in uncovered paths. Live mode WILL fire dispute events.
+
+**Fix:** Fixture-replay tests targeting 80% of `backend/billing/webhook_handler.py`. ~4h.
+
+### 3.5  `workbook_inspector.py` at 18.6% coverage — first-touch on every upload
+**Guardian.** Password-protected xlsx, malformed ods, XML bombs hit unexercised exception paths. CEO uploading real client TBs in Phase 3 will surface edge cases.
+
+**Fix:** Adversarial-fixture corpus + parametrized tests. ~3h.
+
+---
+
+## Tier 4 — Methodology gaps (post-launch product roadmap)
+
+### 4.1  No ISA 520 expectation-formation workflow
+**Accounting Methodology Audit.** Analytical tools (flux, ratio, multi-period) produce observed-vs-prior comparisons but no structured expectation with stated precision and corroboration basis. Required by ISA 520.5(a) / AS 2305.10 when analytics are a primary substantive procedure.
+
+**Why this matters post-launch:** No competing tool addresses this. Product-differentiation opportunity. Likely a Sprint 720+ feature.
+
+### 4.2  No Summary of Uncorrected Misstatements (SUM) schedule
+**Accounting Methodology Audit.** Required by ISA 450 / AU-C 450 to consolidate passed adjustments + sample-projected misstatements + aggregate vs materiality. Platform has adjusting entries (approval-gated) and sampling UEL output, but no consolidation surface.
+
+**Why this matters post-launch:** Every CPA completing an engagement will reach for this and find nothing. Engagement layer feature.
+
+---
+
+## Tier 5 — Operational / monitoring (Phase 5 polish)
+
+- **Redis (Upstash) blip → slowapi fail-open.** Add `/health` Redis ping + Sentry alert on RedisStorage exceptions.
+- **R2 regional outage → mass 410s look like permanent data loss.** Distinguish transient 5xx (→ 503) from permanent 404 (→ 410) in `export_share_storage.download()`. Add `/health/r2` sentinel GET.
+- **Sprint Shepherd YELLOW false-positive.** Today's risk signal was a hotfix description containing the literal substring "TODO." Fix the regex.
+- **Two security-relevant patches available.** fastapi 0.136.0 → 0.136.1 (patch), stripe 15.0.1 → 15.1.0 (minor). Roll into next dep-hygiene hotfix.
+- **Project Auditor's "consolidate verify-against-live lessons":** Three near-duplicate lessons in 24h. Roll up into one canonical "Trust the live system over the documented contract" lesson + 4-line sprint-close checklist.
+
+---
+
+## Tier 6 — Confirmed clean (no action needed)
+
+- Stripe webhook signature verification + atomic dedup ✓
+- Upload pipeline 10-step defense (archive-bomb scan, defusedxml on OFX, formula-injection sanitization) ✓
+- Argon2id passcode KDF (OWASP 2024) ✓
+- No hardcoded secrets, no `dangerouslySetInnerHTML`, no f-string SQL ✓
+- Refresh-token atomic CAS for race safety ✓
+- 0 TODO/FIXME/HACK markers in source ✓
+- 0 confirmed unused Python symbols, 0 orphan React components, 0 orphan migrations ✓
+- 205 type suppressions all in legitimate complexity zones ✓
+- Backend memo citations (PCAOB AS 2401/2501/2305/2310, ISA 240/315/320/450/505/520/530/540/570/580, ASC 606-10) all verified accurate ✓
+- 18 memo PDF endpoints, 9 CSV testing exports, 6 benchmark industries, JE 19 / AR 12 / FA 11 / Inv 10 counts all verified ✓
+- 20 sampled hotfix SHAs in `tasks/todo.md` all resolve in `git log` ✓
+
+---
+
+## Recommended sequencing
+
+| When | Items | Effort |
+|---|---|---|
+| **Today (during Phase 3)** | 1.1 tool-count drift, 1.2 AS 1215, 1.3 CSRF binding, 1.4 bulk-upload (defer or quick-fix), 1.5 webhook-secret checklist, 1.6 off-by-one | ~5h |
+| **Before Stripe live cutover** | 2.5 share-endpoint enumeration, 2.6 admin unlock, 2.4 Redis IP tracker | ~2h |
+| **First week post-launch** | 2.1 OOM mitigation, 2.2 PR-T12/T13 memo, 2.3 ISA 265 phrasing, Tier 5 operational polish | ~3h |
+| **Sprint 717+** | Tier 3 architectural cleanup (AuditEngineBase, helpers shim, export_diagnostics) | 2-3 sprints |
+| **Sprint 720+** | Tier 4 methodology gaps (ISA 520 expectations, SUM schedule) | feature-sized |
+
+---
+
+*Generated 2026-04-24 by IntegratorLead synthesis of 8-agent parallel sweep.*

--- a/reports/audit-accounting-methodology-2026-04-24.md
+++ b/reports/audit-accounting-methodology-2026-04-24.md
@@ -1,0 +1,239 @@
+# Audit Methodology Gap Analysis -- Paciolus v2.1.0
+**Date:** 2026-04-24  
+**Scope:** Platform-wide methodology coverage, citation accuracy, audit-boundary risk, missing tests, workflow fidelity, Phase 3 CPA readiness  
+**Analyst lens:** Trial-balance-first diagnostic intelligence platform -- NOT an audit engine
+
+---
+
+## 1. Executive Summary
+
+Paciolus demonstrates strong TB-driven diagnostic coverage across most IAASB/PCAOB risk domains with correctly bounded language guardrails (banned-patterns regex, ISA 265 structural prohibitions, non-committal scope/methodology templates). The principal methodology risk is not overreach into assurance territory -- that boundary is actively enforced at the code level -- but gaps in the mid-engagement workflow CPAs expect between risk assessment output and substantive conclusion. Three material gaps dominate: (1) no independent expectation-formation workflow for analytical procedures per ISA 520.5(a) / AS 2305.10; (2) no Summary of Uncorrected Misstatements schedule per ISA 450; (3) a three-way match engine structurally blind to service-invoice populations. Citation accuracy in the shipped backend is sound; however, the documented AS 1215 / AS 2401 confusion persists in external-facing docs and marketing copy, creating an immediate credibility risk with PCAOB-registered firms.
+
+---
+
+## 2. Methodology Coverage by Engagement Phase
+
+### 2.1 Planning and Scoping
+
+**Present:**
+- Preflight TB quality assessment (ISA 315 readiness gate)
+- Materiality cascade per ISA 320 / AU-C 320 with ISA 320.11 cited precisely in sampling_memo_generator.py line 709
+- Going concern indicator profile: 7 TB-derivable ISA 570 para 16 indicators with explicit disclaimer for 6 non-TB-derivable categories
+- Composite risk matrix: ISA 315 Appendix 1 4x4 RMM -- Sprint 680 corrected the prior max(IR,CR) approximation to the proper matrix lookup
+- Population profile: stratification, account distribution, Herfindahl concentration
+
+**Missing / Thin:**
+- No engagement-letter scope template or structured assertion-mapping worksheet. CPAs arrive with a TB and no standardized mechanism to document which assertions are in scope for which accounts before running tools.
+- Detection risk is explicitly disclaimed as outside scope in composite_risk_engine.py DISCLAIMER (correct), but leaves the audit-risk model (AR = IR x CR x DR) with no articulation path.
+
+### 2.2 Risk Assessment
+
+**Present:** Related party detection (ASC 850), anomaly detection (z-score, round amounts, sign anomalies, concentration), cutoff risk engine (3 deterministic tests, ISA 501 / ASC 855), accrual completeness engine (12 accrual types), going concern (7 ISA 570 para 16 indicators), lease classification flag (ASC 842 / IFRS 16), account risk heatmap, classification validator.
+
+**Missing:** No impairment-indicator surface for goodwill/intangibles (ASC 350 / IAS 36). No contingency/warranty adequacy ratio (ASC 450 / IAS 37). No subsequent-events scan (ASC 855 / ISA 560 evaluation window).
+
+### 2.3 Substantive Procedures -- Analytical
+
+**Critical Gap -- Expectation Formation:** ISA 520.5(a) and AS 2305.10 require the auditor to form an independent expectation before comparing to recorded amounts. The platform ratio and flux engines produce observed-vs-prior comparisons but do not provide a structured expectation-formation workflow. CPAs using substantive analytical procedures as a primary procedure must document: (1) the basis for the expectation, (2) the precision threshold, (3) the corroboration source. None of these slots exist in any current tool output. A Big-4 quality reviewer would note this immediately. All tools use a single global materiality threshold; ISA 520 requires precision tight enough to detect misstatements at the assertion level. No account-level precision cascade exists.
+
+### 2.4 Substantive Procedures -- Tests of Detail
+
+**Present (12 tools):** JE (19 tests), AP (14 tests), Payroll (13 tests), Revenue (18 tests incl. ASC 606/IFRS 15), AR Aging (12 tests), Fixed Assets (11 tests incl. depreciation recalc), Inventory (10 tests), Bank Rec, Three-Way Match, Multi-Period, Statistical Sampling (ISA 530 / AICPA Table A-1), Multi-Currency.
+
+**Missing Tests by Tool:**
+
+| Tool | Missing Test | Literature Basis |
+|------|-------------|------------------|
+| Three-Way Match | Service-invoice population bypass. Engine requires PO + Invoice + GRN. Service invoices have no GRN counterpart. No two-way match path exists -- systematic untested population in virtually all commercial clients. | ACFE 2024 p.112; COSO 2013 PC10.3 |
+| Inventory | No cash-to-cash cycle (DIO + DSO minus DPO) integration with AR/AP TB accounts. Working capital cycle efficiency indicator absent. | ISA 501.A7; IAS 2.32 |
+| Inventory | No interperiod obsolescence trend. Slow-moving flag is point-in-time only. | ISA 540.A63 |
+| Fixed Assets | No impairment trigger (large goodwill adjacent to declining revenue or negative EBIT). | ASC 350-20-35-3C Step 0; IAS 36.12 |
+| Payroll | PR-T12 and PR-T13 credited as shipped in CLAUDE.md but absent from PAYROLL_TEST_DESCRIPTIONS in payroll_testing_memo_generator.py (only T1-T11 documented). Engine findings undocumented in PDF memo. | Internal consistency gap |
+| Revenue | Missing channel/geography disaggregation completeness test. | ASC 606-10-50-5 |
+| JE | No cross-entity journal entry test. Intercompany elimination engine exists but not cross-linked to JE testing. | ISA 240.A32 |
+| AP | No vendor master file change log analysis (new vendors within 30 days of first payment). | ACFE 2024 p.89 |
+| Statistical Sampling | No non-statistical (judgmental) sample documentation path. | ISA 530.A8 |
+
+### 2.5 Evaluation and Conclusion
+
+**Missing:** No standalone SUM (Summary of Uncorrected Misstatements) schedule per ISA 450 / AU-C 450. No management representation letter checklist (ISA 580) derived from procedures performed.
+
+### 2.6 Reporting
+
+**Missing:** No structured mapping from tool outputs to financial statement line items and disclosure risks. No going concern conclusion worksheet per ISA 570.19-20.
+
+---
+
+## 3. Citation Accuracy Assessment
+
+### 3.1 Shipped Memo Generator Citations
+
+| Standard | Usage | Accuracy |
+|----------|-------|----------|
+| PCAOB AS 2401 | JE, AP, Payroll, Revenue memos | Correct |
+| PCAOB AS 2501 | AR Aging, Fixed Asset, Inventory memos | Correct |
+| PCAOB AS 2305 | Multi-Period, Expense Category memos | Correct |
+| PCAOB AS 2310 | Bank Rec memo | Correct |
+| ISA 315 | Composite risk, preflight | Correct; Appendix 1 4x4 matrix verified in composite_risk_engine.py |
+| ISA 320 | Materiality cascade | Correct; ISA 320.11 cited precisely in sampling_memo_generator.py line 709 |
+| ISA 530 | Statistical sampling | Correct; AICPA Table A-1 expansion factors verified in shared/aicpa_tables.py |
+| ISA 570 | Going concern engine | Correct; para 16 indicator mapping with documented non-TB-derivable exceptions |
+| ISA 450 | Sampling memo step 3 | Correct |
+| ISA 580 | Sampling memo step 4 | Correct |
+| ASC 606-10-25-23 | Revenue cutoff_risk detail procedures | Correct paragraph |
+| ASC 606-10-32-28 | Allocation inconsistency test | Correct |
+| IAS 16 / ASC 360 | Depreciation recalculation Sprint 682 | Correct |
+| ASC 326-20 | AR Aging YAML reference | Correct (CECL) |
+
+Statistical sampling confidence factor derivation uses -ln(p) for Poisson confidence. At 95%: -ln(0.05) = 2.996, displayed as 3.0000. Mathematically correct for monetary unit sampling. Stringer bound table matches published AICPA guidance. No fabricated values found.
+
+### 3.2 Known Citation Defect -- PCAOB AS 1215
+
+The shipped backend memo generators do NOT contain AS 1215. Searching backend/ for "1215" returns zero matches. The citation has been cleared from all engine and memo code.
+
+However, AS 1215 (Audit Documentation) is referenced as the governing standard for JE Testing in:
+- features/status.json (feature acceptance criteria: "Verify PCAOB AS 1215 citation")
+- docs/01-product/USER_PERSONAS.md
+- docs/07-user-facing/USER_GUIDE.md
+- frontend/src/content/standards-specimen.ts
+- frontend/src/app/(marketing)/trust/page.tsx
+
+The correct governing standard for JE fraud testing is PCAOB AS 2401 (Consideration of Fraud), correctly cited in je_testing_memo_generator.py. AS 1215 governs audit documentation form and content -- it is a workpaper standards reference, not a fraud detection procedure standard. A PCAOB-registered firm reviewing the Trust page will flag this immediately.
+
+**Citation Verdict: PASS on shipped backend. CONCERNING on external-facing documentation (AS 1215 in docs and frontend copy).**
+
+---
+
+## 4. Audit-Boundary Risk Assessment
+
+### 4.1 Active Guardrails (Functioning Correctly)
+
+1. shared/scope_methodology.py BANNED_PATTERNS regex: 12 patterns including "proves", "confirms", "constitutes fraud", "is a material misstatement", "guarantees", "certifies".
+2. anomaly_summary_generator.py GUARDRAIL 3: structural prohibition on ISA 265 sections. Practitioner assessment blocks blank; auditor owns all classification.
+3. composite_risk_engine.py DISCLAIMER: detection risk explicitly disclaimed; all risk classifications stated as auditor judgment.
+4. going_concern_engine.py DISCLAIMER: 6 non-TB-derivable ISA 570 para 16 categories named and disclaimed.
+5. test_accrual_completeness.py lines 529-541: mechanical assertion that "deficiency" and "material weakness" do not appear in narratives.
+
+### 4.2 Boundary Risks -- Moderate
+
+**Risk 1 -- Risk tier auto-assignment on memo output.** Every testing memo auto-assigns a risk tier (low / elevated / moderate / high) from flag density. Language is hedged but the tier label is visually prominent. A practitioner might treat it as an ISA 315 risk assessment conclusion. Recommendation: Append "(automated flag density indicator -- auditor judgment required per ISA 315)" to all risk tier labels.
+
+**Risk 2 -- Three-way match language.** three_way_match_memo_generator.py, match rate below 80%: "systemic review of procure-to-pay controls recommended." Edges toward ISA 265 / control deficiency territory. Recommendation: Rephrase to "engagement team should evaluate whether procure-to-pay procedures warrant expansion."
+
+**Risk 3 -- Allowance adequacy language.** ar_aging_memo_generator.py allowance_adequacy_ratio: "potential understatement of credit loss expense per ASC 326." The word "understatement" is a misstatement conclusion. Recommendation: Rephrase to "potential credit loss estimation anomaly requiring auditor evaluation per ASC 326."
+
+### 4.3 Confirmed Non-Boundary (Correctly Handled)
+
+Adjusting entries are approval-gated and not auto-classified as conclusions. Going concern produces a 7-indicator profile only; no "substantial doubt" conclusion output. Allowance adequacy memo states "anomaly indicator, not a sufficiency determination." ISA 265 is blocked at generator level with mechanically enforced test assertion.
+
+---
+
+## 5. Workflow Fidelity vs. Real Audit Practice
+
+### 5.1 What the Engagement Layer Gets Right
+
+Materiality cascade math is correct and ISA 320 paragraph references are accurate. Tool-run sequencing (preflight, TB analysis, tool testing, anomaly summary) maps to real audit workflow sequence. Workpaper index tracks tool execution with lead sheet cross-references. Follow-up item tracker is correctly bounded to narrative descriptions with no financial data persistence.
+
+### 5.2 Workflow Gaps
+
+**Gap 1 -- No assertion-level scoping worksheet.** Real engagements begin with an assertion matrix mapping accounts to assertions to procedures. The composite risk engine accepts assertion-level inputs but does not produce or enforce a coverage worksheet. A CPA cannot see "Completeness assertion for Revenue -- addressed by RT-04, RT-09, confirmation."
+
+**Gap 2 -- Tools operate in isolation.** Each tool runs against a standalone file upload. The account risk heatmap aggregates signals post-hoc by account name string matching, fragile when account names vary across ERP export files.
+
+**Gap 3 -- No engagement scope agreement.** No engagement scope template, no agreed-upon procedure list, no mechanism to distinguish audit from review or compilation.
+
+**Gap 4 -- No supervisor review path.** workpaper_signoff accepts prepared_by and reviewed_by as free-text strings. The user model could support a review-approval workflow (ISQC 1 / PCAOB AS 1220) but does not currently implement it.
+
+**Gap 5 -- Completion gate is tool-coverage-based, not assertion-coverage-based.** 100% convergence index is achievable by running all tools against trivially small populations without addressing all in-scope assertions.
+
+---
+
+## 6. Phase 3 CPA Expectations
+
+A CPA doing end-to-end platform testing in Phase 3 will expect:
+
+1. Engagement scoping before tools: engagement type (audit/review/AUP), materiality basis tied to entity characteristics per ISA 320.A3, assertion-level scoping. Engagement type and assertion scoping worksheet are absent.
+2. ISA 520-compliant expectation documentation for analytical procedures. Absent.
+3. A SUM schedule per ISA 450. Absent.
+4. A representation letter checklist derived from procedures performed (ISA 580). Absent.
+5. Service-invoice testing capability. Three-way match engine is goods-only.
+6. Opening balance reconciliation workpaper per ISA 510. Multi-period tool provides flux but not a formal reconciliation.
+7. Explicit disclosure at point of export that diagnostic memos are not ISA 230 / AS 1215 audit documentation. Boundary is in docs/tos-section-8-draft.md but not surfaced at the export interface.
+
+---
+
+## 7. Prioritized Feature Recommendations
+
+See below for all 9 features in order of priority score.
+
+**Feature 1 -- PCAOB AS 1215 Cleanup in External Docs**
+Impact: 5 | Complexity: 1 | Priority Score: 5.0
+Purpose: Remove AS 1215 as the governing JE Testing standard from features/status.json, docs/01-product/USER_PERSONAS.md, docs/07-user-facing/USER_GUIDE.md, frontend/src/content/standards-specimen.ts, frontend/src/app/(marketing)/trust/page.tsx. Replace with AS 2401 (Consideration of Fraud). Retain AS 1215 only where it correctly references workpaper documentation standards.
+Zero-Storage Compatibility: Confirmed.
+Customer Value: Prevents immediate credibility loss with PCAOB-registered firms at first Trust page inspection.
+
+**Feature 2 -- PR-T12 / PR-T13 Payroll Memo Documentation**
+Impact: 4 | Complexity: 1 | Priority Score: 4.0
+Purpose: Add PR-T12 and PR-T13 entries to PAYROLL_TEST_DESCRIPTIONS in backend/payroll_testing_memo_generator.py. PR-T12: Flags employees with duplicate name matches across payroll register, a ghost-employee indicator. PR-T13: Reconciles total gross pay to total net pay accounting for all statutory deductions; flags unresolved residuals as payroll processing anomalies.
+Zero-Storage Compatibility: Confirmed.
+Customer Value: Closes a documentation gap that fails any workpaper quality review. Two-line fix.
+
+**Feature 3 -- Boundary Language Remediation (3 instances)**
+Impact: 4 | Complexity: 1 | Priority Score: 4.0
+Purpose: Remove language patterns that edge toward audit conclusion territory. (1) backend/three_way_match_memo_generator.py line ~113: systemic review of procure-to-pay controls recommended --> engagement team should evaluate whether procure-to-pay procedures warrant expansion. (2) backend/ar_aging_memo_generator.py allowance_adequacy_ratio: potential understatement of credit loss expense per ASC 326 --> potential credit loss estimation anomaly requiring auditor evaluation per ASC 326. (3) All memo risk tier labels: append (automated flag density -- auditor judgment required per ISA 315).
+Zero-Storage Compatibility: Confirmed.
+
+**Feature 4 -- ISA 520 Expectation Formation Panel**
+Impact: 5 | Complexity: 3 | Priority Score: 1.67
+Purpose: Structured input/output for forming and documenting independent expectations per ISA 520.5(a) / AS 2305.10. Inputs: current-period TB plus optional prior-period TB plus optional industry benchmark from existing ratio engine. Outputs: expectation basis, precision threshold, expected range, actual-vs-expected variance, within-threshold indicator -- all in a PDF memo section.
+Zero-Storage Compatibility: Confirmed -- all inputs ephemeral.
+Customer Value: First tool producing ISA 520-compliant expectation documentation without an external spreadsheet.
+
+**Feature 5 -- Summary of Uncorrected Misstatements Schedule**
+Impact: 5 | Complexity: 3 | Priority Score: 1.67
+Purpose: Standalone ISA 450 / AU-C 450 SUM schedule for end-of-engagement accumulation. Accepts: passed adjustment amounts (form input), UEL projections from sampling tool (JSON passthrough), overall materiality from engagement record. Applies trivial threshold filter, aggregates by assertion and direction, compares net aggregate to overall materiality.
+Zero-Storage Compatibility: Confirmed -- SUM amounts entered per-session, not persisted.
+Customer Value: Closes the single most workflow-critical gap for CPA end-of-engagement use.
+
+**Feature 6 -- Three-Way Match: Service Invoice Path**
+Impact: 4 | Complexity: 3 | Priority Score: 1.33
+Purpose: PO plus Invoice (no GRN) two-way match path for service-category invoice populations. When invoice keywords match a configurable services list, route to two-way match instead of three-way. Report two_way_match_services flag type separately. Compute match rates separately for goods vs. services with distinct benchmarks.
+Zero-Storage Compatibility: Confirmed.
+Customer Value: Addresses systematic untested population in virtually all commercial audit clients.
+
+**Feature 7 -- Impairment Indicator Screen**
+Impact: 3 | Complexity: 2 | Priority Score: 1.5
+Purpose: TB-derivable impairment screening when goodwill or intangibles exceed 10% of total assets. Compute goodwill/revenue, goodwill/EBIT, sustained operating loss indicator. Narrative: potential Step 0 qualitative impairment indicator -- auditor should evaluate whether formal quantitative assessment is required per ASC 350-20-35-3C / IAS 36.12.
+Zero-Storage Compatibility: Confirmed.
+
+**Feature 8 -- ISA 530 Judgmental Sample Documentation**
+Impact: 3 | Complexity: 2 | Priority Score: 1.5
+Purpose: ISA 530.A8-compliant workpaper for judgmental item selections. Accepts selected-item list, selection rationale (high value / high risk / unusual characteristics), population total. Computes coverage %, item count, high/low amounts. Outputs judgmental sample memo PDF with selection basis, coverage, and exceptions.
+Zero-Storage Compatibility: Confirmed.
+
+**Feature 9 -- Assertion Coverage Worksheet**
+Impact: 4 | Complexity: 4 | Priority Score: 1.0
+Purpose: Allow CPAs to define which assertions are in scope for which accounts before executing tools. Display TB accounts; auditor checks applicable assertions (Existence, Completeness, Valuation, Rights, Presentation). Record tool-to-assertion mappings. Output: coverage gap list and alerts on unaddressed pairs in workpaper index.
+Zero-Storage Compatibility: Confirmed -- assertion selections passed per-session.
+
+---
+
+## 8. Priority Ranking by CPA-Retention Risk
+
+| Rank | Feature | Impact | Complexity | Priority Score | Retention Risk Driver |
+|------|---------|--------|------------|---------------|----------------------|
+| 1 | AS 1215 citation cleanup in external docs | 5 | 1 | 5.0 | Immediate credibility loss with PCAOB-registered firms on first Trust page inspection |
+| 2 | PR-T12/T13 payroll memo documentation | 4 | 1 | 4.0 | Engine findings undocumented in PDF -- fails workpaper quality review |
+| 2 | Boundary language patch (3 instances) | 4 | 1 | 4.0 | ISA 265 proximity risk on control and misstatement language |
+| 4 | ISA 520 expectation formation panel | 5 | 3 | 1.67 | First-session failure for CPA running substantive analytics as primary procedure |
+| 4 | SUM schedule aggregator | 5 | 3 | 1.67 | End-of-engagement workflow breakage -- no engagement can be formally concluded |
+
+---
+
+## 9. Constraints Compliance
+
+All recommendations are: executable from TB or tool-output data with no external system integration; deterministic and rules-based (no ML inference); zero-storage compatible (all financial data ephemeral per session); bounded as diagnostic aids that do not infer auditor judgment or produce audit conclusions.
+
+---
+
+*This document is a methodology gap analysis for an internal diagnostic intelligence platform. It does not constitute an audit opinion, engagement quality review conclusion, or regulatory compliance assessment.*

--- a/reports/audit-critic-2026-04-24.md
+++ b/reports/audit-critic-2026-04-24.md
@@ -1,0 +1,140 @@
+# BackendCritic — Complexity Debt Audit
+**Date:** 2026-04-24
+**Branch:** `sprint-716-complete-status`
+**Scope:** Backend routes/shared/engines, frontend components/hooks, Alembic migrations, overnight agents
+**Persona:** Technical Skeptic; veto threshold = Complexity Score >7
+
+---
+
+## Methodology
+
+I ranked candidates by `wc -l`, then sampled the top 25 backend routes, top 25 shared modules, all 19 testing engines (`*_engine.py`), the largest frontend pages/contexts, all 41 Alembic migrations, and the 6 overnight agents. I steelmanned each finding (acknowledging the design pressure that produced it) before scoring it. Items below score 5 were dropped from the report — only debt that genuinely blocks future sprint velocity made the cut.
+
+A general note before the list: **most of the backend is in surprisingly good shape.** `engine_framework.py` (`AuditEngineBase`) is a clean ABC, `routes/export_testing.py` already collapsed 7 near-identical CSV endpoints onto a `csv_export_handler()`, and the routes package has been split sensibly (~21 routers with cohesive boundaries). The debt below is concentrated in three places: an unfinished engine refactor, a half-applied CSV-export refactor, and a `shared.helpers` shim that has outlived its usefulness.
+
+---
+
+## Findings (ranked by Complexity Score)
+
+### 1. Inconsistent engine pattern — `AuditEngineBase` adopted by only 3 of 12 testing engines
+- **Complexity Score:** 8 / 10 — **VETO** further engine work until reconciled
+- **Identified Debt:**
+  - `backend/engine_framework.py` defines a clean abstract `AuditEngineBase` with a 10-step pipeline (detect → override → parse → quality → enrich → tests → score → build → cleanup).
+  - **Only `je_testing_engine.py`, `ap_testing_engine.py`, `payroll_testing_engine.py` import and subclass it** (3 of 12 engines).
+  - The other 9 — `revenue_testing_engine.py` (2,509 LoC), `ar_aging_engine.py` (2,179), `fixed_asset_testing_engine.py` (1,666), `inventory_testing_engine.py` (1,534), `three_way_match_engine.py` (1,476), `accrual_completeness_engine.py`, `population_profile_engine.py`, `sampling_engine.py`, `cash_flow_projector_engine.py` — each ship a **module-level top-level function** (`run_revenue_testing()`, `run_ar_aging()`, `run_inventory_testing()`, etc.) that re-implements the same pipeline as procedural code.
+  - Result: when Sprint 689 expands from 12 → 18 tools, every new engine has two valid templates to copy from. `ratio_engine.py` is 2,591 lines and is itself an outlier (no class structure at all). The "shared base class" is shared only with the three tools that existed when it was written (Sprint 519).
+- **Steelman:** Refactoring 9 engines mid-flight is risky on a production-live platform; the procedural form is genuinely simpler when you don't need per-engine state. The base class also forces a tuple-return hack (`extract_test_results`) for JE's Benford output, which is a smell.
+- **Alternative Proposal:**
+  1. **Demote `AuditEngineBase` to a thin functional pipeline.** Replace the ABC with a single `def run_audit_pipeline(detect_fn, parse_fn, quality_fn, tests_fn, score_fn, build_fn, *, rows, columns, mapping)` orchestrator. No subclassing — engines pass functions. This matches the procedural style the other 9 already use.
+  2. Migrate the 3 OO engines to the functional form (small change — strip `class` wrapper, lift methods to module-level).
+  3. Mandate the functional pipeline for all new tools in Sprint 689a–g via a `scripts/check_engine_pattern.py` lint that fails CI if a `*_engine.py` file lacks a `run_*()` entry point matching the signature.
+  4. Document the pattern in `backend/engine_framework.py` (3 paragraphs) so the next engine author has a single template.
+
+### 2. `shared.helpers.py` is a re-export shim that has earned its own removal
+- **Complexity Score:** 7 / 10
+- **Identified Debt:**
+  - `backend/shared/helpers.py` (189 LoC, but ~50 lines of import re-exports). The module's own docstring says it "used to be a ~1,100-line grab bag" and was decomposed into 4 cohesive modules during the 2026-04-20 refactor pass.
+  - The file then re-exports **35+ symbols** from `shared.upload_pipeline`, `shared.filenames`, `shared.background_email`, and `shared.tool_run_recorder` for backward compat — **including private symbols** like `_XLS_MAGIC`, `_parse_csv`, `_validate_xlsx_archive`, `_log_tool_activity`. Re-exporting a `_private` symbol is a contradiction in terms.
+  - Counts: 62 call sites still go through the shim (`from shared.helpers import …`); only 6 use the real targets directly. The shim is winning.
+  - Risk: every new sprint adds another `from shared.helpers import X` import because the docstring says "new code should import from the target module directly" but no enforcement exists. The shim is becoming permanent.
+- **Steelman:** A shim is exactly the right pattern *during* a refactor — it keeps the diff small and lets you migrate at leisure. The 2026-04-20 refactor was correct.
+- **Alternative Proposal:**
+  1. **One-shot codemod**: a 50-line script replaces every `from shared.helpers import X` with the canonical target import (`shared.upload_pipeline`, `shared.filenames`, etc.). This is mechanical — the shim already has the mapping.
+  2. Delete the re-export block from `shared/helpers.py`. Keep only the 4 helpers that legitimately live there: `try_parse_risk`, `try_parse_risk_band`, `parse_json_list`, `parse_json_mapping`, and the 3 client-access functions (`is_authorized_for_client`, `get_accessible_client`, `require_client`). File shrinks from 189 → ~80 LoC and stops being a confusing "where does X live?" question for new contributors.
+  3. Add a CI check in `scripts/` that fails on `from shared.helpers import _` (any leading-underscore re-export is forbidden).
+
+### 3. `routes/export_diagnostics.py` (689 LoC) — 7 copy-pasted CSV-writer endpoints
+- **Complexity Score:** 7 / 10
+- **Identified Debt:**
+  - `routes/export_diagnostics.py` has 9 endpoints; 7 of them are the same shape: open `StringIO`, instantiate `csv.writer`, write a header row, iterate input items, write `[]`, write SUMMARY rows, encode `utf-8-sig`, call `streaming_csv_response`. Lines 126–290 (TB + Anomalies), 433–470 (preflight), 473–544 (population profile), 547–625 (expense category), 628–689 (accrual completeness).
+  - The sister file `routes/export_testing.py` **already solved this** — Sprints 218-219 introduced `csv_export_handler(test_results, schema, composite_score, …)` plus a per-tool `*_COLUMNS` schema, collapsing 7 near-identical endpoints into one-liners. `export_diagnostics.py` did not get the same treatment.
+  - Each of those 7 functions has its own `try/except (ValueError, KeyError, TypeError, UnicodeEncodeError)` block, its own `log_secure_operation` call pair, its own `safe_download_filename(…)` invocation. Every bug fix or column addition has to be made 7 times.
+- **Steelman:** The diagnostic CSV layouts are heterogeneous (some have summary headers, some have multi-section reports with blank-row separators, some embed prior-period comparisons) — a one-size-fits-all schema like `*_COLUMNS` won't fit cleanly. Resisting premature abstraction is correct.
+- **Alternative Proposal:**
+  1. Extract a **`csv_section_writer(sections: list[CsvSection])`** helper where `CsvSection = (header: str, columns: list[str], rows: Iterable[list])`. The 7 endpoints become 5–10 lines each declaring their sections; the helper handles `StringIO`/`csv.writer`/`utf-8-sig`/`StreamingResponse`/error mapping uniformly.
+  2. Don't try to share the schema with `export_testing.py` — that ABC-style mistake from item 1 is what we're avoiding. Two helpers (one schema-driven for testing, one section-driven for diagnostics) is fine.
+  3. Stop new diagnostic CSV endpoints (Sprint 689 will add several for the 6 promoted tools) from being copy-pasted by adding a `pre-commit` lint that flags `csv.writer(output)` outside the helpers.
+
+### 4. Two parallel `FOLLOW_UP_PROCEDURES` dicts in one module
+- **Complexity Score:** 6 / 10
+- **Identified Debt:**
+  - `backend/shared/follow_up_procedures.py` (793 LoC) contains both `FOLLOW_UP_PROCEDURES: dict[str, str]` (line 12) and `FOLLOW_UP_PROCEDURES_ALT: dict[str, list[str]]` (line 545) plus `FINDING_BENCHMARKS` at line 536.
+  - `get_follow_up_procedure(test_key, rotation_index)` at line 756 picks between them via the `rotation_index` argument — but the call sites in memo generators almost all pass `rotation_index=0`, so `_ALT` is mostly unused dead weight.
+  - This is a "rotate procedures so memos don't read identically" feature. The need is real (auditor-facing copy variety) but the implementation duplicates **600+ lines of prose** that must stay aligned with the canonical wording or memos will contradict themselves.
+- **Steelman:** A truly random LLM-generated paraphrase would risk hallucinating procedures (and we explicitly don't trust LLMs in audit copy). Hand-curated alternatives are safer.
+- **Alternative Proposal:**
+  1. Drop `FOLLOW_UP_PROCEDURES_ALT` entirely until a memo template ships that actually rotates between alternates. No call site today needs the variety.
+  2. Move `FINDING_BENCHMARKS` (only one entry as of this audit) to whichever memo generator uses it, or delete if unused.
+  3. File shrinks from 793 → ~250 LoC. Keep the rotation hook signature in `get_follow_up_procedure()` so re-introducing `_ALT` later is a one-line additive change.
+
+### 5. Two `TOOL_LABELS` dicts of different sizes in different modules
+- **Complexity Score:** 6 / 10
+- **Identified Debt:**
+  - `routes/activity.py:403` — `TOOL_LABELS: dict[str, str]` with 13 entries keyed by string (`"trial_balance"`, etc.).
+  - `workpaper_index_generator.py:TOOL_LABELS` — different shape, keyed by the `ToolName` enum (referenced at `anomaly_summary_generator.py:58, 342, 367, 404, 480, 529, 635` and `tests/test_ar_aging.py:1271`).
+  - The two diverge: `routes/activity.py` is missing `multi_currency`, `composite_risk`, all 6 hidden tools that Sprint 689 is about to promote. When Sprint 689g flips marketing copy "12 → 18 tools", **two source files must be edited in lockstep** — the current activity-feed dropdown (`/activity/tool-feed`) won't show labels for the 6 new tools.
+- **Steelman:** Different shapes serve different needs (dropdown labels vs. PDF cell paragraphs).
+- **Alternative Proposal:**
+  1. **One canonical source of truth** in `backend/shared/tool_registry.py`: a `TOOLS: list[ToolMeta]` registry with `(name: ToolName, label: str, route_segment: str, tier_required: TierLevel)`.
+  2. Both call sites consume `{t.name.value: t.label for t in TOOLS}` or `{t.name: t.label for t in TOOLS}` as needed — no duplicated literals.
+  3. Eliminates the "we forgot to update both maps" risk for Sprint 689g.
+
+### 6. Stale "12-tool" string in production app metadata
+- **Complexity Score:** 4 / 10 (cosmetic — flagging because it is the OpenAPI title)
+- **Identified Debt:**
+  - `backend/main.py:243` — `description="12-Tool Audit Intelligence Suite for Financial Professionals"`.
+  - This is the FastAPI app description served at `/openapi.json` (production). Will misrepresent the platform the moment Sprint 689a lands.
+- **Alternative Proposal:** Source it from `version.py` or read tool count from the `TOOLS` registry above. One-line fix; mention it during 689g.
+
+### 7. Marketing pages are 1,000+ LoC single-component files
+- **Complexity Score:** 6 / 10
+- **Identified Debt:**
+  - `frontend/src/app/(marketing)/trust/page.tsx` — 1,314 LoC, 7 internal components.
+  - `frontend/src/app/(marketing)/privacy/page.tsx` — 1,028 LoC, **1 component** (everything is inline JSX).
+  - `frontend/src/app/(marketing)/terms/page.tsx` — 1,021 LoC.
+  - `frontend/src/app/(marketing)/pricing/page.tsx` — 935 LoC.
+  - These pages mix data definitions (the `ArchitectureNode[]`, `SecurityControl[]`, `ComplianceMilestone[]` arrays in trust/page.tsx are >300 LoC) with JSX rendering, with framer-motion choreography, with TypeScript type definitions. A single edit to a security-policy bullet point requires loading the entire 1,300-line file in the IDE.
+  - This is high-touch, low-test-coverage code (no tests under `__tests__/marketing/`). Edits during compliance updates carry real regression risk.
+- **Steelman:** Marketing pages are mostly content; they don't need cleverness. Splitting a "static content" page into 14 files can be over-engineering.
+- **Alternative Proposal:**
+  1. Co-locate per-page data: `trust/data.ts` exports `architectureNodes`, `securityControls`, `complianceMilestones` etc. The page becomes the JSX shell only (~400 LoC).
+  2. The 4–7 internal subcomponents in trust/page.tsx (e.g., `<ArchitectureCard>`, `<ControlList>`, `<PlaybookPhase>`) move to `trust/_components/` (Next.js underscore convention — not routed).
+  3. Don't introduce a CMS or MDX — that is the wrong cure for "we have one large file."
+
+### 8. Alembic merge migrations stacking
+- **Complexity Score:** 5 / 10
+- **Identified Debt:**
+  - 41 migrations total. Two are merge-only: `a848ac91d39a_merge_sprint_590_591_593_heads.py` and `dd9b8bff6e0c_merge_heads_before_numeric_migration.py`.
+  - Merge migrations are normal hygiene when feature branches diverge — these are not bad. **However**, `c1a5f0d7b4e2_harden_export_share_passcode.py:22` and `d1e2f3a4b5c6_add_share_security_columns.py:10-11` both contain comments narrating "renamed pre-merge on 2026-04-08 to unblock the merge train" — i.e., humans are manually re-parenting migrations to dodge head conflicts. That is a process smell, not a code smell.
+- **Alternative Proposal:** No code change. Add a CI step (`alembic heads | wc -l`) that fails the build if `> 1` head exists on `main`. This forces every PR to merge cleanly before landing instead of relying on a manual "merge train" merge migration.
+
+### 9. Overnight agents — well-shaped, no debt
+- **Complexity Score:** 3 / 10 (passes the bar)
+- **Assessment:** `scripts/overnight/` is **not over-engineered.** Six agent modules (avg 250 LoC each), one orchestrator (190 LoC), one briefing compiler (436 LoC). Each agent writes a `.<name>_<date>.json` artifact; `briefing_compiler.py` reads all six and renders the morning markdown. Clean separation of concerns; agents are independent processes; there is no "framework" — just JSON files on disk. **Keep as-is.** The only nit: `briefing_compiler.py` could split its 8 `_format_*_section()` functions into `agents/<name>.py:format_section()` so each agent owns its output rendering. That is a 3 / 10 nice-to-have, not debt.
+
+---
+
+## Items I steelmanned but did NOT flag
+
+- **`testing_response_schemas.py` (1,137 LoC, 71 classes)** — large but cohesive. Each class is a Pydantic response model bound to one route endpoint. Splitting per-tool would help readability marginally but cost `from shared.testing_response_schemas import …` ergonomics. Score: 4 / 10. Not worth a sprint.
+- **`upload_pipeline.py` (812 LoC)** — has many private helpers but single-responsibility (file upload validation + parsing dispatch). Already extracted from `helpers.py` cleanly. Score: 4 / 10.
+- **`auth_routes.py` (778 LoC)** — large but every endpoint is a distinct auth flow (register/login/refresh/verify/resend/forgot/reset). Splitting auth across files makes security review harder. Score: 4 / 10. **Do not split.**
+- **`activity.py` (594 LoC)** — close to the threshold but defensible: activity log + tool feed + user prefs share the same domain (dashboard). Score: 5 / 10. Watch but don't refactor.
+- **The 21 routes in `backend/routes/`** — average ~250 LoC, well-bounded by domain. The split is a real architectural win.
+
+---
+
+## Portfolio Verdict: **Paying Debt Down (net positive)**
+
+Reading the codebase end-to-end I see a project that has **been actively reducing complexity**:
+- 2026-04-20 refactor decomposed an 1,100-line `helpers.py` into 4 cohesive modules.
+- Sprint 519 introduced `AuditEngineBase` to standardize testing engines.
+- Sprints 218–219 collapsed 7 testing-export endpoints onto a shared handler.
+- The `routes/` package split (21 cohesive routers) is one of the cleanest I've seen at this scale.
+- Husky pre-commit hooks (lint, mypy, todo-staging gate) are mechanically enforced — not discipline-dependent.
+
+The debt that remains is **half-finished refactors**: the engine base class adopted by 3 of 12 engines, the CSV handler applied to one of two export modules, the `helpers.py` shim that should be deleted now that the migration targets exist. None of these are crises. All three would be **low-risk one-sprint cleanups before Sprint 689 expands the tool count to 18.**
+
+**Recommendation to IntegratorLead:** Insert a pre-689 cleanup sprint addressing items 1, 2, 3, 5 above (combined Complexity Score 28 / 40 — high). This is exactly the kind of work that pays off when the platform is about to grow by 50% in tool count. Skipping it means Sprint 689a–g will copy-paste from whichever pattern the previous engine used, hardening today's inconsistencies into permanent architecture.
+
+If only one item ships: **#1 (engine pattern reconciliation)**. The mismatch between `AuditEngineBase` and the 9 procedural engines is the single biggest source of "which template do I copy?" risk in the upcoming expansion.

--- a/reports/audit-deadcode-2026-04-24.md
+++ b/reports/audit-deadcode-2026-04-24.md
@@ -1,0 +1,98 @@
+﻿# Paciolus Dead Code & Tech Debt Audit
+**Date:** 2026-04-24
+**Scope:** Backend (backend/*.py), Frontend (frontend/src/**/*.ts / *.tsx)
+
+## Executive Summary
+
+The Paciolus codebase is clean with respect to orphaned code markers.
+
+**Key Metrics:**
+- **TODO/FIXME/HACK/XXX markers:** 0
+- **Type suppressions:** 201 Python, 4 TypeScript
+- **Unused components:** 0 confirmed orphaned
+- **Empty __init__.py files:** 6 (all valid)
+- **Stale env vars:** 0
+- **Orphan migrations:** 0
+
+## 1. TODO / FIXME / HACK / XXX Markers
+**Result: CLEAN** — 0 explicit markers found.
+
+## 2. Unused Python Symbols
+No strongly orphaned functions detected.
+- All engine files imported in routes/ or main.py
+- Helper functions in shared/ are re-exported or used internally
+- CLI scripts correctly isolated
+
+## 3. Unused React Components
+**223 .tsx files scanned** — all exports in-use.
+- No orphaned components identified
+- TrendSparklineMini verified in use
+
+## 4. Commented-Out Code Blocks
+**Result: MINIMAL** — no systematic code blocks found.
+
+## 5. Type Suppressions: 205 total
+Top hotspots:
+| File | Count | Reason |
+|------|-------|--------|
+| export_memos.py | 14 | Pydantic dynamic fields (justified) |
+| alembic/env.py | 13 | Schema migration complexity |
+| je_testing_engine.py | 11 | Fixture typing |
+| conftest.py | 10 | Pytest standard pattern |
+
+Frontend: 4 instances in context layer (acceptable).
+
+## 6. Deprecated Re-exports
+**0 deprecated aliases found**
+- backend/shared/__init__.py: minimal barrel structure
+- frontend index.ts files: all exports in-use
+
+## 7. Orphan Alembic Migrations
+42 migrations reviewed — all active, no orphans.
+
+## 8. Empty __init__.py Files (6 found)
+All valid structural patterns:
+- domain_config/ — enums only
+- export/serializers/ — internal utilities
+- pdf/sections/ — PDF section classes
+- scripts/ — CLI scripts
+- tests/helpers/ — test namespace
+- tests/ — pytest convention
+
+## 9. Stale Feature Flags & Env Variables
+5 env vars used, all in conditional branches:
+- SENDGRID_API_KEY — active
+- GCP_PROJECT_ID — active
+- AZURE_VAULT_URL — active
+- DEV_USER_PASSWORD — active
+- DEV_USER_TIER — active
+
+## 10. Files Not Modified in 180+ Days
+All files active — last commit 2026-04-24.
+
+---
+
+## Summary
+
+| Category | Count | Status |
+|----------|-------|--------|
+| TODO/FIXME | 0 | Clean |
+| Orphaned functions | 0 | Clean |
+| Unused components | 0 | Clean |
+| Type suppressions | 205 | Clustered (justified) |
+| Empty __init__.py | 6 | Valid |
+| Stale env vars | 0 | All used |
+| Orphan migrations | 0 | Clean |
+| Old files | 0 | Active |
+
+## Top 10 Deletion Candidates
+**None identified.** Codebase shows excellent hygiene.
+
+## Recommendations
+1. Review export_memos.py payload typing (14 suppressions) — add TypedDict wrapper
+2. Current suppression quality is high — no review needed
+3. Continue TODO/FIXME discipline — zero markers found
+
+---
+Report Generated: 2026-04-24
+Confidence Level: High

--- a/reports/audit-guardian-2026-04-24.md
+++ b/reports/audit-guardian-2026-04-24.md
@@ -1,0 +1,265 @@
+# QualityGuardian Audit — Phase 3 Validation + Stripe Cutover Failure-Mode Analysis
+
+**Date:** 2026-04-24
+**Persona:** QualityGuardian (Failure-Mode Analyst)
+**Audit scope:** (1) Phase 3 walkthrough risk, (2) Stripe live cutover, (3) prod-only failure modes not in test suite, (4) coverage blind spots in 10 weakest files.
+**Posture:** Pessimistic about first versions. Anything that can break, will break under production load on a real CEO clicking through 18 memos plus a real-money Stripe charge.
+
+Test baseline: 8095 backend + 1915 frontend tests, 92.89% backend line coverage.
+
+---
+
+## 1. Phase 3 walkthrough risk surface
+
+### 1.1 Back-to-back generation of 18 memo PDFs + 3 report PDFs on a single engagement
+
+- **Failure Mode:** Memory pressure on Render Standard (2 GB RAM single worker). `ReportLab` + `openpyxl` + `pdfminer` are all cumulative — each PDF build holds Story objects, embedded fonts, images (logo via `find_logo`), and rendered table styles in RAM until `doc.build()` flushes. Generating 21 PDFs back-to-back without a yield/restart cycle can OOM-kill the worker mid-engagement, causing a 502 on memo #15 with no clean rollback. Compounded by `excel_generator.py` using openpyxl Workbook objects (45.7% covered) and `leadsheet_generator.py` instantiating fresh NamedStyles every call (11.4% covered). NamedStyle name collisions raise `ValueError` (silently caught — but other workbook operations on the same in-process module may share state in cached `_register_styles()`).
+- **Test Scenario Checklist:**
+  1. Loadtest: trigger all 18 memo endpoints + 3 report endpoints sequentially against a single `engagement_id`, with TB containing 2,000+ rows. Watch RSS in `/health/metrics` for monotonic growth across the run; assert worker doesn't restart.
+  2. Concurrent test: 2 users on same instance each running 5 memos in parallel (Enterprise CEO + impersonator). Confirm slowapi rate limit isn't exceeded but assert no 502/503.
+  3. NamedStyle pollution: render Lead Sheets twice in the same worker — second call must not raise on `add_named_style` collisions.
+- **Defense Strategy:** Add an explicit `gc.collect()` between memo generations in `routes/export_memos.py` after each PDF write. Move PDF generation to a streaming generator (yield bytes chunks) where `reportlab` allows. Set Render `maxRequestsPerWorker` recycling so a worker handling 21 memos is recycled cleanly. Add a per-request RSS log via `resource.getrusage()` so Phase 3 surfaces the memory curve.
+- **Severity:** **High** (CEO will hit this and it looks worse than it is).
+- **Fix-before-launch?:** **Yes** — at minimum the gc.collect + worker-recycle config.
+
+### 1.2 Bulk upload (Enterprise tier) — in-memory job store, single-worker assumption
+
+- **Failure Mode:** `backend/routes/bulk_upload.py:37` defines `_bulk_jobs: OrderedDict[str, dict]` as a **module-global, per-worker** structure. Render Standard runs gunicorn with multiple workers on a single instance. CEO uploads 5 TBs → request hits Worker A, which spawns `asyncio.create_task(_process_bulk_files(...))`. CEO polls `GET /upload/bulk/{job_id}/status` → request hits Worker B → 404 "Job not found." Worse: if Render scales horizontally or recycles the worker mid-job, the job dict is dropped and the in-flight asyncio task disappears with it. Also: `asyncio.create_task` in a request scope is **not** awaited — if the event loop closes (graceful shutdown during deploy), the bulk task is silently abandoned, files marked "processing" forever, upload counter potentially under-incremented.
+- **Test Scenario Checklist:**
+  1. Two-worker integration test: start uvicorn with `--workers 2`, POST a bulk job, then poll `/status` 10x. Assert ≥1 of the 10 polls returns 404 (proves the bug exists today) — then fix and assert all 10 return 200.
+  2. Worker-restart test: start a job, send SIGHUP to the worker mid-processing, confirm job state is recoverable or surfaces an explicit "lost" error rather than perpetual "processing".
+  3. Quota test: queue 5 files, kill the worker before any complete; assert `increment_upload_count` was either fully applied or fully rolled back (no half-counted quota).
+- **Defense Strategy:** Move bulk job state to Postgres (it's an Enterprise feature — durability is expected). Use a `BulkUploadJob` model with `(job_id, user_id, status, file_descriptors_jsonb)`. Replace `asyncio.create_task` with a proper background-task pattern (Celery / RQ / Render cron worker) or persist progress to DB on each file completion so any worker can serve `/status`. Until that's done, document Phase 3 limitation: bulk upload only stable on single-worker Render Standard.
+- **Severity:** **Critical** for Enterprise UX, **Medium** for launch-blocking (Enterprise tier launches with 0 customers).
+- **Fix-before-launch?:** **Yes** if any Enterprise customer signs up Day 1; otherwise document as known limitation and gate behind a feature flag.
+
+### 1.3 Engagement layer end-to-end — completion gate edge cases
+
+- **Failure Mode:** Completion gate logic (`engagement_manager.py`) checks open follow-up items + materiality + workpaper completion before marking complete. Edge cases: (a) follow-up item soft-deleted while completion-gate query is in flight (no row lock — race window), (b) materiality cascade re-run mid-engagement changes thresholds and previously "passed" tools now fail their threshold but the gate has already been crossed, (c) workpaper index built before final TB upload — completion gate references stale TB metadata.
+- **Test Scenario Checklist:**
+  1. Open follow-up item, start the completion-gate request, soft-delete the item before the gate query commits — assert gate output reflects pre-delete state OR re-queries.
+  2. Run completion gate with materiality cascade modified between two gate calls; assert the second call recomputes thresholds rather than serving cached state.
+  3. Diagnostic package ZIP — bulk-export with one tool's results stale (TB re-uploaded after tool ran). Assert ZIP includes a "stale data" disclaimer banner per CLAUDE.md guardrails.
+- **Defense Strategy:** Wrap the completion-gate query in a serializable transaction. Add a `last_tb_uploaded_at` watermark — any tool whose `created_at` < watermark must be flagged as stale in the diagnostic package ZIP.
+- **Severity:** **Medium**.
+- **Fix-before-launch?:** No (CEO can rebuild engagement if it trips). Track for Sprint 718.
+
+### 1.4 Export sharing — passcode brute-force lockout & R2 connectivity
+
+- **Failure Mode 1:** **Self-DoS lockout** — CEO testing a passcode share types it wrong twice fat-fingered → 5+ failures escalate to 60s-per-failure lockout per-token, then per-IP throttle compounds (`security_middleware.check_ip_blocked` returns 429 with 15-min Retry-After). CEO can't unlock without Postgres surgery on `passcode_locked_until` column. There is no admin "unlock share" endpoint.
+- **Failure Mode 2:** **R2 outage during share creation** — `export_share_storage.upload()` raises → 503. But what if R2 GET fails AFTER share creation succeeded? `_resolve_export_bytes()` returns 410 "no longer available" — correct, but logs only `share_id`, not enough to alert on a regional R2 outage vs a single missing object.
+- **Failure Mode 3:** **Stale R2 client cache** — `_get_client()` caches `_s3_client` and `_configured` as module globals. If R2 credentials are rotated mid-flight (incident response), workers hold the old client until restart. `_reset_for_tests()` exists but isn't exposed via admin/health.
+- **Test Scenario Checklist:**
+  1. Submit 12 wrong passcodes from one IP across 3 different shares; assert per-IP `check_ip_blocked` triggers, then assert (manual) admin unlock path exists.
+  2. Mock R2 download to return None for a valid `object_key`; assert 410 returned with structured log including `bucket`, `key`, and a Sentry tag for grouping.
+  3. Rotate `R2_EXPORTS_SECRET_ACCESS_KEY`, hit a share without restart — confirm whether stale client errors out cleanly.
+- **Defense Strategy:** Add a CEO-only `POST /admin/share/{id}/unlock` clearing `passcode_locked_until`. Add a healthcheck endpoint `/health/r2` that runs a GET on a sentinel object so monitoring catches R2 regional outages before users do. Add `record_billing_event`-style telemetry on R2 5xx rate.
+- **Severity:** **Medium** (passcode lockout self-DoS is annoying but recoverable via DB).
+- **Fix-before-launch?:** Yes for the admin unlock endpoint; the rest can wait.
+
+### 1.5 Admin dashboard — impersonation read-only enforcement
+
+- **Failure Mode:** `ImpersonationMiddleware` is registered but its enforcement is method-based, not endpoint-aware. Any future endpoint that uses GET for a side-effect operation (e.g., `/diagnostic/run?recompute=1`) bypasses the read-only mute. Audit log writes during impersonation also need to record the actor pair (admin + impersonated_user) — if only the impersonated user is logged, an audit reviewer cannot tell who actually clicked.
+- **Test Scenario Checklist:**
+  1. As impersonator, attempt `POST /clients` (must 403), `DELETE /clients/{id}` (must 403), `GET /admin/audit-log` (must 200, with the actor pair fields populated on every row generated under the session).
+  2. Negative test: impersonator hits a hypothetical GET-with-side-effect — confirm middleware doesn't accidentally bless it.
+- **Defense Strategy:** Move impersonation read-only enforcement onto a route-decorator allowlist rather than method-based. Add explicit `actor_user_id` + `effective_user_id` columns in `ActivityLog`.
+- **Severity:** **Medium** (compliance — affects audit-trail quality, not user-visible).
+- **Fix-before-launch?:** No — verify Phase 3 walkthrough surfaces no such GET endpoints, then track.
+
+---
+
+## 2. Stripe live cutover failure modes
+
+### 2.1 Webhook signature verification with the wrong secret
+
+- **Failure Mode:** `STRIPE_WEBHOOK_SECRET` env var is per-environment. If CEO copies the **test** webhook secret into the live env vars (or vice versa), `stripe.Webhook.construct_event` raises `SignatureVerificationError` and returns 400. **Stripe will retry for 3 days with exponential backoff, but ALL events fail** — paid customers won't appear in the admin dashboard, trial conversions won't fire emails, churn events won't downgrade tiers. Worst: this is silent. The 400 looks like normal noise in logs.
+- **Test Scenario Checklist:**
+  1. Smoke test in Phase 4.1: configure live webhook, fire a test event from Stripe Dashboard ("Send test webhook"), assert backend returns **200**. If 400 → secret mismatch.
+  2. Add a webhook-health metric: 24h rolling 4xx rate on `/billing/webhook` should alert at >5%.
+  3. CI gate: assert `STRIPE_WEBHOOK_SECRET` starts with `whsec_` (live + test both use this prefix, but at least catches blanks).
+- **Defense Strategy:** Add Sentry alert rule on `Webhook signature verification failed` log message. After Phase 4.1 cutover, manually fire a Stripe CLI test event and assert delivery before doing the real-money smoke test.
+- **Severity:** **Critical**.
+- **Fix-before-launch?:** **Yes — operational checklist item.** Add to Phase 4.1 step list.
+
+### 2.2 Coupon stacking / promo code validation
+
+- **Failure Mode:** `validate_promo_for_interval(promo_code, interval)` — `MONTHLY_20_3MO` is monthly-only, `ANNUAL_10_1YR` is annual-only. If validator allows the wrong combo, customer pays 80% of an annual plan on first invoice ($800 not $1000). Also: Stripe Customer Portal allows the customer to apply additional coupons themselves on invoice — does our local subscription state reflect this discount on the next invoice's billing event? `handle_invoice_paid` records `PAYMENT_RECOVERED` but doesn't capture amount discrepancies vs catalog price.
+- **Test Scenario Checklist:**
+  1. POST `/billing/create-checkout-session` with `tier=solo, interval=monthly, promo=ANNUAL_10_1YR`; assert 400.
+  2. POST with `tier=enterprise, interval=annual, promo=MONTHLY_20_3MO`; assert 400.
+  3. Reconciliation test: every `invoice.paid` event's `amount_paid` should be within 5% of the expected catalog price for that tier × interval (after announced discounts). Anything outside is a fraud or coupon-stacking signal — flag in `BillingEvent`.
+- **Defense Strategy:** Already implemented at the validator. Add the reconciliation telemetry as a post-launch metric.
+- **Severity:** **Medium** (revenue leak if validator has a hole, fraud signal if Customer Portal bypass exists).
+- **Fix-before-launch?:** No — keep monitoring as post-launch metric.
+
+### 2.3 Seat add-on proration races
+
+- **Failure Mode:** `add_seats` / `remove_seats` calls Stripe with proration. If two API calls land within milliseconds (CEO double-clicking the "Add seat" button), Stripe processes both, each prorated against the previous state. Result: customer gets billed for the same seat twice. `idempotency_key` is set on `create_checkout_session` but I don't see one on the seat-mutation paths — verify in `subscription_manager.add_seats`.
+- **Test Scenario Checklist:**
+  1. Concurrent call: send two `POST /billing/add-seats` with `{seats: 1}` from same user with same idempotency key; assert second call is idempotent (returns same SubscriptionItem ID).
+  2. UI test: button must disable on click and re-enable on response. (Frontend concern — confirm.)
+  3. Webhook ordering test: `customer.subscription.updated` fires twice for back-to-back seat changes; out-of-order guard at `process_webhook_event` line 960 covers this — assert it triggers under the test.
+- **Defense Strategy:** Audit `subscription_manager.add_seats` for an `idempotency_key` parameter on the Stripe call. Add UI debounce. Frontend "Add seat" button must be visibly disabled during the API round-trip.
+- **Severity:** **High** (revenue + customer trust).
+- **Fix-before-launch?:** **Yes** for idempotency key on the Stripe mutation; UI debounce is launch-week polish.
+
+### 2.4 Customer Portal cancel-at-period-end race
+
+- **Failure Mode:** Customer cancels via Customer Portal → `customer.subscription.updated` fires with `cancel_at_period_end=true`. Then `customer.subscription.deleted` fires when the period actually ends. Between those two events, the customer still has paid access. Concurrent `customer.subscription.updated` ordering bug: the existing guard at line 960 only kicks in if `event_created < sub.updated_at`. If two webhooks land in the same second (event_time == sub_updated), the guard does NOT fire (`<` not `<=`), and a stale "active" event can re-activate a CANCELED subscription. The handler at line 311 also checks `sub.status == CANCELED and new_status == active`, mitigating this — but a two-step (`canceled → past_due → active`) sequence escapes that guard.
+- **Test Scenario Checklist:**
+  1. Replay test: pre-load DB with a CANCELED subscription, then process a stale `customer.subscription.updated` event with `status=past_due` (older event_created) — assert no state change.
+  2. Same-timestamp test: event_created == sub.updated_at exactly; assert event is rejected as stale (currently it isn't — boundary bug).
+- **Defense Strategy:** Change `event_time < sub_updated` to `event_time <= sub_updated` at `routes/billing.py:978`. Document the intent: "We treat exactly-equal timestamps as stale because Stripe sub-second resolution is not guaranteed."
+- **Severity:** **Medium** (rare race, recoverable).
+- **Fix-before-launch?:** Yes — one-line fix.
+
+---
+
+## 3. Production-only failure modes not covered by tests
+
+### 3.1 Redis (Upstash) intermittent disconnect under sustained load
+
+- **Failure Mode:** `RATE_LIMIT_STRICT_MODE=true` in production. `get_storage_backend()` checks Redis at startup but doesn't probe again. If Upstash hiccups mid-day, slowapi's RedisStorage client will raise — what does slowapi do under exception? Most slowapi RedisStorage failures fail-OPEN (allow the request through), which is the OPPOSITE of fail-closed. A Redis blip during a brute-force window means the attacker has unlimited attempts.
+- **Test Scenario Checklist:**
+  1. Chaos test: kill Redis connectivity (block egress to Upstash) for 30s mid-load; assert either (a) all requests fail-closed with 503 from slowapi, or (b) the limiter has a documented degraded mode that still tracks counters in-memory per-process and doesn't allow unlimited.
+  2. Health endpoint: `/health` should report Redis liveness so Render auto-restart fires on Redis loss.
+- **Defense Strategy:** Add a Redis ping in `/health` (already present? verify). Document slowapi failure mode and accept it OR replace slowapi with a cap-then-fail-closed wrapper.
+- **Severity:** **High** (security regression on Redis blip).
+- **Fix-before-launch?:** No — verify `/health` covers Redis, then track for Sprint 718.
+
+### 3.2 Neon pooler intermittent disconnect
+
+- **Failure Mode:** Neon pooled endpoint occasionally drops connections in pgbouncer-style transaction-pooling mode. SQLAlchemy's connection pool retries via `pool_pre_ping=True` (verify in `database.py`). If this isn't set, requests get `OperationalError: server closed the connection` randomly. Webhook handlers especially — losing a webhook to a transient DB error returns 500, Stripe retries, but if our dedup row was also lost in rollback, we now process duplicate side effects.
+- **Test Scenario Checklist:**
+  1. Verify `database.py` engine has `pool_pre_ping=True` and `pool_recycle <= 300` for Neon (their pooler drops idle ~5 min).
+  2. Inject a `OperationalError` mid-webhook in tests; assert (a) DB rollback runs, (b) `ProcessedWebhookEvent` is not committed, (c) a 500 is returned to Stripe (so it retries).
+- **Defense Strategy:** Already mitigated by the dedup commit being atomic with the handler logic. Verify.
+- **Severity:** **Medium**.
+- **Fix-before-launch?:** No — verify `pool_pre_ping`, then track.
+
+### 3.3 SendGrid outage during trial-ending email
+
+- **Failure Mode:** `handle_subscription_trial_will_end` already wraps email in try/except (line 593) — so the webhook returns 200 even on email failure. **But:** the failure is logged as `WARNING`, not `ERROR`, so Sentry won't surface it. Customers get no 3-day warning, churn rate spikes silently. Sprint 715 tracks SendGrid 403 specifically.
+- **Test Scenario Checklist:**
+  1. Inject SendGrid 403; assert log emitted at ERROR level (not WARNING) so Sentry catches it.
+  2. Add a metric `email_send_failures_total{template="trial_ending"}` to Prometheus.
+- **Defense Strategy:** Upgrade the log level on email failure to ERROR. Add Prometheus counter. (Already partially tracked in Sprint 715.)
+- **Severity:** **Medium**.
+- **Fix-before-launch?:** No — Sprint 715 active.
+
+### 3.4 Sentry outage — error visibility loss
+
+- **Failure Mode:** Sentry SDK is best-effort, so an outage doesn't break the app. But if Sentry is down during the live-Stripe smoke test, a real bug appears with zero visibility. Sentry's own status page is the only canary.
+- **Test Scenario Checklist:** N/A — accept as residual.
+- **Defense Strategy:** Mirror critical errors to Loki (Sprint 716 deployed) so dual visibility exists. Confirm Loki ingest path is independent of Sentry.
+- **Severity:** **Low** (Loki backstops it).
+- **Fix-before-launch?:** No — Sprint 716 covers it.
+
+### 3.5 R2 connectivity loss during export-share download
+
+- **Failure Mode:** R2 GET fails, returns 410 "Shared export is no longer available." Customer thinks their export is permanently gone. There's no retry, no fallback to inline blob (correctly — the row has only `object_key` after Sprint 611 flip).
+- **Test Scenario Checklist:**
+  1. Inject 503 from boto3 GET; assert response is 503 (transient) NOT 410 (permanent), and customer can retry.
+  2. Add a 1-attempt retry with 1s backoff on the GET path.
+- **Defense Strategy:** Distinguish transient (5xx, timeout) from permanent (404 NoSuchKey) in `export_share_storage.download()`. Return None for permanent, raise for transient. Caller maps transient → 503, permanent → 410.
+- **Severity:** **Medium**.
+- **Fix-before-launch?:** Yes — small change, big UX win.
+
+---
+
+## 4. Coverage blind-spot analysis — top 10 weakest files
+
+### 4.1 `excel_generator.py` (45.7%, 328 missing) — **High**
+
+- **Failure mode:** Uncovered paths likely include error-recovery branches in workbook serialization (broken styles, openpyxl save errors on exotic Excel content). Exception handling around `Workbook.save(buffer)` may leak the buffer or partial-write a corrupt XLSX.
+- **Test:** Generate an XLSX with 100k rows (TB at scale); assert no MemoryError and the file opens in Excel.
+- **Defense:** Wrap save in try/except, ensure `buffer.close()` on failure, return 503 to user.
+- **Fix-before-launch?:** No — current 6,188 backend tests have surfaced no Excel issues.
+
+### 4.2 `billing/webhook_handler.py` (57.4%, 185 missing) — **Critical**
+
+- **Failure mode:** Specific uncovered branches: dispute handlers, invoice.created analytics, the trial_will_end email try/except path (line 593 explicitly marked `# pragma: no cover`), the proration-detection branch at line 364 (`old_tier and old_tier != tier`), the `ValueError` catch at `_apply_dpa_from_metadata`. In live mode, dispute events WILL fire (chargeback fraud is real).
+- **Test:** Replay a fixture for each: `charge.dispute.created` (won), `charge.dispute.created` (lost), `invoice.created` proration, `customer.subscription.updated` upgrade Solo→Professional, downgrade Pro→Solo.
+- **Defense:** Add an integration test that loops through every WEBHOOK_HANDLERS entry with a representative event, asserts no unhandled exception. Targets 80%+ coverage of this file.
+- **Fix-before-launch?:** **Yes** — at minimum, dispute handler smoke test before live keys.
+
+### 4.3 `population_profile_memo.py` (39.7%, 170 missing) — **Medium**
+
+- **Failure mode:** Uncovered = exception paths in PDF rendering. With realistic TBs that have Unicode account names or huge magnitude distributions, ReportLab Paragraph rendering can raise `LayoutError`. Lands as 500 on `/audit/population-profile/pdf`.
+- **Test:** Render with a TB containing `™`, `é`, `中文`, and a 50k-row population.
+- **Defense:** Wrap memo build in try/except → log and return 503.
+- **Fix-before-launch?:** No — Phase 3 will catch if real.
+
+### 4.4 `workbook_inspector.py` (18.6%, 136 missing) — **High**
+
+- **Failure mode:** This is the FIRST file run on every uploaded xlsx/xls/ods. 18.6% coverage means parsing-error paths are largely untested. A malicious or malformed xlsx (XML bomb, ZIP slip, password-protected) hits this file first. `InvalidFileException` is imported but the catch path is uncovered. Phase 3 CEO uploads "real" client TBs — many will have weird formatting.
+- **Test:** Upload (a) password-protected xlsx, (b) xlsx with circular references, (c) xlsx with 1M empty rows, (d) ods file masquerading as xlsx by extension.
+- **Defense:** Already has `MaxBodySizeMiddleware` upstream. Add explicit `InvalidFileException` → 400 with message "File appears corrupted or password-protected."
+- **Fix-before-launch?:** **Yes** — first-touch upload path; 18.6% is too low.
+
+### 4.5 `pdf/sections/diagnostic.py` (64.9%, 134 missing) — **Medium**
+
+- **Failure mode:** Uncovered branches likely include: missing-data placeholders, ratio-rendering with None values, framework-resolution edge cases (GAAP vs IFRS toggle).
+- **Test:** Generate diagnostic PDF on a TB missing one ratio's required accounts.
+- **Defense:** Already has framework resolution module. Verify all rendering paths handle None gracefully.
+- **Fix-before-launch?:** No.
+
+### 4.6 `leadsheet_generator.py` (11.4%, 124 missing) — **High**
+
+- **Failure mode:** The lowest-covered file in the report set. Lead sheet Excel generation: `_register_styles` swallows ValueError on duplicate styles. If two requests share a process and both register the same NamedStyle, the SECOND call's exception is caught and styles are silently incomplete on the workbook → corrupt-looking Excel.
+- **Test:** Call `LeadSheetGenerator(...)` twice in the same Python process; assert second workbook has all expected styles applied.
+- **Defense:** Use a fresh openpyxl Workbook per request (already does), and rely on the per-Workbook style namespace rather than the swallowed exception. Refactor `_register_styles` to be idempotent, not exception-swallowing.
+- **Fix-before-launch?:** **Yes** — 11.4% coverage on a customer-facing PDF/Excel artifact is unacceptable.
+
+### 4.7 `config.py` (54.5%, 96 missing) — **Low** (boot-time only)
+
+- **Failure mode:** Uncovered = startup-fail branches that run once and exit. They've been exercised by every CI run and by Render boot. Real risk: a NEW required var added without test coverage that hard-fails in prod when the env doesn't have it.
+- **Test:** Add a unit test that imports `config` with each required var unset, asserts SystemExit.
+- **Defense:** Already hard-fails. Acceptable to leave.
+- **Fix-before-launch?:** No.
+
+### 4.8 `main.py` (44.2%, 92 missing) — **Low** (lifespan only)
+
+- **Failure mode:** Uncovered = lifespan startup branches (cleanup_scheduler, Stripe validation, RL backend probe). Same as config.py — these run once at boot. Real risk: rate-limit fail-closed branch (line 209-219) — if the misconfiguration is ever real, app refuses to start, which is intended behavior. Already exercised on every Render deploy.
+- **Test:** Start app with REDIS_URL unreachable + RATE_LIMIT_STRICT_MODE=true; assert RuntimeError on lifespan start.
+- **Defense:** Already implemented.
+- **Fix-before-launch?:** No.
+
+### 4.9 `preflight_engine.py` (84.1%, 79 missing) — **Low**
+
+- **Failure mode:** Edge cases in column detection on non-English headers, weird CSV separators, mixed-sign accounts. Already 84% covered, well-exercised.
+- **Test:** Upload TB with German headers ("Soll", "Haben"), Spanish ("Debe", "Haber").
+- **Defense:** Acceptable as-is.
+- **Fix-before-launch?:** No.
+
+---
+
+## Summary tables
+
+### Top 5 fix-before-launch (Phase 3 + Phase 4.1 blockers)
+
+| # | Issue | File / Path | Severity | Effort |
+|---|---|---|---|---|
+| 1 | Stripe webhook secret mismatch silent failure | `routes/billing.py` + Phase 4.1 checklist | Critical | 1 line + ops checklist |
+| 2 | Bulk upload in-memory job state breaks on multi-worker | `routes/bulk_upload.py:37` | Critical (Enterprise) | 1 sprint to migrate to DB |
+| 3 | Memo back-to-back memory pressure (gc + worker recycle) | `routes/export_memos.py` | High | 1 day |
+| 4 | Webhook handler dispute / upgrade path coverage 57.4% | `billing/webhook_handler.py` | High | 1 day to add fixture replay |
+| 5 | Workbook-inspector 18.6% coverage on upload-first path | `workbook_inspector.py` | High | 1 day |
+
+### Top 3 post-launch monitoring gaps
+
+| # | Gap | Mitigation |
+|---|---|---|
+| 1 | Redis (Upstash) blip → slowapi fail-OPEN, brute-force window | Add `/health` Redis ping + Sentry alert on RedisStorage error |
+| 2 | Stripe webhook 4xx silent — wrong secret would brick all events | Add 24h rolling `4xx_rate{path=/billing/webhook}` alert at >5% |
+| 3 | R2 regional outage → mass 410s look like permanent data loss | Add `/health/r2` sentinel GET + Sentry alert; distinguish 5xx vs 404 in `export_share_storage.download()` |
+
+### Tensions surfaced
+
+- **MarketScout speed vs Guardian rigor:** Phase 3 is days away. Top 5 fix-before-launch list is achievable in 3–4 days. Items 4 and 5 (coverage on webhook + workbook_inspector) compete with Phase 4.1 timeline. Recommend completing 1–3 hard, accepting 4–5 as Sprint 718 immediately post-launch.
+- **Bulk upload (#2):** Conflicts with "all paid tiers get all 18 tools" promise. If launch ships with Enterprise feature broken on multi-worker scale, Enterprise tier is effectively defective from Day 1. **Defer Enterprise tier marketing** OR **fix bulk job state** are the two options.
+
+---
+
+*Prepared by: QualityGuardian persona, 2026-04-24. Steel-manned the originating Sprint 716 + Phase 3 plan (8095 tests + Loki + Sentry are strong foundations) before identifying defense gaps. No new sprint authored — output is risk register + test scenarios for IntegratorLead to triage with CEO.*

--- a/reports/audit-hallucination-2026-04-24.md
+++ b/reports/audit-hallucination-2026-04-24.md
@@ -1,0 +1,250 @@
+# Hallucination Audit — 2026-04-24
+
+> Sweep target: codebase, marketing copy, docs, memo templates, MEMORY.md, hotfix SHAs.
+> Methodology: Read protocol at `.claude/agents/LLM_HALLUCINATION_AUDIT_PROMPT.md`,
+> then verify priority area claims against actual code. All file:line citations
+> reference the snapshot at HEAD `acfa06c6` on branch `sprint-716-complete-status`.
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 4 |
+| Medium   | 10 |
+| Low      | 5 |
+| **Total** | **19** |
+
+Two themes dominate: (1) the homepage / pricing / terms pages have a partial
+"12 → 18 tools" rebrand from Sprint 689 Path B that landed marketing prose flips
+on some surfaces but **not** the underlying data (ToolLedger renders 12 tools
+behind copy that says "Eighteen"), and (2) `frontend/src/app/tools/page.tsx`
+holds stale hard-coded test counts that drift below the actual engine numbers
+by 1–3 tests per tool.
+
+---
+
+## Critical Findings (user trust / accounting citations / legal copy)
+
+### C-1. ToolLedger renders 12 tools behind "Eighteen Tools" header
+**Source:** `frontend/src/components/marketing/ToolLedger.tsx:69` plus
+`frontend/src/content/tool-ledger.ts:155` (`CANONICAL_TOOL_COUNT = 12`)
+**Claim:** Homepage section heading reads "Eighteen Tools · One Platform" and
+component docstring says "all 18 tools visible at once" (line 8).
+**Truth:** `TOOL_LEDGER` array contains 12 entries; the runtime assertion at
+`tool-ledger.ts:157-161` enforces `length === 12`; the `ROMAN` map in
+`ToolLedger.tsx:37-40` only goes up to XII. Customers landing on the homepage
+read "Eighteen tools" but see 12 rows.
+**Severity:** Critical — direct contradiction visible to every visitor.
+
+### C-2. Pricing page advertises "All 18 diagnostic tools" on every paid tier
+**Source:** `frontend/src/app/(marketing)/pricing/page.tsx:381, 402, 482, 608`;
+`frontend/src/app/(marketing)/pricing/layout.tsx:5,8`;
+`frontend/src/app/(marketing)/terms/page.tsx:616,621,626`.
+**Claim:** Solo / Professional / Enterprise feature lists each say "All 18
+diagnostic tools"; Terms of Service tier table repeats "All 18 tools" three
+times.
+**Truth:** Only 12 tools render in the canonical catalog (`TOOL_LEDGER`,
+`CANONICAL_TOOL_COUNT = 12` in both `frontend/src/content/tool-ledger.ts` and
+implicitly via the comment `# CANONICAL TOOL COUNT: 18` in
+`backend/shared/entitlements.py:14` — note the backend source-of-truth comment
+disagrees with the frontend canonical count). 23 tool route pages exist under
+`frontend/src/app/tools/` but only 12 are surfaced as "in the catalog."
+**Severity:** Critical — contractually-relevant copy in Terms of Service (legal
+surface) overstates entitlements.
+
+### C-3. tools/page.tsx test counts are stale across 6 tools
+**Source:** `frontend/src/app/tools/page.tsx:47-52`
+**Claim vs. truth (verified by counting `def _test_…` / `def test_…` in the engine files):**
+- Line 47: AP `testCount: 13` → actual **14** (`backend/ap_testing_engine.py`)
+- Line 48: Revenue `testCount: 16` → actual **18** (`backend/revenue_testing_engine.py`)
+- Line 49: AR `testCount: 11` → actual **12** (`backend/ar_aging_engine.py`)
+- Line 50: Payroll `testCount: 11` → actual **13** (`backend/payroll_testing_engine.py`)
+- Line 51: Fixed Assets `testCount: 9` → actual **11** (`backend/fixed_asset_testing_engine.py`)
+- Line 52: Inventory `testCount: 9` → actual **10** (`backend/inventory_testing_engine.py`)
+**Severity:** Critical — every authenticated user lands on `/tools` and reads
+test counts that understate platform depth by ~13 tests cumulatively.
+
+### C-4. CLAUDE.md cites "PCAOB AS 1215" but no memo references it
+**Source:** `CLAUDE.md` Key Capabilities → "PCAOB AS 1215/2401/2501"
+**Truth:** `Grep "AS 1215"` across `backend/` returns **zero matches**. AS 2401
+(fraud) and AS 2501 (estimates) are cited in the JE and AR memos respectively.
+AS 1215 (Audit Documentation) is plausible but never actually cited in any
+generated memo.
+**Severity:** Critical — accounting-citation hallucination in the operator
+manual feeds downstream marketing/sales claims that the engine doesn't back.
+
+---
+
+## Medium Findings (marketing drift)
+
+### M-1. ProofStrip / EvidenceBand / BottomProof claim "140+ automated tests across all 18 diagnostic tools"
+**Source:** `frontend/src/components/marketing/ProofStrip.tsx:43`,
+`EvidenceBand.tsx:30-33`, `BottomProof.tsx:30-35`.
+**Truth:** Sum of test-batteries in code: JE 19 + AP 14 + Revenue 18 + AR 12 +
+Payroll 13 + Fixed Asset 11 + Inventory 10 = **97**. "140+" is overstated by
+~45%. (Plausible if individual sub-checks are counted, but the engines define
+97 numbered tests.)
+**Severity:** Medium — marketing puffery, contradicted by the catalog itself.
+
+### M-2. BottomProof has internal contradiction — "12" + "all 18" in adjacent metrics
+**Source:** `frontend/src/components/marketing/BottomProof.tsx:32-49,69`
+**Claim:** Metric tile target value `12` labelled "Audit Tools", but
+neighboring tile says "Across all 18 diagnostic tools", and section paragraph
+on line 69 says "Twelve audit-focused tools."
+**Severity:** Medium — visible contradiction in the closing-proof section.
+
+### M-3. ToolSlideshow / ToolShowcase mix "12" and "18"
+**Source:** `frontend/src/components/marketing/ToolSlideshow.tsx:418,511,514,581`;
+`frontend/src/components/marketing/ToolShowcase.tsx:30,139,156,284,328`.
+**Claim:** Components carry both "Eighteen Tools. One Platform." heading and
+copy reading "Twelve purpose-built tools" within ~3 lines of each other.
+**Severity:** Medium — same dual-rebrand drift pattern as C-1/C-2.
+
+### M-4. Demo / dashboard pages call out "12+ tools" while pricing says "18"
+**Source:** `frontend/src/app/(marketing)/demo/layout.tsx:5,8`;
+`frontend/src/app/dashboard/page.tsx:11`; `frontend/src/app/tools/page.tsx:6`.
+**Truth:** Pricing/Terms say 18; demo metadata + dashboard comment say "12+ tools";
+TOOLS array at `tools/page.tsx:39-67` enumerates 24 tools.
+**Severity:** Medium — three different counts surfacing on three different pages.
+
+### M-5. Workspace shows "/18 tools" denominator
+**Source:** `frontend/src/app/(workspace)/portfolio/[clientId]/workspace/[engagementId]/page.tsx:188`
+**Claim:** `{toolRuns.length}/18 tools` denominator implies 18 tools per engagement.
+**Truth:** `engagement_model.py:74` `ToolName` enum has only **13** entries
+(12 + flux_analysis); workspace numerator is bounded by the enum, so progress
+bar will never exceed 13/18.
+**Severity:** Medium — a customer running every tool will see "13/18" forever.
+
+### M-6. CLAUDE.md "17 core ratios" claim
+**Source:** `CLAUDE.md` Key Capabilities → "17 core ratios"
+**Truth:** `RatioEngine.calculate_all_ratios()`
+(`backend/ratio_engine.py:1450-1483`) returns **18** keyed ratios:
+current_ratio, quick_ratio, debt_to_equity, gross_margin, net_profit_margin,
+operating_margin, interest_coverage, return_on_assets, return_on_equity, dso,
+dpo, dio, ccc, equity_ratio, long_term_debt_ratio, asset_turnover,
+inventory_turnover, receivables_turnover.
+**Severity:** Medium — internal-doc undercount; contradicts itself.
+
+### M-7. CLAUDE.md "Revenue Testing (18 tests — 14 core … 4 contract-aware)"
+**Source:** `CLAUDE.md` Key Capabilities
+**Truth:** `revenue_testing_engine.py` `def test_…` count is **18**, but the
+breakdown is 14 core + 4 contract-aware (`test_contract_validity`,
+`test_recognition_before_satisfaction`, `test_missing_obligation_linkage`,
+`test_modification_treatment_mismatch`) — call it 14 core + 4 + an extra
+allocation_inconsistency that lives in a different bucket. Total of 18 holds;
+sub-categorization is fuzzy. Verified, count is correct.
+**Severity:** Low — leaving as-is; partial-claim verifiable.
+
+### M-8. CLAUDE.md "AP Testing (14 tests incl. AP-T14 Invoice-Without-PO per ACFE 2024)"
+**Source:** `CLAUDE.md` Key Capabilities
+**Truth:** Verified at `backend/ap_testing_engine.py:1700`
+(`def test_invoice_without_po`). Count of 14 confirmed. **Citation OK.**
+**Severity:** N/A (verified).
+
+### M-9. MEMORY.md describes archive_sprints.sh fix as "pending pre-requisite" for Sprint 689a
+**Source:** `memory/MEMORY.md` "Sprint 689 Path B locked 2026-04-23" entry —
+"Pre-requisite: fix `scripts/archive_sprints.sh` or manually archive sprints
+673–677 at start of 689a session."
+**Truth:** `tasks/todo.md` Hotfix entry dated 2026-04-23 records that the fix
+landed and Sprints 673–677 were archived to
+`tasks/archive/sprints-673-677-details.md` (142 lines). PR #100 then merged
+689a–g. MEMORY.md is two days stale.
+**Severity:** Medium — operator memory drift; misleading for a fresh session.
+
+### M-10. CLAUDE.md "Tests: 6,188 + 1,345" vs MEMORY.md "7,363 + 1,751" vs current ~6,965
+**Source:** `CLAUDE.md` Sprint 499–515 era line; `memory/MEMORY.md` line 4.
+**Truth:** Actual `^\s*def test_` count in `backend/tests/` = **6,965** as of
+HEAD. CLAUDE.md last-updated era footer is stale; MEMORY.md likely overcounts
+by ~5% (probably from a `pytest --collect-only` count which includes
+parametrize expansions).
+**Severity:** Medium — internal-doc inconsistency; affects Sprint review claims.
+
+---
+
+## Low Findings (internal-doc drift)
+
+### L-1. CLAUDE.md "8 industry ratios"
+**Source:** `CLAUDE.md` Key Capabilities
+**Truth:** `industry_ratios.py` has 9 `def calculate_…` methods (excluding
+`calculate_all`): inventory_turnover x2 (Mfg+Retail), days_inventory_outstanding,
+asset_turnover x2 (Mfg+Generic), gmroi, revenue_per_employee,
+utilization_rate, revenue_per_billable_hour. "8" is a defensible deduplicated
+count but actual surface area is 9 distinct methods.
+**Severity:** Low.
+
+### L-2. CLAUDE.md "21+ router files"
+**Source:** `CLAUDE.md` Architecture section
+**Truth:** `backend/routes/*.py` = **58 files**. "21+" was correct ages ago.
+**Severity:** Low — undercount understates architectural scope.
+
+### L-3. CLAUDE.md "~49 export endpoints across 7 route modules"
+**Source:** `CLAUDE.md` Key Capabilities
+**Truth:** Likely correct order of magnitude. Verified `export_memos.py` has
+18 routes, `export_testing.py` has 9 CSV routes — count of 49 across all is
+plausible but unverified.
+**Severity:** Low — flagged for next deep audit.
+
+### L-4. CLAUDE.md SoD page "Twelve standards-backed SoD rules"
+**Source:** `frontend/src/app/tools/sod/page.tsx:93`
+**Truth:** Not verified against `sod_engine.py` rule library this pass — but
+worth a follow-up; SoD-rule counts are exactly the kind of marketing-prose
+hallucination this audit targets.
+**Severity:** Low — flagged as TODO.
+
+### L-5. tasks/todo.md hotfix `d74db7c` SHA
+**Source:** `tasks/todo.md:23`
+**Claim:** "[2026-04-23] d74db7c: record Sprint 673 COMPLETE — DB_TLS_OVERRIDE
+removed from Render prod"
+**Truth:** `git rev-parse d74db7c` resolves to
+`d74db7c14331a89dfe5ed959fe2d11277c192a8c` — exists. Verified.
+**Severity:** N/A (verified).
+
+---
+
+## Verified-Clean Spot Checks (no drift found)
+
+- JE Testing claim of **19 tests** → `je_testing_engine.py` has 19 `def test_…` symbols
+- AR Aging claim of **12 tests** → `ar_aging_engine.py` has 12 underscore-prefixed test methods
+- Fixed Assets claim of **11 tests** → `fixed_asset_testing_engine.py` 11 methods
+- Inventory claim of **10 tests** → `inventory_testing_engine.py` 10 methods
+- Sampling memo claim of "ISA 530 + PCAOB AS 2315" → cited literally on `sampling_memo_generator.py:573`
+- Multi-period memo claim of "ISA 520 + PCAOB AS 2305" → cited at line 1403
+- AR memo claim of "ISA 540 + PCAOB AS 2501" → cited at lines 5, 56, 84, 215
+- 18 memo PDF endpoints → confirmed in `backend/routes/export_memos.py` (18 `route_path=`)
+- 9 testing-tool CSV exports → confirmed in `backend/routes/export_testing.py`
+- 6 benchmark industries → confirmed in `benchmark_engine.py:1107-1112`
+- LOKI_URL `logs-prod-042.grafana.net` → confirmed in `backend/config.py:464` and runbook
+- R2 endpoint URL → confirmed in MEMORY.md vs `export_share_storage.py`
+- Hotfix SHAs `6802bd63`, `9820bb2f`, `9f000703`, `8fd93bb5`, `7915d779`,
+  `22e16dc6`, `a32f5669`, `73aaa519`, `39791eca`, `29f768ed`, `e04e63e2`,
+  `8b3f76d0`, `8372073a`, `5fc04534`, `52ddfe03`, `7fa8a211`, `fb8a1fa8`,
+  `e3d6c885`, `d74db7c1`, `b0ddbf69` → all resolve in `git log --all`
+
+---
+
+## Recommended Remediation Priority
+
+1. **Critical → fix in next hotfix sprint:**
+   - Update `frontend/src/content/tool-ledger.ts` to 18 entries (the actual
+     promoted catalog from Sprint 689 Path B), or revert all "Eighteen Tools"
+     copy back to "Twelve" until catalog data lands. The half-done state is
+     worse than either consistent state.
+   - Bump test counts in `frontend/src/app/tools/page.tsx:47-52` to the
+     verified engine values.
+   - Either remove `PCAOB AS 1215` from `CLAUDE.md` Key Capabilities or add it
+     as a citation in the audit-engine memo template.
+2. **Medium → fold into next marketing-copy sweep:**
+   - Reconcile "140+ automated tests" claim — either count granular sub-checks
+     and document the methodology, or update prose to "97 + analytical procedures".
+   - Update MEMORY.md Sprint 689 entry to reflect that pre-requisite cleared.
+   - Reconcile Tests count across CLAUDE.md / MEMORY.md / nightly artifacts.
+3. **Low → defer to next audit:**
+   - SoD rule count
+   - Export-endpoint total count
+   - Router-file count in CLAUDE.md
+
+---
+
+*Audit run by Claude (Opus 4.7, 1M context) on 2026-04-24.
+Protocol: `.claude/agents/LLM_HALLUCINATION_AUDIT_PROMPT.md`.
+Branch: `sprint-716-complete-status`. HEAD: `acfa06c6`.*

--- a/reports/audit-project-auditor-2026-04-24.md
+++ b/reports/audit-project-auditor-2026-04-24.md
@@ -1,0 +1,105 @@
+# Project Auditor Report — Paciolus
+**Date:** 2026-04-24
+**Branch:** `sprint-716-complete-status`
+**Auditor frame:** Outside consultant, workflow discipline (process, not code)
+**Prior audit:** 35th — 2026-04-14 — 4.8/5.0 🟢
+
+---
+
+## Phase 1 — Evidence Gathered
+
+- **Project tree (top level):** `backend/`, `frontend/`, `tasks/`, `docs/`, `reports/`, `skills/`, `scripts/`, `.claude/`, plus `CLAUDE.md`, `AGENTS.md`, `audit-journal.md`, `MEMORY.md`. Standard well-organized layout.
+- **CLAUDE.md:** Present, 200+ lines. Defines Document Authority Hierarchy, Directive Protocol (5 steps), Sprint vs. Hotfix classification, design mandate. Cross-references `tasks/PROTOCOL.md` and the commit-msg hook.
+- **tasks/todo.md:** 120 lines. Active Phase contains exactly **2 items** — Sprint 715 (PENDING, gated on 24h post-deploy watch) and Sprint 716 (COMPLETE 2026-04-24). Active Phase header explicitly notes "Sprints 611 + 677–714 archived 2026-04-24 to `tasks/archive/sprints-611-714-details.md`." Hotfix log healthy: 22 entries, all in `[date] sha: description (files touched)` format.
+- **tasks/lessons.md:** 1,039 lines. Most recent four lessons all from 2026-04-23/24 (Sprint 716 deployed-code verification; Render Log Streams ≠ Loki protocol mismatch; `logger.exception` Sentry escalation from Sprint 713; Render edit-form screenshot secret-leak from R2 provisioning). Each is structurally complete: incident → root cause → pattern → enforcement.
+- **.claude/agents/:** 11 files — `accounting-expert-auditor.md`, `critic.md`, `designer.md`, `executor.md`, `future-state-consultant-agent.md`, `guardian.md`, `project-auditor.md`, `scout.md`, plus 3 prompt-template artifacts (`AUDIT_OWNERSHIP.md`, `DIGITAL_EXCELLENCE_COUNCIL_PROMPT.md`, `LLM_HALLUCINATION_AUDIT_PROMPT.md`). Single-purpose, no bloat.
+- **.claude/commands/:** `audit.md` (this command).
+- **Git log (last 25):** Sprint 716 (#103) merged today; preceded by Sprint 713 (P2 Sentry sweep, #102), main-catchup PR #100 covering Sprints 689a–g + 611 + 691, Sprint 714 (#98), Sprint 711 (#95). Each Sprint commit followed by a `fix:` entry recording the SHA into `tasks/todo.md` Review section. Atomic, conventional, traceable.
+- **Nightly orchestrator (2026-04-24):** Status YELLOW (overall) with QA Warden 🟢 GREEN — backend 8,095 passed / 0 failed (637.5s); frontend 1,915 passed / 0 failed (49.8s). Coverage Sentinel 🟢 92.89% (+0.34pp 7-day delta). Sprint Shepherd 🟡 (1 risk-keyword false positive: "TODO" in a hotfix description). Dependency Sentinel 🟡 (9 outdated backend, 1 frontend; 2 security-relevant patches available — fastapi 0.136.0→0.136.1, stripe 15.0.1→15.1.0).
+- **Code quality scan:** 19 TODO/FIXME occurrences across 15 backend files (concentrated in test infrastructure: 5 in `tests/anomaly_framework/generators/currency_generators.py`, plus single-occurrence informational comments in 9 engine/memo files). 6 TODO occurrences across 6 frontend files (4 in error boundary stubs, 2 in `useFocusTrap.ts`/`useStatisticalSampling.ts` deferred type migrations). **Zero HACK markers in production paths.**
+- **Sprint 716 Review section (sample of recent rigor):** Documents the in-process LokiHandler implementation, env-var wiring, 6 saved queries, runbook authoring, deploy-confirmation workflow, AND the LogQL correction story (the runbook's section 4 was rewritten post-deploy after CEO discovered indexed-label selectors don't work against Grafana Cloud's ingest layer — substituted line-filter + JSON parsing). Honest documentation of mid-flight scope adjustments.
+- **Archive structure:** 20+ sprint-detail archive files in `tasks/archive/`, latest `sprints-611-714-details.md` archived today. `archive_sprints.sh` was bug-fixed 2026-04-23 (broken grep-pipeline replaced with awk-based pairing); fix lessons captured.
+
+---
+
+## Phase 2 — Per-Pillar Scores
+
+### A1. Plan Mode Default — **5/5**
+**Finding:** Sprint 716 is a textbook plan-execute-document arc. Active Phase entry was authored before implementation with a structured Plan/Out-of-Scope split, env-var checklist for the CEO, and 6 saved-query LogQL specs written upfront. Mid-flight, when the protocol mismatch surfaced (Render Log Streams advertised TCP/syslog only, Loki accepts HTTPS push only), the operator stopped, re-scoped the sprint to in-process Python handler rather than improvising a bridge — and captured the protocol-mismatch lesson immediately. Sprint 715 was correctly held PENDING with an explicit trigger condition ("CEO signal: if warn log count > 0 after 24h") rather than rushed.
+**Recommendation:** Continue current practice.
+
+### A2. Subagent Strategy — **5/5**
+**Finding:** 11 agents in `.claude/agents/`, all single-purpose. Hierarchy is clear: 5 sub-agents for the Conflict Loop (`critic`, `scout`, `executor`, `guardian`, `designer`), 1 deep specialist (`accounting-expert-auditor`), 1 strategy (`future-state-consultant-agent`), 1 meta (`project-auditor`), and 3 prompt templates for periodic large-scale reviews (Digital Excellence Council, hallucination audit, audit ownership). The hallucination-audit prompt was added Audit 35 (2026-04-14) as a direct outcome of the Sprint 598 hallucinated-coverage incident — meta-governance evolution. The 2026-04-23 R2 provisioning lesson explicitly warns about screenshot leaks and prescribes JS DOM extraction over pixel screenshots — the operator is actively codifying agent-tool failure modes.
+**Recommendation:** Continue current practice.
+
+### A3. Self-Improvement Loop — **5/5**
+**Finding:** Lessons file is at peak health. The four lessons captured 2026-04-23/24 are all from genuine fresh corrections (not retroactive), each follows the prescribed structure (incident → root cause → pattern → enforcement), and they cross-reference each other where appropriate (Sprint 716 deploy-verification lesson cites the Sprint 551-era Stripe deploy as an analogous failure mode; Sprint 713 logger-level lesson cites Sprints 711 and 712 as the prior touches in the same domain — "third sprint in three weeks to touch Sentry log-level semantics — worth a lint rule on future route handlers"). The 2026-04-23 R2 screenshot-leak lesson includes a 4-step containment-rotation-repaste-save remediation order codified for future credential leak incidents. The lessons are not just captured — they are referenced as a systems theory of operator failure modes.
+**Recommendation:** Continue current practice.
+
+### A4. Verification Before Done — **5/5**
+**Finding:** Nightly orchestrator ran GREEN today on QA Warden (8,095 backend / 1,915 frontend / 0 failures / 637.5s + 49.8s). Coverage 92.89% with positive 7-day delta. Sprint 716 Review section explicitly documents the deploy-confirmation step (Render Web Shell `python -c "from <module> import <new_symbol>"` probe — the same probe that surfaced "the deployed image is Sprint 713's commit, not 716's"). The CI gate is enforced: PR #103 (Sprint 716) was preceded by an `8e65d30e` commit that was local-only and would have shipped silently; the CEO caught it via runtime probe before the sprint was marked COMPLETE. Verification went *beyond* "tests pass" to "the running production process actually loads the new code." Sprint 611 Review reports "11 new tests + 129 touched-surface regression passed" — verification is granular, not aggregate.
+**Recommendation:** Continue current practice.
+
+### A5. Demand Elegance (Balanced) — **4/5**
+**Finding:** Code-level discipline is strong: 19 TODO/FIXME across all of backend (production code clean; vast majority in test fixtures and intentionally-marked deferred items), 6 in frontend (4 are error-boundary stubs, 2 are deferred type migrations already tracked in the Deferred Items table). Zero HACK markers. Sprint 716's rescope mid-flight (sidecar bridge → in-process handler) is the elegance principle in action — when the proposed solution required new infrastructure, the simpler additive path was chosen. **Minor flag:** the Sprint 716 runbook required a post-deploy correction (LogQL queries that would have failed against Grafana Cloud's ingest layer were authored from documentation rather than verified against ingested data first). The CEO caught it within hours; the runbook is now correct. The pattern — "verify the *target system's actual behavior*, not just its documented contract" — generalizes the Sprint 716 deploy-verification lesson and is worth a separate codification.
+**Recommendation:** Add a third "verify against production reality" lesson tying together (1) deployed-code verification (Sprint 716), (2) protocol-match verification (Sprint 716 mid-flight), and (3) query-against-real-data verification (Sprint 716 runbook). They are facets of one principle: **trust the live system over the documented contract**. A single consolidated lesson would compress three near-duplicates into one canonical reference.
+
+### A6. Autonomous Bug Fixing — **5/5**
+**Finding:** Sprint 713 (P2 Sentry sweep) is exemplary autonomous resolution: three Sentry issues were filed by production, root-cause-traced (caught-and-mapped 4xx errors being promoted via `logger.exception`), and fixed via the correct semantic refactor (`logger.warning(..., exc_info=True)`) — not by suppressing the symptom. Sprint 711 was a P1 production bug-fix batch (verification-status datetime + cleanup_scheduler visibility) self-contained in a single PR. The 2026-04-23 archive_sprints.sh fix (broken grep-pipeline → awk pair-extraction) was diagnosed and fixed in-session without escalation. No back-and-forth patches in the recent git log; every `Sprint N:` commit is followed by a single `fix: record SHA` housekeeping entry, never a follow-up bug fix to the just-shipped sprint.
+**Recommendation:** Continue current practice.
+
+### B. Task Management — **5/5**
+**Finding:** All 6 sub-practices fully exercised in this cycle:
+1. **Plan First** — Sprint 716 Active Phase entry pre-dates implementation; Sprint 715 has full plan with explicit deferral trigger.
+2. **Verify Plan** — Sprint 716 was re-scoped mid-flight when the protocol mismatch surfaced; the plan was updated in `todo.md` before re-execution rather than diverging silently.
+3. **Track Progress** — Sprint 716 status moved PENDING → COMPLETE 2026-04-24 with full Review section.
+4. **Explain Changes** — Each sprint Review documents specific files, test counts, deploy SHAs, and out-of-scope items.
+5. **Document Results** — Sprint 716 Review records PR SHA `6802bd63`, deploy timestamp 12:51 UTC, 40 ingested log lines confirmed, 6 saved queries authored, runbook live.
+6. **Capture Lessons** — Four fresh lessons captured 2026-04-23/24, immediately following the events.
+
+Active Phase has **1 completed sprint + 1 pending** = under the 5-sprint archival gate. Today's archival of Sprints 611 + 677–714 (eight batches into one archive file) was proactive: the gate would only have triggered after the next Sprint commit, but the operator cleared it ahead of time. Hotfix log: 22 entries, all in correct `[date] sha: description (files touched)` format.
+**Recommendation:** Continue current practice.
+
+### C. Core Principles — **5/5**
+**Finding:**
+- **Simplicity First:** Sprint 716 in-process Loki handler is roughly 80 lines of Python plus a config flag — the minimum viable shape. No sidecar, no protocol bridge, no log-format DSL. Sprint 715 is held in plan form with an explicit trigger rather than pre-implemented "just in case." Sprint 713's three Sentry fixes are surgical: change `logger.exception` to `logger.warning(..., exc_info=True)` at three call sites. No new abstractions.
+- **No Laziness:** Sprint 713 didn't suppress the Sentry noise — it traced each one to a caught-and-mapped 4xx and reclassified the log severity to match its semantic meaning. Sprint 716's mid-flight rescope rejected the easy path (introduce a sidecar) for the right path (in-process direct push). Sprint 716's deploy-verification lesson is itself a no-laziness signal: rather than hand-waving "deploy presumed OK," the operator added a 30-second probe to the sprint-close template.
+- **Minimal Impact:** Sprint 716 touches 4 files (Loki handler, logging_setup, requirements.txt, runbook). Sprint 713 touches 3 files. No opportunistic adjacent-code cleanup. Oat & Obsidian compliance unchanged. Zero-Storage compliance unchanged.
+
+23rd consecutive cycle at 5/5 for Core Principles.
+**Recommendation:** Continue current practice.
+
+---
+
+## Phase 3 — Synthesis
+
+### Scores at a Glance
+| Pillar                  | Score |
+|-------------------------|-------|
+| Workflow Orchestration  | 4.8   |
+| Task Management         | 5/5   |
+| Core Principles         | 5/5   |
+| **Overall**             | **4.9** |
+
+**Health Rating:** 🟢 **Excellent** (4.9/5.0)
+
+### Top 3 Strengths
+1. **Self-improvement loop is operating at peak.** Four substantive lessons captured in 24–36 hours, each tied to a real incident, each codifying a reusable pattern with explicit prevention rules. The lessons reference each other and form a system, not isolated entries.
+2. **Verification rigor extended past tests to deployed reality.** Sprint 716's deploy-probe discovery (the running Render image was Sprint 713's commit, not 716's) was caught and codified within the same sprint. This is verification-of-verification — exactly what Audit 35 hoped would emerge.
+3. **Mid-flight rescope discipline.** When the Loki integration revealed a protocol mismatch with Render's log drain surface, the sprint was paused, re-scoped in `todo.md`, and re-executed cleanly — not improvised through with a workaround. Conflict Loop discipline applied to the operator's own decisions, not just agent disagreements.
+
+### Top 3 Weaknesses
+1. **Three near-duplicate lessons in 24h on "verify against live system."** Sprint 716's deploy-verification, mid-flight protocol-match, and post-deploy LogQL correction are three facets of one principle. Three separate lessons risk diluting the canonical reference. Consolidation would strengthen retention.
+2. **Sprint Shepherd YELLOW is a brittle signal.** Today's nightly went YELLOW because a hotfix description contained the literal substring "TODO" — a false positive. As the volume of legitimate hotfix entries grows, false-positive risk-keyword matches will erode trust in the Sprint Shepherd signal. Worth a smarter regex or a configurable suppress list.
+3. **Two security-relevant dependency patches sitting available.** fastapi 0.136.0 → 0.136.1 and stripe 15.0.1 → 15.1.0 are both flagged by today's Dependency Sentinel. They are minor patches, not urgent, but they accumulate — last hygiene pass was 2026-04-22.
+
+### Single Concrete Next Action
+**Consolidate the three "verify against live system" lessons (Sprint 716 deploy-probe, Sprint 716 protocol-match, Sprint 716 LogQL-against-ingested-data) into a single canonical lesson titled "Trust the live system over the documented contract."** Cross-reference the original three for incident detail. Then pair it with a sprint-close template addition: a 4-line "verify-against-live" checklist (deploy SHA matches new code; integration protocol matches both ends; query/probe runs against real ingested data; log line found in target log surface). This generalizes the pattern beyond the Loki sprint and prevents the lesson list from accumulating duplicate facets of one principle.
+
+### Trend Note
+- Workflow Orchestration: 4.8 → 4.8 (flat — A5 has the same minor flag, now a "consolidate" recommendation rather than a "capture" recommendation)
+- Task Management: 4/5 → **5/5** (regression at Audit 35 from missing-SHA backfill is fully resolved; archival was proactive; commit-msg gate operating cleanly)
+- Core Principles: 5/5 → 5/5 (23rd consecutive cycle)
+- Overall: 4.8 → **4.9**
+
+The 35th audit's minor regression (hotfix SHA backfill, archival proximity) has been fully cleared. Active Phase is at 1 completed + 1 pending — well under the gate. Sprint 716 brought a new external observability surface online (Grafana Cloud Loki) without infrastructure cost or service disruption. The platform is launch-ready from a workflow-discipline perspective; remaining gates are CEO-external (Phase 3 functional validation, Sprint 447 Stripe production cutover).

--- a/reports/audit-scout-2026-04-24.md
+++ b/reports/audit-scout-2026-04-24.md
@@ -1,0 +1,199 @@
+# MarketScout Audit — 2026-04-24
+
+**Persona:** External-perspective user advocate. Win condition: Time-to-Market.
+**Scope:** Phase 3 (functional validation) → Phase 4.1 (Stripe live cutover) → Phase 4.5 launch announcement.
+**Vantage point:** Non-technical CPA browsing https://paciolus.com cold, then signing up.
+
+---
+
+## TL;DR
+
+Code is launch-ready. The risk is not engineering — it's marketing/reality drift introduced by Sprint 689g's "12 → 18 tools" bulk sed pass and a Phase 3 checklist that hasn't been updated to match the catalog the CEO is about to validate. Three small data-file fixes close the biggest credibility hole. After that, only Stripe live keys + legal sign-off stand between today and the launch announcement.
+
+---
+
+## 1. MVP Risk — what's delaying launch unnecessarily
+
+### a. Sprint 715 SendGrid 403 root-cause investigation
+**Market Value: Low | MVP Risk: NONE | User Persona Impact: zero pre-launch users affected**
+
+Already correctly classified P2 in `tasks/todo.md`. The fix from Sprint 713 (catch the exception, log it) already prevents the user-facing crash. The remaining work is *observability investigation* — figuring out *which* recipients trigger the 403. This must NOT block launch. The trigger condition (CEO signal: warn-log count > 0 after 24h) is correct. **Keep deferred. Do not investigate pre-launch.**
+
+### b. Sprint 689a–g full 12 → 18 tool expansion
+**Market Value: High (already shipped) | MVP Risk: Done — but cleanup gap created | User Persona Impact: real (paid tier value prop is now bigger)**
+
+Path B is already COMPLETE per `tasks/archive/sprints-611-714-details.md` and merged via PR #100 (`9cc3171a`). Backend `CANONICAL_TOOL_COUNT = 18`. Pricing/Terms/Footer/About/Demo/Register copy all flipped to "18 tools". CEO's instinct here was correct — 7 new tool surfaces with ~4,500 LoC of working backend already in production was too valuable to throw away.
+
+**However**, the sed pass left two data files behind (see §3). This is the live-site credibility risk.
+
+### c. Phase 4.4 backups (pg_dump cron to R2)
+**Market Value: Med (insurance, not feature) | MVP Risk: Should not block launch | User Persona Impact: zero — invisible to users, important for CEO sleep**
+
+Owner is "I" (Claude) — only needs CEO R2 token + IAM creation. Should land in parallel with 4.1, not after. Belt-and-suspenders on top of Neon PITR.
+
+### d. Phase 5 Sentry alert rules + uptime monitor
+**Market Value: Low pre-launch | MVP Risk: NONE | User Persona Impact: zero**
+
+Correctly already in Phase 5. Keep there.
+
+### e. SOC 2 deferrals (464, 466, 467, 468, 469)
+**Market Value: Low until enterprise demand materializes | MVP Risk: NONE | User Persona Impact: zero — no SOC 2 references on website**
+
+Correctly deferred. Confirm the CEO's 2026-04-24 directive to "schedule any deferred items that are free" only landed Sprint 716 (Loki) — the rest still cost money and stay deferred. **Keep deferred. Do not let SOC 2 scope creep back in.**
+
+---
+
+## 2. User Persona Impact per pending pipeline item
+
+| Item | Helps the cold-CPA-signup persona? | Recommendation |
+|---|---|---|
+| Sprint 715 (SendGrid 403 RCA) | No — affects an unknown subset of email recipients on a path we can't identify yet | **Defer past launch.** Wait for production signal. |
+| Phase 3 functional validation | **Yes — directly.** This is the gate that catches "user clicks button, nothing happens" | **Highest priority.** Update checklist (see §4 punch list). |
+| Phase 4.1 Stripe live cutover | **Yes — directly.** This is the gate that turns on revenue | **Highest priority.** Already documented well in ceo-actions.md. |
+| Phase 4.2 legal placeholders | **Yes — risk mitigation, regulatory** | **Highest priority.** Counsel sign-off is sequential. |
+| Phase 4.3 custom domain | Helpful — `https://paciolus.com` already live for frontend; only `api.paciolus.com` left | Land it, but don't gate launch announcement on it (CORS update is a 5-min config) |
+| Phase 4.4 backups | No — invisible to users | Land in parallel, not sequential |
+| Phase 4.5 24h smoke test | Yes — final go/no-go | Required gate |
+
+**Items with zero pre-launch persona impact:** Sprint 715. Defer.
+
+---
+
+## 3. Marketing vs Reality Gaps (LIVE PRODUCTION CREDIBILITY RISK)
+
+This is the single largest issue I found. Sprint 689g's bulk sed pass ("12 → 18 tools") flipped the *prose copy* across 34 files but missed two data files. The result: live `https://paciolus.com` says "18 tools" in headers and renders 12 cards directly underneath. **A non-technical CPA who can count rows will spot this in 15 seconds.**
+
+### Gap 1 — Homepage `<ToolLedger>` (highest visibility)
+**File:** `D:\Dev\Paciolus\frontend\src\content\tool-ledger.ts`
+
+- `CANONICAL_TOOL_COUNT = 12` (line 155) — backend was flipped to 18, frontend was missed
+- `TOOL_LEDGER` array has 12 entries (line 39–148)
+- Component header at `ToolLedger.tsx:69` reads **"Eighteen Tools · One Platform"**
+- Component footer at `ToolLedger.tsx:101` reads **"{12} tools · every paid plan · every result cited"** (interpolates the constant)
+- `ToolLedger.tsx:61` `aria-label="Twelve audit tools — catalog ledger"` (screen readers contradict the visible header)
+- Comment at `tool-ledger.ts:25` literally says "When Sprint 689 reconciles the catalog … update this file" — Sprint 689 happened, file wasn't updated.
+
+**Live on production homepage right now.** This is the fix that matters most.
+
+### Gap 2 — `/demo` page
+**File:** `D:\Dev\Paciolus\frontend\src\app\(marketing)\demo\page.tsx`
+
+- Section header line 94: **"All eighteen tools included with every paid plan."**
+- Section header line 91: **"The Complete Tool Suite"**
+- `DEMO_TOOLS` array (line 33–46) has **12 entries** — same drift as ToolLedger.
+
+### Gap 3 — `/tools` catalog page
+**File:** `D:\Dev\Paciolus\frontend\src\app\tools\page.tsx`
+
+- Line 6 docblock: "Browsable catalog of all 12+ diagnostic tools" (forgivable — that "+" is honest)
+- `TOOLS` array has **26 entries** including 5 not in `tool-ledger.ts` and not in marketing copy: `composite_risk`, `account_risk_heatmap`, `flux_analysis`, `loan_amortization`, `depreciation`. Plus the 7 promoted tools from 689a–g.
+- `ToolShowcase.tsx:136` `const TOTAL_COUNT = TOOLS.length` (= 12, since `ToolShowcase` uses a different separate list of 12)
+- `ToolShowcase.tsx:139` filter button hard-coded label: `"All 18 tools"` while computed `TOTAL_COUNT = 12`. Mixed source-of-truth bug.
+
+**The actual product surface is 26 routes.** The marketing claim is 18. The data files render 12. **Three different numbers visible on production simultaneously.**
+
+### Recommended canonical answer
+The cleanest story for a CPA is **"18 audit-grade tools, plus calculators."** That bins the situation honestly:
+- 18 = the ones in `_ALL_TOOLS` of `entitlements.py` (the marketing claim Stripe is built around)
+- The other 5 (heatmap, flux, loan, depreciation, composite-risk) are calculators / diagnostic adjuncts, mostly already entitled and shipped, but not the "audit testing" headline
+
+Whatever the canonical answer is, **all three data sources need to converge on it before launch**.
+
+---
+
+## 4. Minimum Viable Pre-Launch Punch List
+
+In strict order. Estimates assume a single focused session each.
+
+### Pre-launch — must land before Phase 4.5 announcement
+
+1. **HOTFIX: Reconcile tool-count drift** (~2h)
+   - Update `frontend/src/content/tool-ledger.ts`: flip `CANONICAL_TOOL_COUNT = 18`, add 6 entries (multi-currency was 689a, the other 5 promoted tools should appear), update the docblock and the `aria-label`.
+   - Update `frontend/src/app/(marketing)/demo/page.tsx`: `DEMO_TOOLS` array (add 6 entries) OR change copy to "All twelve testing tools demonstrated; six advanced tools available with every paid plan."
+   - Update `frontend/src/components/marketing/ToolShowcase.tsx`: drop the hard-coded "All 18 tools" label or sync with TOOLS data.
+   - Single `fix:` commit. No sprint number needed.
+
+2. **Phase 3 checklist update** (~30 min)
+   - `tasks/ceo-actions.md` line 55: change "12 testing tools" to match canonical answer + list the 7 promoted tools by name.
+   - Add explicit Phase 3 sub-step: "Exercise the 7 newly-promoted tools (multi-currency, sod, intercompany, w2-reconciliation, form-1099, book-to-tax, cash-flow-projector). Each has a backend tier-gate retrofit that has unit-test coverage but has never been exercised by a real user clicking through the UI."
+   - The CEO is about to do functional validation on a list that omits a third of the catalog.
+
+3. **Phase 4.1 Stripe live cutover** (CEO calendar, ~2-4h)
+   - Already excellently documented. No changes needed.
+
+4. **Phase 4.2 legal sign-off** (CEO + counsel calendar, sequential blocker)
+   - Cannot be parallelized.
+
+5. **Phase 4.4 backups** (in parallel with 4.1, ~1h once R2 token is in hand)
+   - R2 buckets already provisioned 2026-04-23. Just needs cron + IAM token.
+
+6. **Phase 4.5 24h smoke test + announcement**
+
+### Defer to Phase 5 / post-launch
+
+- Sprint 715 SendGrid 403 RCA — defer to 24h post-launch as already planned
+- Sentry alert rules — Phase 5
+- Uptime monitor — Phase 5
+- Any SOC 2 deferrals — keep deferred
+- DMARC `p=quarantine` → `p=reject` — already on a 30-day natural cadence
+
+**Cuttable from any pre-launch milestone:** anything not on lines 1–6 above.
+
+---
+
+## 5. Friction Points for a Cold CPA Signup
+
+Walking the funnel as a non-technical 15-year-experienced auditor at a 12-person firm landing on `paciolus.com` from a Google search:
+
+### Bounce risk: HIGH — homepage tool count contradiction
+**Where:** Homepage `<ToolLedger>` (immediately below hero) — header says "Eighteen Tools" with 12 cards beneath.
+**Why this matters for this persona:** CPAs *count things*. It's the job. A claim that doesn't tie out is a credibility hit before they even read the value prop.
+**Fix:** Punch list item #1.
+
+### Bounce risk: MED — `/demo` page same gap
+**Where:** "All eighteen tools included with every paid plan" header over 12 cards.
+**Why this matters:** Demo page is the natural second click after the homepage. Same mismatch reinforces "this team isn't detail-oriented" — which is the worst possible vibe to project to an auditor.
+**Fix:** Punch list item #1.
+
+### Bounce risk: MED — `/tools` catalog page docstring
+**Where:** Comment in source code reads "all 12+ diagnostic tools" — not visible to users but speaks to internal source-of-truth confusion.
+**Fix:** Punch list item #1 cleanup.
+
+### Bounce risk: LOW — pricing page
+The pricing page is in good shape. "All 18 diagnostic tools" claim, seat calculator works, FAQ is honest, 7-day trial is prominent, "no credit card required to start" is the right hook. **No friction here.**
+
+### Bounce risk: LOW — register flow
+"Seven-day trial. All eighteen tools. Raw financial files are never stored." — **excellent copy.** The Zero-Storage badge is a strong differentiator for a CPA worried about client confidentiality. No friction.
+
+### Bounce risk: LOW — empty-state experience
+Once registered, the dashboard / tools catalog likely renders the 26-tool list. CPAs are unlikely to bounce here — abundance is good — but they may be confused by which 18 are "the audit tools" and which 5 are "calculators". A category label cleanup on `/tools` would help (`Core Analysis | Testing Suite | Advanced` exists; promoting `Calculators` as a fourth category would clarify).
+
+### Bounce risk: MED — first-tool flow on the 7 newly-promoted tools
+**Where:** SoD / Intercompany / W-2 / 1099 / Book-to-Tax / Cash-Flow-Projector pages. Per Sprint 689g notes, these have backend tier-gate retrofits that were tested with unit tests but **never exercised end-to-end by a real CPA in production**.
+**Why this matters:** A 403 / surprise paywall / parser failure on one of these tools is the kind of thing that gets caught only by Phase 3 functional validation. The current Phase 3 checklist (line 55 of ceo-actions.md) doesn't mention them by name, so they may get skipped.
+**Fix:** Punch list item #2.
+
+---
+
+## Output Summary
+
+| Item | Market Value | MVP Risk | User Persona Impact |
+|---|---|---|---|
+| Sprint 715 (SendGrid 403 RCA) | Low | None — already deferred correctly | Zero pre-launch |
+| Sprint 689a–g (already DONE) | High | Done; cleanup gap remains | Real — bigger value prop |
+| **Tool-count drift fix (NEW HOTFIX)** | **High** | **Pre-launch credibility risk** | **High — visible on production homepage today** |
+| **Phase 3 checklist update (NEW HOTFIX)** | **High** | **Risk of skipping 7 untested tools** | **High — first paying users are the canaries otherwise** |
+| Phase 4.1 Stripe live cutover | High | Sequential blocker | Real — turns on revenue |
+| Phase 4.2 legal sign-off | High | Sequential blocker | Real — regulatory |
+| Phase 4.3 custom domain (api subdomain) | Med | Not announcement-blocking | Cosmetic |
+| Phase 4.4 backups | Med | Should run in parallel | Zero (insurance) |
+| Phase 5 alerts + uptime | Low | None — Phase 5 | Zero pre-launch |
+| SOC 2 deferrals | Low | None — deferred | Zero — no website refs |
+
+---
+
+## Final word
+
+The CEO's instinct to ship 18 tools rather than 12 was the right call commercially. The execution missed two data files. Fix those two files, name-list the 7 promoted tools in the Phase 3 checklist, and the punch list to launch is just legal + Stripe live keys. The product is ready. The pipeline is ready. The marketing surface needs 2 hours of cleanup and then the launch story is internally consistent.
+
+— MarketScout, 2026-04-24

--- a/reports/audit-security-2026-04-24.md
+++ b/reports/audit-security-2026-04-24.md
@@ -1,0 +1,240 @@
+# Security Review — Paciolus v2.1.0
+**Date:** 2026-04-24
+**Reviewer:** IntegratorLead (security-review skill)
+**Branch:** `sprint-716-complete-status`
+**Scope:** Auth surface, upload surface, export/share surface, billing webhook, SQL injection, XSS/CSP, secret exposure
+**Mode:** Pre-Stripe-cutover hardening (CEO Phase 3 functional validation underway)
+
+---
+
+## Findings Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High     | 1 |
+| Medium   | 3 |
+| Low      | 3 |
+| Info     | 2 |
+
+The codebase shows mature defense-in-depth: HMAC-signed CSRF, Argon2id passcode KDF (Sprint 697), per-IP + per-token brute-force throttle on share downloads (Sprints 697/698), defusedxml on OFX, archive-bomb detection on XLSX, parameterized SQL throughout audit ingest, formula-injection sanitizer on CSV/Excel exports, refresh-token rotation with reuse detection + atomic CAS, fail-closed Redis rate limiter in production. Origin/Referer allow-list + Sec-Fetch-Site fallback close the cookie-only CSRF gap that the user-binding miss (H-01) opens.
+
+The most actionable finding (H-01) is one missed code path in the CSRF middleware — it reads only the `Authorization: Bearer` header to derive `expected_user_id`, so production browsers (which use the HttpOnly `paciolus_access` cookie and never send Bearer) silently bypass the user-binding check the rest of the system advertises.
+
+---
+
+## H-01 (HIGH) — CSRF user-binding silently disabled for browser cookie auth
+
+**File:** `backend/security_middleware.py:485-509` (`_extract_user_id_from_auth`) → consumed at lines 537, 562, 595
+**Frontend confirmation:** `frontend/src/utils/authMiddleware.ts:71-83` (`injectAuthHeaders` deliberately omits `Authorization`)
+**Severity:** HIGH (defense-in-depth bypass; not directly exploitable today, becomes exploitable on first XSS or token-leak)
+
+### Vulnerability
+`_extract_user_id_from_auth` only inspects `Authorization: Bearer …` to recover the user_id used in CSRF token binding. The production browser path mints HttpOnly `paciolus_access` and `paciolus_refresh` cookies (see `backend/routes/auth_routes.py:107-122`) and the frontend explicitly does NOT inject a Bearer header (`authMiddleware.ts:64-67`). Result: for every browser POST/PUT/DELETE/PATCH, `expected_user_id = None` is passed into `validate_csrf_token` (line 537/595), which then short-circuits the binding check at `security_middleware.py:427` (`if expected_user_id is not None …`).
+
+The CSRF token format is documented (line 357) as `{nonce}:{ts}:{user_id}:{hmac}` and the per-request mint embeds the issuing user. That binding is the entire reason the token is user-scoped rather than session-scoped. Today, in production, any leaked/stolen valid CSRF token is replayable against any other authenticated user's cookie session for 30 minutes (the token TTL).
+
+### Exploit scenario
+1. Attacker obtains *any* valid CSRF token issued in the last 30 min (XSS payload that can read DOM but not the HttpOnly cookie, log scraping of `console.log(headers)` from a partner integration, accidental Sentry breadcrumb leak, etc.).
+2. Victim browser also has a live `paciolus_access` cookie session (different user).
+3. Attacker convinces victim to load attacker-controlled page on a same-site subdomain that bypasses Origin allow-listing (e.g. SSRF on a Sentry DSN-style endpoint, or a future subdomain misconfiguration).
+4. Page POSTs to `/clients`, `/engagements/{id}` etc. carrying the leaked CSRF token. CSRF middleware accepts it (origin allow-listed, HMAC valid, not-expired) and the request mutates state under the victim's identity.
+
+The HMAC + 30-min expiry + Origin allow-list still hold, so this is not a 1-click compromise. But the user-binding is the documented ceiling of CSRF defense and it is silently a no-op.
+
+### Remediation
+Augment `_extract_user_id_from_auth` to read the access cookie when no Bearer is present:
+
+```python
+def _extract_user_id_from_auth(self, request: Request) -> Optional[str]:
+    import jwt as _jwt
+    from config import ACCESS_COOKIE_NAME, JWT_ALGORITHM, JWT_SECRET_KEY
+
+    auth = request.headers.get("Authorization", "")
+    token = auth[7:] if auth.startswith("Bearer ") else request.cookies.get(ACCESS_COOKIE_NAME)
+    if not token:
+        return None
+    try:
+        payload = _jwt.decode(
+            token, JWT_SECRET_KEY or "",
+            algorithms=[JWT_ALGORITHM],
+            options={"verify_exp": False},
+        )
+        sub = payload.get("sub")
+        return str(sub) if sub else None
+    except Exception:
+        return None
+```
+
+Add a regression test that exercises a cookie-only POST with a CSRF token issued for a different user_id and asserts a 403.
+
+---
+
+## M-01 (MEDIUM) — Refresh cookie uses `SameSite=None` in production
+
+**File:** `backend/routes/auth_routes.py:76-94` (`_set_refresh_cookie`), 107-122 (`_set_access_cookie`)
+**Severity:** MEDIUM (CSRF backstop weakened; Origin/Referer enforcement compensates)
+
+### Vulnerability
+The reviewer's stated requirement is `SameSite=Lax` in production. The code unconditionally selects `SameSite=None` whenever `COOKIE_SECURE` is true (production), to support cross-origin AJAX from `paciolus.com` → `paciolus-api.onrender.com`. The trade-off is documented (lines 80-85), but `SameSite=None` means the cookie is attached to *any* cross-site request the browser initiates to the API — including the cross-site GET that some forge-cookie attacks rely on.
+
+### Why it's MEDIUM not HIGH
+1. The CSRF middleware (`security_middleware.py:434-606`) enforces Origin/Referer allow-listing on every mutation method, blocking cross-site forgery even when the cookie is attached.
+2. Sec-Fetch-Site fallback (line 474-483) catches the rare browser that suppresses Origin/Referer.
+3. The refresh cookie is `path=/auth` only.
+
+### Exploit scenario
+Combined with H-01, a cross-site GET from a malicious page on a subdomain that ends up in `CORS_ORIGINS` (e.g. a future `staging.paciolus.com` slip-up) auto-attaches the refresh cookie, and a token with no user binding is replayable.
+
+### Remediation
+- Move the API to a same-site domain (`api.paciolus.com`) so `SameSite=Lax` becomes viable. CEO has been planning custom domain anyway; this is the security argument for prioritizing it before scale-out.
+- Until then: keep H-01 fixed (user binding is the real backstop), and document this in `docs/04-compliance/SECURITY_POLICY.md` as a known trade-off.
+
+---
+
+## M-02 (MEDIUM) — Share endpoint leaks existence of passcode-protected shares
+
+**File:** `backend/routes/export_sharing.py:471-481` (`download_share` GET handler)
+**Severity:** MEDIUM (information disclosure → enables targeted brute-force)
+
+### Vulnerability
+`GET /export-sharing/{token}` distinguishes three states:
+- 404 — token doesn't exist or is revoked
+- 410 — exists but expired
+- 403 — exists, valid, has a passcode
+
+An attacker sweeping share-token guesses can enumerate which (small fraction of) tokens are passcode-protected vs. open. A 403 result tells them "this token exists and is worth sustained brute-force on POST /download" — collapsing a 256-bit search down to whichever tokens they happened to hit. Token brute-force is bounded by 32-byte URL-safe random (`secrets.token_urlsafe(32)`), which is comfortably out of reach in absolute terms — but the asymmetry encourages targeted abuse where `RATE_LIMIT_EXPORT` (20-120/min) becomes the only barrier.
+
+### Exploit scenario
+Attacker scripts random-token GET requests from a botnet. Each 403 response identifies a real passcode share. They concentrate POST /download attacks on those tokens, riding under the per-token throttle (5 attempts before lockout) by switching tokens often.
+
+### Remediation
+Return 404 unconditionally on GET when a passcode is required, and surface the "use POST" hint only on the POST path. The information leakage from the 403 message ("This share link requires a passcode...") provides no usability benefit — legitimate users always have the share URL+passcode together because the creator gave them both.
+
+```python
+if share.passcode_hash:
+    # Sprint 698: do not differentiate from "no such share" — enumeration defense
+    raise HTTPException(status_code=404, detail="Share link not found.")
+```
+
+Update the frontend share-recipient UI to always POST first; if 404, show "link expired/invalid"; if 403, show passcode prompt.
+
+---
+
+## M-03 (MEDIUM) — Per-IP failure tracker is in-memory only, resets on restart
+
+**File:** `backend/security_middleware.py:619-674` (`record_ip_failure`, `check_ip_blocked`, `_ip_failure_tracker`)
+**Severity:** MEDIUM (rate-limit weakened by deploys/scale-out)
+
+### Vulnerability
+`_ip_failure_tracker` is a process-local `dict[str, list[float]]`. Under Render's auto-restart on deploy and Gunicorn's multi-worker model, the per-IP brute-force gate (Sprint 697 finding #2 / Sprint 698) is reset every deploy and is not shared across workers. An attacker who notices a deploy can reset their counter; an attacker hitting a different worker also gets a fresh counter.
+
+The auth-failure DB-backed lockout (`record_failed_login` line 677) is not affected — it persists in `users.failed_login_attempts`. But the IP-level guard for `/auth/login` and `/export-sharing/{token}/download` only applies in-memory.
+
+### Exploit scenario
+Attacker times credential-stuffing against `/auth/login` to coincide with deploy windows (Render shows deploy times). 20 failures per IP per worker per 15 minutes × N workers × M deploys/day grants meaningful throughput.
+
+### Remediation
+Move `_ip_failure_tracker` to Redis using the same backend that backs `slowapi`. The existing storage URI is already resolved in `shared/rate_limits.py:207-249`. Use a sliding-window key per IP with TTL = `IP_FAILURE_WINDOW_SECONDS`.
+
+---
+
+## L-01 (LOW) — Org co-members can delete each other's clients without role check
+
+**File:** `backend/client_manager.py:69-100` (`get_client`), `285-299` (`delete_client`)
+**Routes:** `backend/routes/clients.py:272-284` (DELETE), `216-269` (PUT)
+**Severity:** LOW (could be intentional org-sharing policy; depends on PM intent)
+
+### Vulnerability
+`get_client(user_id, client_id)` returns the client whether the caller is the direct owner OR any organization co-member of the owner. Both `update_client` and `delete_client` build on `get_client`, so any org member (regardless of `OrgRole`) can mutate or delete clients owned by another org member.
+
+In the admin dashboard endpoints (`routes/admin_dashboard.py:60-62`), there's an explicit `OWNER`/`ADMIN` check. No equivalent check exists in the client routes — an `OrgRole.MEMBER` can delete the org owner's client.
+
+### Exploit scenario
+Disgruntled junior auditor at a 10-seat firm deletes the partner's clients minutes before resigning. Soft-delete may save the data (per Sprint 360 immutability guarantees) but workflow disruption is real.
+
+### Remediation
+Decide PM intent first. If write operations should require role ≥ ADMIN within the org, add a role check in `update_client`/`delete_client`. If shared write is intentional (likely), add an audit log entry per mutation that records both the actor and the owner so post-incident attribution is unambiguous.
+
+---
+
+## L-02 (LOW) — Excel `.upper()` on materiality without sanitization
+
+**File:** `backend/excel_generator.py:321-322`
+**Severity:** LOW (data path is engine-controlled; not user-injectable today)
+
+### Vulnerability
+`materiality = ab.get("materiality", "unknown"); ws.cell(...).value = materiality.upper()` writes a raw string to an Excel cell without `sanitize_csv_value`. Today the materiality values come from `audit_engine.py` as a fixed enum (`material`/`immaterial`/`unknown`), so this isn't exploitable. But the rest of the file consistently calls `sanitize_csv_value` on user-derived strings, and the inconsistency would mask formula injection if the contract ever loosens.
+
+### Remediation
+Wrap with `sanitize_csv_value(materiality.upper())` for consistency and defense-in-depth.
+
+---
+
+## L-03 (LOW) — Login response timing can leak account existence under load
+
+**File:** `backend/routes/auth_routes.py:268-301`
+**Severity:** LOW (mitigated by lockout returning identical 401; timing channel is narrow)
+
+### Vulnerability
+The login flow conditionally calls `record_failed_login(db, existing_user.id)` on line 295 when an existing user supplies a wrong password, but skips the DB write when the email is unknown. Under load this yields a measurable timing difference (DB UPDATE vs. branch skip), which could be used for slow account enumeration.
+
+### Why it's LOW
+- The 401 detail is identical for both paths (line 297-301).
+- bcrypt verification on the existing-but-wrong-password path dominates timing (~250ms) and itself differentiates from "user not found, no bcrypt call" — that's the bigger leak.
+- Public guidance: do a fake bcrypt verify on the unknown-email path to equalize. Code already does this implicitly via `authenticate_user` returning `None` early.
+
+Actually re-reading: `authenticate_user` does NOT call bcrypt when the user doesn't exist (line 528-530 returns immediately). So unknown-email is much faster than known-email-wrong-password.
+
+### Remediation
+Add a fake bcrypt comparison in `authenticate_user` when the user doesn't exist:
+
+```python
+if user is None:
+    # Constant-time defense against account enumeration via timing
+    _bcrypt.checkpw(b"dummy", b"$2b$12$" + b"X" * 53)  # ~same cost as real verify
+    log_secure_operation(...)
+    return None
+```
+
+---
+
+## INFO-01 — Stripe webhook handler is solid
+
+**File:** `backend/routes/billing.py:345-449` (`stripe_webhook`)
+
+Signature verification via `stripe.Webhook.construct_event` (line 375), atomic dedup via `INSERT ... ON CONFLICT DO NOTHING` on `ProcessedWebhookEvent` (lines 396-414), correct 400/500 status discrimination so Stripe retries operational errors but not malformed/forged ones, CSRF-exempt by allowlist (`security_middleware.py:314`). No findings.
+
+## INFO-02 — Upload pipeline is well-defended
+
+**File:** `backend/shared/upload_pipeline.py`, `backend/shared/ofx_parser.py`, `backend/shared/pdf_parser.py`
+
+10-step ingress validation (size, content-type, extension, magic bytes, archive-bomb, XML-bomb, row/col/cell caps, formula-injection sanitization on export). XLSX archive inspection enforces ≤10K entries, ≤1GB uncompressed, ≤100:1 ratio, and scans embedded XML for `<!DOCTYPE>`/`<!ENTITY>`. OFX uses `defusedxml.ElementTree` with explicit XML-bomb prefix scan. openpyxl loaded with `read_only=True, data_only=True, keep_vba=False, keep_links=False`. xlrd 2.x dropped formula support. PDF parsed via pdfplumber with per-page 5s timeout and 500-page cap. No findings on this surface.
+
+---
+
+## Notes on Anti-patterns NOT found
+
+- No `dangerouslySetInnerHTML` anywhere in `frontend/src` (clean).
+- No f-string SQL with user input. The two `f"ALTER TABLE ... ADD COLUMN {col_name} {col_type}"` sites in `database.py:190` and `:251` use a hardcoded allowlist — safe DDL.
+- No hardcoded secrets, Stripe keys, or AWS credentials in source. `.env.example` files contain only placeholder text (`sk_test_...`, `whsec_...`).
+- CSP nonce-based, dynamic per-request via `frontend/src/proxy.ts`. `'strict-dynamic'` removes host-allowlist attack surface. No `'unsafe-eval'` in production.
+- Refresh-token rotation includes atomic CAS (`auth.py:738-752`) — race-safe against concurrent refresh.
+- Account lockout and IP-failure tracking compose correctly (`auth_routes.py:281-302`).
+- Argon2id parameters meet OWASP 2024 (time_cost=3, memory=64MiB, parallelism=4) per `passcode_security.py:51-63`.
+
+---
+
+## Recommended Triage Order
+
+1. **H-01** — fix before Stripe cutover. ~1 hour: edit `_extract_user_id_from_auth`, add cookie-fallback test, redeploy.
+2. **M-02** — cheap UX improvement that closes an enumeration channel. ~1 hour.
+3. **M-03** — Redis migration for IP failure tracker. ~2-4 hours, requires storage-key collision design with slowapi prefix.
+4. **L-03** — fake bcrypt verify on unknown-email login. ~30 min.
+5. **L-01** — clarify org-RBAC intent with CEO before coding.
+6. **M-01** — track as known trade-off; tie to api.paciolus.com domain migration.
+7. **L-02** — drop into next batch refactor.
+
+---
+
+*End of report.*

--- a/reports/nightly/.baseline.json
+++ b/reports/nightly/.baseline.json
@@ -1,24 +1,29 @@
 {
   "qa_warden": {
-    "date": "2026-04-22",
+    "date": "2026-04-27",
     "backend": {
-      "passed": 8046,
-      "failed": 0,
+      "passed": 8472,
+      "failed": 4,
       "errors": 0,
-      "duration_s": 607.7,
-      "failing_tests": [],
+      "duration_s": 745.9,
+      "failing_tests": [
+        "tests/test_security_hardening_2026_04_20.py::TestCSRFRefreshLogout::test_production_rejects_x_requested_with_only[asyncio]",
+        "tests/test_security_hardening_2026_04_20.py::TestCSRFRefreshLogout::test_dev_still_accepts_x_requested_with[asyncio]",
+        "tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_strict_mode_defaults_true_in_production",
+        "tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_valid_override_allowed"
+      ],
       "collection_error": null,
       "new_failures": [],
       "resolved": []
     },
     "frontend": {
-      "passed": 1887,
+      "passed": 1937,
       "failed": 0,
-      "duration_s": 47.1
+      "duration_s": 21.9
     }
   },
   "report_auditor": {
-    "date": "2026-04-22",
+    "date": "2026-04-27",
     "bug_tracker": {
       "BUG-001": {
         "description": "Suggested procedures rotation bug \u2014 procedures repeat rather than rotate across reports",
@@ -58,7 +63,7 @@
     }
   },
   "coverage_sentinel": {
-    "date": "2026-04-22",
+    "date": "2026-04-27",
     "history": [
       {
         "date": "2026-04-14",
@@ -87,7 +92,26 @@
       {
         "date": "2026-04-22",
         "percent_covered": 92.71
+      },
+      {
+        "date": "2026-04-25",
+        "percent_covered": 92.83
+      },
+      {
+        "date": "2026-04-26",
+        "percent_covered": 92.82
+      },
+      {
+        "date": "2026-04-27",
+        "percent_covered": 92.85
       }
     ]
+  },
+  "dependency_sentinel": {
+    "first_seen": {
+      "backend:cryptography@47.0.0": "2026-04-26",
+      "backend:fastapi@0.136.1": "2026-04-26",
+      "backend:stripe@15.1.0": "2026-04-26"
+    }
   }
 }

--- a/reports/nightly/.coverage_sentinel_2026-04-23.json
+++ b/reports/nightly/.coverage_sentinel_2026-04-23.json
@@ -1,0 +1,110 @@
+{
+  "agent": "coverage_sentinel",
+  "status": "green",
+  "percent_covered": 92.71,
+  "covered_lines": 88974,
+  "num_statements": 95974,
+  "missing_lines": 7000,
+  "rolling_mean_pct": 92.46,
+  "delta_pp": 0.25,
+  "rolling_window_days": 7,
+  "history": [
+    {
+      "date": "2026-04-14",
+      "percent_covered": 92.09
+    },
+    {
+      "date": "2026-04-15",
+      "percent_covered": 92.1
+    },
+    {
+      "date": "2026-04-17",
+      "percent_covered": 92.23
+    },
+    {
+      "date": "2026-04-19",
+      "percent_covered": 92.66
+    },
+    {
+      "date": "2026-04-20",
+      "percent_covered": 92.66
+    },
+    {
+      "date": "2026-04-21",
+      "percent_covered": 92.8
+    },
+    {
+      "date": "2026-04-22",
+      "percent_covered": 92.71
+    },
+    {
+      "date": "2026-04-23",
+      "percent_covered": 92.71
+    }
+  ],
+  "top_uncovered_files": [
+    {
+      "path": "excel_generator.py",
+      "percent_covered": 45.7,
+      "missing_lines": 328,
+      "num_statements": 604
+    },
+    {
+      "path": "billing\\webhook_handler.py",
+      "percent_covered": 57.37,
+      "missing_lines": 185,
+      "num_statements": 434
+    },
+    {
+      "path": "population_profile_memo.py",
+      "percent_covered": 39.72,
+      "missing_lines": 170,
+      "num_statements": 282
+    },
+    {
+      "path": "workbook_inspector.py",
+      "percent_covered": 18.56,
+      "missing_lines": 136,
+      "num_statements": 167
+    },
+    {
+      "path": "pdf\\sections\\diagnostic.py",
+      "percent_covered": 64.92,
+      "missing_lines": 134,
+      "num_statements": 382
+    },
+    {
+      "path": "leadsheet_generator.py",
+      "percent_covered": 11.43,
+      "missing_lines": 124,
+      "num_statements": 140
+    },
+    {
+      "path": "scripts\\create_dev_user.py",
+      "percent_covered": 0.0,
+      "missing_lines": 111,
+      "num_statements": 111
+    },
+    {
+      "path": "config.py",
+      "percent_covered": 54.5,
+      "missing_lines": 96,
+      "num_statements": 211
+    },
+    {
+      "path": "main.py",
+      "percent_covered": 44.24,
+      "missing_lines": 92,
+      "num_statements": 165
+    },
+    {
+      "path": "preflight_engine.py",
+      "percent_covered": 84.14,
+      "missing_lines": 79,
+      "num_statements": 498
+    }
+  ],
+  "non_production_excluded": 3,
+  "reasons": [],
+  "summary": "Backend coverage: 92.71% (88,974/95,974 statements, 7,000 uncovered). 7-day mean: 92.46% (+0.25pp). Non-production excluded: 3 file(s)."
+}

--- a/reports/nightly/.coverage_sentinel_2026-04-24.json
+++ b/reports/nightly/.coverage_sentinel_2026-04-24.json
@@ -1,0 +1,114 @@
+{
+  "agent": "coverage_sentinel",
+  "status": "green",
+  "percent_covered": 92.89,
+  "covered_lines": 90088,
+  "num_statements": 96980,
+  "missing_lines": 6892,
+  "rolling_mean_pct": 92.55,
+  "delta_pp": 0.34,
+  "rolling_window_days": 7,
+  "history": [
+    {
+      "date": "2026-04-14",
+      "percent_covered": 92.09
+    },
+    {
+      "date": "2026-04-15",
+      "percent_covered": 92.1
+    },
+    {
+      "date": "2026-04-17",
+      "percent_covered": 92.23
+    },
+    {
+      "date": "2026-04-19",
+      "percent_covered": 92.66
+    },
+    {
+      "date": "2026-04-20",
+      "percent_covered": 92.66
+    },
+    {
+      "date": "2026-04-21",
+      "percent_covered": 92.8
+    },
+    {
+      "date": "2026-04-22",
+      "percent_covered": 92.71
+    },
+    {
+      "date": "2026-04-23",
+      "percent_covered": 92.71
+    },
+    {
+      "date": "2026-04-24",
+      "percent_covered": 92.89
+    }
+  ],
+  "top_uncovered_files": [
+    {
+      "path": "excel_generator.py",
+      "percent_covered": 45.7,
+      "missing_lines": 328,
+      "num_statements": 604
+    },
+    {
+      "path": "billing\\webhook_handler.py",
+      "percent_covered": 57.37,
+      "missing_lines": 185,
+      "num_statements": 434
+    },
+    {
+      "path": "population_profile_memo.py",
+      "percent_covered": 39.72,
+      "missing_lines": 170,
+      "num_statements": 282
+    },
+    {
+      "path": "workbook_inspector.py",
+      "percent_covered": 18.56,
+      "missing_lines": 136,
+      "num_statements": 167
+    },
+    {
+      "path": "pdf\\sections\\diagnostic.py",
+      "percent_covered": 64.92,
+      "missing_lines": 134,
+      "num_statements": 382
+    },
+    {
+      "path": "leadsheet_generator.py",
+      "percent_covered": 11.43,
+      "missing_lines": 124,
+      "num_statements": 140
+    },
+    {
+      "path": "scripts\\create_dev_user.py",
+      "percent_covered": 0.0,
+      "missing_lines": 111,
+      "num_statements": 111
+    },
+    {
+      "path": "config.py",
+      "percent_covered": 54.5,
+      "missing_lines": 96,
+      "num_statements": 211
+    },
+    {
+      "path": "main.py",
+      "percent_covered": 44.24,
+      "missing_lines": 92,
+      "num_statements": 165
+    },
+    {
+      "path": "preflight_engine.py",
+      "percent_covered": 84.14,
+      "missing_lines": 79,
+      "num_statements": 498
+    }
+  ],
+  "non_production_excluded": 3,
+  "reasons": [],
+  "summary": "Backend coverage: 92.89% (90,088/96,980 statements, 6,892 uncovered). 7-day mean: 92.55% (+0.34pp). Non-production excluded: 3 file(s)."
+}

--- a/reports/nightly/.coverage_sentinel_2026-04-25.json
+++ b/reports/nightly/.coverage_sentinel_2026-04-25.json
@@ -1,0 +1,110 @@
+{
+  "agent": "coverage_sentinel",
+  "status": "green",
+  "percent_covered": 92.83,
+  "covered_lines": 90720,
+  "num_statements": 97722,
+  "missing_lines": 7002,
+  "rolling_mean_pct": 92.46,
+  "delta_pp": 0.37,
+  "rolling_window_days": 7,
+  "history": [
+    {
+      "date": "2026-04-14",
+      "percent_covered": 92.09
+    },
+    {
+      "date": "2026-04-15",
+      "percent_covered": 92.1
+    },
+    {
+      "date": "2026-04-17",
+      "percent_covered": 92.23
+    },
+    {
+      "date": "2026-04-19",
+      "percent_covered": 92.66
+    },
+    {
+      "date": "2026-04-20",
+      "percent_covered": 92.66
+    },
+    {
+      "date": "2026-04-21",
+      "percent_covered": 92.8
+    },
+    {
+      "date": "2026-04-22",
+      "percent_covered": 92.71
+    },
+    {
+      "date": "2026-04-25",
+      "percent_covered": 92.83
+    }
+  ],
+  "top_uncovered_files": [
+    {
+      "path": "excel_generator.py",
+      "percent_covered": 45.7,
+      "missing_lines": 328,
+      "num_statements": 604
+    },
+    {
+      "path": "billing\\webhook_handler.py",
+      "percent_covered": 59.91,
+      "missing_lines": 174,
+      "num_statements": 434
+    },
+    {
+      "path": "population_profile_memo.py",
+      "percent_covered": 39.72,
+      "missing_lines": 170,
+      "num_statements": 282
+    },
+    {
+      "path": "workbook_inspector.py",
+      "percent_covered": 18.56,
+      "missing_lines": 136,
+      "num_statements": 167
+    },
+    {
+      "path": "pdf\\sections\\diagnostic.py",
+      "percent_covered": 64.92,
+      "missing_lines": 134,
+      "num_statements": 382
+    },
+    {
+      "path": "leadsheet_generator.py",
+      "percent_covered": 11.43,
+      "missing_lines": 124,
+      "num_statements": 140
+    },
+    {
+      "path": "scripts\\create_dev_user.py",
+      "percent_covered": 0.0,
+      "missing_lines": 111,
+      "num_statements": 111
+    },
+    {
+      "path": "config.py",
+      "percent_covered": 57.39,
+      "missing_lines": 98,
+      "num_statements": 230
+    },
+    {
+      "path": "main.py",
+      "percent_covered": 44.24,
+      "missing_lines": 92,
+      "num_statements": 165
+    },
+    {
+      "path": "routes\\internal_admin.py",
+      "percent_covered": 55.43,
+      "missing_lines": 82,
+      "num_statements": 184
+    }
+  ],
+  "non_production_excluded": 3,
+  "reasons": [],
+  "summary": "Backend coverage: 92.83% (90,720/97,722 statements, 7,002 uncovered). 7-day mean: 92.46% (+0.37pp). Non-production excluded: 3 file(s)."
+}

--- a/reports/nightly/.coverage_sentinel_2026-04-26.json
+++ b/reports/nightly/.coverage_sentinel_2026-04-26.json
@@ -1,0 +1,114 @@
+{
+  "agent": "coverage_sentinel",
+  "status": "green",
+  "percent_covered": 92.82,
+  "covered_lines": 91483,
+  "num_statements": 98556,
+  "missing_lines": 7073,
+  "rolling_mean_pct": 92.57,
+  "delta_pp": 0.25,
+  "rolling_window_days": 7,
+  "history": [
+    {
+      "date": "2026-04-14",
+      "percent_covered": 92.09
+    },
+    {
+      "date": "2026-04-15",
+      "percent_covered": 92.1
+    },
+    {
+      "date": "2026-04-17",
+      "percent_covered": 92.23
+    },
+    {
+      "date": "2026-04-19",
+      "percent_covered": 92.66
+    },
+    {
+      "date": "2026-04-20",
+      "percent_covered": 92.66
+    },
+    {
+      "date": "2026-04-21",
+      "percent_covered": 92.8
+    },
+    {
+      "date": "2026-04-22",
+      "percent_covered": 92.71
+    },
+    {
+      "date": "2026-04-25",
+      "percent_covered": 92.83
+    },
+    {
+      "date": "2026-04-26",
+      "percent_covered": 92.82
+    }
+  ],
+  "top_uncovered_files": [
+    {
+      "path": "excel_generator.py",
+      "percent_covered": 45.7,
+      "missing_lines": 328,
+      "num_statements": 604
+    },
+    {
+      "path": "billing\\webhook_handler.py",
+      "percent_covered": 59.91,
+      "missing_lines": 174,
+      "num_statements": 434
+    },
+    {
+      "path": "population_profile_memo.py",
+      "percent_covered": 39.72,
+      "missing_lines": 170,
+      "num_statements": 282
+    },
+    {
+      "path": "workbook_inspector.py",
+      "percent_covered": 18.56,
+      "missing_lines": 136,
+      "num_statements": 167
+    },
+    {
+      "path": "pdf\\sections\\diagnostic.py",
+      "percent_covered": 64.92,
+      "missing_lines": 134,
+      "num_statements": 382
+    },
+    {
+      "path": "leadsheet_generator.py",
+      "percent_covered": 11.27,
+      "missing_lines": 126,
+      "num_statements": 142
+    },
+    {
+      "path": "scripts\\create_dev_user.py",
+      "percent_covered": 0.0,
+      "missing_lines": 111,
+      "num_statements": 111
+    },
+    {
+      "path": "config.py",
+      "percent_covered": 57.39,
+      "missing_lines": 98,
+      "num_statements": 230
+    },
+    {
+      "path": "main.py",
+      "percent_covered": 44.24,
+      "missing_lines": 92,
+      "num_statements": 165
+    },
+    {
+      "path": "routes\\internal_admin.py",
+      "percent_covered": 55.43,
+      "missing_lines": 82,
+      "num_statements": 184
+    }
+  ],
+  "non_production_excluded": 3,
+  "reasons": [],
+  "summary": "Backend coverage: 92.82% (91,483/98,556 statements, 7,073 uncovered). 7-day mean: 92.57% (+0.25pp). Non-production excluded: 3 file(s)."
+}

--- a/reports/nightly/.coverage_sentinel_2026-04-27.json
+++ b/reports/nightly/.coverage_sentinel_2026-04-27.json
@@ -1,0 +1,118 @@
+{
+  "agent": "coverage_sentinel",
+  "status": "green",
+  "percent_covered": 92.85,
+  "covered_lines": 93720,
+  "num_statements": 100932,
+  "missing_lines": 7212,
+  "rolling_mean_pct": 92.67,
+  "delta_pp": 0.18,
+  "rolling_window_days": 7,
+  "history": [
+    {
+      "date": "2026-04-14",
+      "percent_covered": 92.09
+    },
+    {
+      "date": "2026-04-15",
+      "percent_covered": 92.1
+    },
+    {
+      "date": "2026-04-17",
+      "percent_covered": 92.23
+    },
+    {
+      "date": "2026-04-19",
+      "percent_covered": 92.66
+    },
+    {
+      "date": "2026-04-20",
+      "percent_covered": 92.66
+    },
+    {
+      "date": "2026-04-21",
+      "percent_covered": 92.8
+    },
+    {
+      "date": "2026-04-22",
+      "percent_covered": 92.71
+    },
+    {
+      "date": "2026-04-25",
+      "percent_covered": 92.83
+    },
+    {
+      "date": "2026-04-26",
+      "percent_covered": 92.82
+    },
+    {
+      "date": "2026-04-27",
+      "percent_covered": 92.85
+    }
+  ],
+  "top_uncovered_files": [
+    {
+      "path": "excel_generator.py",
+      "percent_covered": 45.7,
+      "missing_lines": 328,
+      "num_statements": 604
+    },
+    {
+      "path": "billing\\webhook_handler.py",
+      "percent_covered": 59.91,
+      "missing_lines": 174,
+      "num_statements": 434
+    },
+    {
+      "path": "population_profile_memo.py",
+      "percent_covered": 39.72,
+      "missing_lines": 170,
+      "num_statements": 282
+    },
+    {
+      "path": "workbook_inspector.py",
+      "percent_covered": 18.56,
+      "missing_lines": 136,
+      "num_statements": 167
+    },
+    {
+      "path": "pdf\\sections\\diagnostic.py",
+      "percent_covered": 64.92,
+      "missing_lines": 134,
+      "num_statements": 382
+    },
+    {
+      "path": "leadsheet_generator.py",
+      "percent_covered": 11.27,
+      "missing_lines": 126,
+      "num_statements": 142
+    },
+    {
+      "path": "scripts\\create_dev_user.py",
+      "percent_covered": 0.0,
+      "missing_lines": 111,
+      "num_statements": 111
+    },
+    {
+      "path": "config.py",
+      "percent_covered": 57.39,
+      "missing_lines": 98,
+      "num_statements": 230
+    },
+    {
+      "path": "main.py",
+      "percent_covered": 44.24,
+      "missing_lines": 92,
+      "num_statements": 165
+    },
+    {
+      "path": "routes\\internal_admin.py",
+      "percent_covered": 55.43,
+      "missing_lines": 82,
+      "num_statements": 184
+    }
+  ],
+  "non_production_excluded": 3,
+  "reasons": [],
+  "summary": "Backend coverage: 92.85% (93,720/100,932 statements, 7,212 uncovered). 7-day mean: 92.67% (+0.18pp). Non-production excluded: 3 file(s)."
+}

--- a/reports/nightly/.coverage_sentinel_2026-04-28.json
+++ b/reports/nightly/.coverage_sentinel_2026-04-28.json
@@ -1,0 +1,110 @@
+{
+  "agent": "coverage_sentinel",
+  "status": "green",
+  "percent_covered": 93.13,
+  "covered_lines": 94151,
+  "num_statements": 101099,
+  "missing_lines": 6948,
+  "rolling_mean_pct": 92.46,
+  "delta_pp": 0.67,
+  "rolling_window_days": 7,
+  "history": [
+    {
+      "date": "2026-04-14",
+      "percent_covered": 92.09
+    },
+    {
+      "date": "2026-04-15",
+      "percent_covered": 92.1
+    },
+    {
+      "date": "2026-04-17",
+      "percent_covered": 92.23
+    },
+    {
+      "date": "2026-04-19",
+      "percent_covered": 92.66
+    },
+    {
+      "date": "2026-04-20",
+      "percent_covered": 92.66
+    },
+    {
+      "date": "2026-04-21",
+      "percent_covered": 92.8
+    },
+    {
+      "date": "2026-04-22",
+      "percent_covered": 92.71
+    },
+    {
+      "date": "2026-04-28",
+      "percent_covered": 93.13
+    }
+  ],
+  "top_uncovered_files": [
+    {
+      "path": "excel_generator.py",
+      "percent_covered": 45.7,
+      "missing_lines": 328,
+      "num_statements": 604
+    },
+    {
+      "path": "billing\\webhook_handler.py",
+      "percent_covered": 59.91,
+      "missing_lines": 174,
+      "num_statements": 434
+    },
+    {
+      "path": "population_profile_memo.py",
+      "percent_covered": 39.72,
+      "missing_lines": 170,
+      "num_statements": 282
+    },
+    {
+      "path": "workbook_inspector.py",
+      "percent_covered": 18.56,
+      "missing_lines": 136,
+      "num_statements": 167
+    },
+    {
+      "path": "pdf\\sections\\diagnostic.py",
+      "percent_covered": 64.92,
+      "missing_lines": 134,
+      "num_statements": 382
+    },
+    {
+      "path": "leadsheet_generator.py",
+      "percent_covered": 11.27,
+      "missing_lines": 126,
+      "num_statements": 142
+    },
+    {
+      "path": "scripts\\create_dev_user.py",
+      "percent_covered": 0.0,
+      "missing_lines": 111,
+      "num_statements": 111
+    },
+    {
+      "path": "config.py",
+      "percent_covered": 57.39,
+      "missing_lines": 98,
+      "num_statements": 230
+    },
+    {
+      "path": "main.py",
+      "percent_covered": 44.24,
+      "missing_lines": 92,
+      "num_statements": 165
+    },
+    {
+      "path": "routes\\internal_admin.py",
+      "percent_covered": 55.43,
+      "missing_lines": 82,
+      "num_statements": 184
+    }
+  ],
+  "non_production_excluded": 3,
+  "reasons": [],
+  "summary": "Backend coverage: 93.13% (94,151/101,099 statements, 6,948 uncovered). 7-day mean: 92.46% (+0.67pp). Non-production excluded: 3 file(s)."
+}

--- a/reports/nightly/.dependency_sentinel_2026-04-23.json
+++ b/reports/nightly/.dependency_sentinel_2026-04-23.json
@@ -1,0 +1,97 @@
+{
+  "agent": "dependency_sentinel",
+  "status": "green",
+  "backend_outdated": [
+    {
+      "package": "certifi",
+      "current": "2026.2.25",
+      "latest": "2026.4.22",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "click",
+      "current": "8.3.2",
+      "latest": "8.3.3",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pathspec",
+      "current": "1.0.4",
+      "latest": "1.1.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pdfminer.six",
+      "current": "20251230",
+      "latest": "20260107",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": true,
+      "deferral_reason": "Calendar-versioned release; waiting on downstream compatibility confirmation",
+      "deferral_review_by": "2026-04-30"
+    },
+    {
+      "package": "uvicorn",
+      "current": "0.45.0",
+      "latest": "0.46.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "frontend_outdated": [],
+  "security_flagged": [],
+  "deferred": [
+    {
+      "package": "pdfminer.six",
+      "current": "20251230",
+      "latest": "20260107",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": true,
+      "deferral_reason": "Calendar-versioned release; waiting on downstream compatibility confirmation",
+      "deferral_review_by": "2026-04-30"
+    }
+  ],
+  "top5_updates": [
+    {
+      "package": "certifi",
+      "current": "2026.2.25",
+      "latest": "2026.4.22",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pathspec",
+      "current": "1.0.4",
+      "latest": "1.1.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "uvicorn",
+      "current": "0.45.0",
+      "latest": "0.46.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "click",
+      "current": "8.3.2",
+      "latest": "8.3.3",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "summary": "Backend: 5 outdated. Frontend: 0 outdated. 0 security-relevant packages have updates. 1 deferred."
+}

--- a/reports/nightly/.dependency_sentinel_2026-04-24.json
+++ b/reports/nightly/.dependency_sentinel_2026-04-24.json
@@ -1,0 +1,163 @@
+{
+  "agent": "dependency_sentinel",
+  "status": "yellow",
+  "backend_outdated": [
+    {
+      "package": "anthropic",
+      "current": "0.96.0",
+      "latest": "0.97.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "certifi",
+      "current": "2026.2.25",
+      "latest": "2026.4.22",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "click",
+      "current": "8.3.2",
+      "latest": "8.3.3",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "fastapi",
+      "current": "0.136.0",
+      "latest": "0.136.1",
+      "severity": "patch",
+      "watchlist": true,
+      "deferred": false
+    },
+    {
+      "package": "hypothesis",
+      "current": "6.152.1",
+      "latest": "6.152.2",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pathspec",
+      "current": "1.0.4",
+      "latest": "1.1.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pdfminer.six",
+      "current": "20251230",
+      "latest": "20260107",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": true,
+      "deferral_reason": "Calendar-versioned release; waiting on downstream compatibility confirmation",
+      "deferral_review_by": "2026-04-30"
+    },
+    {
+      "package": "stripe",
+      "current": "15.0.1",
+      "latest": "15.1.0",
+      "severity": "minor",
+      "watchlist": true,
+      "deferred": false
+    },
+    {
+      "package": "uvicorn",
+      "current": "0.45.0",
+      "latest": "0.46.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "frontend_outdated": [
+    {
+      "package": "@sentry/nextjs",
+      "current": "10.49.0",
+      "latest": "10.50.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "security_flagged": [
+    {
+      "package": "fastapi",
+      "current": "0.136.0",
+      "latest": "0.136.1",
+      "severity": "patch",
+      "watchlist": true,
+      "deferred": false
+    },
+    {
+      "package": "stripe",
+      "current": "15.0.1",
+      "latest": "15.1.0",
+      "severity": "minor",
+      "watchlist": true,
+      "deferred": false
+    }
+  ],
+  "deferred": [
+    {
+      "package": "pdfminer.six",
+      "current": "20251230",
+      "latest": "20260107",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": true,
+      "deferral_reason": "Calendar-versioned release; waiting on downstream compatibility confirmation",
+      "deferral_review_by": "2026-04-30"
+    }
+  ],
+  "top5_updates": [
+    {
+      "package": "anthropic",
+      "current": "0.96.0",
+      "latest": "0.97.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "certifi",
+      "current": "2026.2.25",
+      "latest": "2026.4.22",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pathspec",
+      "current": "1.0.4",
+      "latest": "1.1.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "stripe",
+      "current": "15.0.1",
+      "latest": "15.1.0",
+      "severity": "minor",
+      "watchlist": true,
+      "deferred": false
+    },
+    {
+      "package": "uvicorn",
+      "current": "0.45.0",
+      "latest": "0.46.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "summary": "Backend: 9 outdated. Frontend: 1 outdated. 2 security-relevant packages have updates. 1 deferred."
+}

--- a/reports/nightly/.dependency_sentinel_2026-04-25.json
+++ b/reports/nightly/.dependency_sentinel_2026-04-25.json
@@ -1,0 +1,203 @@
+{
+  "agent": "dependency_sentinel",
+  "status": "red",
+  "backend_outdated": [
+    {
+      "package": "anthropic",
+      "current": "0.96.0",
+      "latest": "0.97.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "certifi",
+      "current": "2026.2.25",
+      "latest": "2026.4.22",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "click",
+      "current": "8.3.2",
+      "latest": "8.3.3",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "cryptography",
+      "current": "46.0.7",
+      "latest": "47.0.0",
+      "severity": "major",
+      "watchlist": true,
+      "deferred": false
+    },
+    {
+      "package": "fastapi",
+      "current": "0.136.0",
+      "latest": "0.136.1",
+      "severity": "patch",
+      "watchlist": true,
+      "deferred": false
+    },
+    {
+      "package": "hypothesis",
+      "current": "6.152.1",
+      "latest": "6.152.2",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "packaging",
+      "current": "26.1",
+      "latest": "26.2",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pathspec",
+      "current": "1.0.4",
+      "latest": "1.1.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pdfminer.six",
+      "current": "20251230",
+      "latest": "20260107",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": true,
+      "deferral_reason": "Calendar-versioned release; waiting on downstream compatibility confirmation",
+      "deferral_review_by": "2026-04-30"
+    },
+    {
+      "package": "ruff",
+      "current": "0.15.11",
+      "latest": "0.15.12",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "stripe",
+      "current": "15.0.1",
+      "latest": "15.1.0",
+      "severity": "minor",
+      "watchlist": true,
+      "deferred": false
+    },
+    {
+      "package": "tzdata",
+      "current": "2026.1",
+      "latest": "2026.2",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "uvicorn",
+      "current": "0.45.0",
+      "latest": "0.46.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "frontend_outdated": [
+    {
+      "package": "@sentry/nextjs",
+      "current": "10.49.0",
+      "latest": "10.50.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "security_flagged": [
+    {
+      "package": "cryptography",
+      "current": "46.0.7",
+      "latest": "47.0.0",
+      "severity": "major",
+      "watchlist": true,
+      "deferred": false
+    },
+    {
+      "package": "fastapi",
+      "current": "0.136.0",
+      "latest": "0.136.1",
+      "severity": "patch",
+      "watchlist": true,
+      "deferred": false
+    },
+    {
+      "package": "stripe",
+      "current": "15.0.1",
+      "latest": "15.1.0",
+      "severity": "minor",
+      "watchlist": true,
+      "deferred": false
+    }
+  ],
+  "deferred": [
+    {
+      "package": "pdfminer.six",
+      "current": "20251230",
+      "latest": "20260107",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": true,
+      "deferral_reason": "Calendar-versioned release; waiting on downstream compatibility confirmation",
+      "deferral_review_by": "2026-04-30"
+    }
+  ],
+  "top5_updates": [
+    {
+      "package": "cryptography",
+      "current": "46.0.7",
+      "latest": "47.0.0",
+      "severity": "major",
+      "watchlist": true,
+      "deferred": false
+    },
+    {
+      "package": "anthropic",
+      "current": "0.96.0",
+      "latest": "0.97.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "certifi",
+      "current": "2026.2.25",
+      "latest": "2026.4.22",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "packaging",
+      "current": "26.1",
+      "latest": "26.2",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pathspec",
+      "current": "1.0.4",
+      "latest": "1.1.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "summary": "Backend: 13 outdated. Frontend: 1 outdated. 3 security-relevant packages have updates. 1 deferred."
+}

--- a/reports/nightly/.dependency_sentinel_2026-04-26.json
+++ b/reports/nightly/.dependency_sentinel_2026-04-26.json
@@ -1,0 +1,225 @@
+{
+  "agent": "dependency_sentinel",
+  "status": "red",
+  "backend_outdated": [
+    {
+      "package": "anthropic",
+      "current": "0.96.0",
+      "latest": "0.97.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "certifi",
+      "current": "2026.2.25",
+      "latest": "2026.4.22",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "click",
+      "current": "8.3.2",
+      "latest": "8.3.3",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "cryptography",
+      "current": "46.0.7",
+      "latest": "47.0.0",
+      "severity": "major",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-26",
+      "days_outdated": 0,
+      "past_deadline": false
+    },
+    {
+      "package": "fastapi",
+      "current": "0.136.0",
+      "latest": "0.136.1",
+      "severity": "patch",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-26",
+      "days_outdated": 0,
+      "past_deadline": false
+    },
+    {
+      "package": "hypothesis",
+      "current": "6.152.1",
+      "latest": "6.152.2",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "packaging",
+      "current": "26.1",
+      "latest": "26.2",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pathspec",
+      "current": "1.0.4",
+      "latest": "1.1.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pdfminer.six",
+      "current": "20251230",
+      "latest": "20260107",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": true,
+      "deferral_reason": "Calendar-versioned release; waiting on downstream compatibility confirmation",
+      "deferral_review_by": "2026-04-30"
+    },
+    {
+      "package": "ruff",
+      "current": "0.15.11",
+      "latest": "0.15.12",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "stripe",
+      "current": "15.0.1",
+      "latest": "15.1.0",
+      "severity": "minor",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-26",
+      "days_outdated": 0,
+      "past_deadline": false
+    },
+    {
+      "package": "tzdata",
+      "current": "2026.1",
+      "latest": "2026.2",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "uvicorn",
+      "current": "0.45.0",
+      "latest": "0.46.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "frontend_outdated": [
+    {
+      "package": "@sentry/nextjs",
+      "current": "10.49.0",
+      "latest": "10.50.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "security_flagged": [
+    {
+      "package": "cryptography",
+      "current": "46.0.7",
+      "latest": "47.0.0",
+      "severity": "major",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-26",
+      "days_outdated": 0,
+      "past_deadline": false
+    },
+    {
+      "package": "fastapi",
+      "current": "0.136.0",
+      "latest": "0.136.1",
+      "severity": "patch",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-26",
+      "days_outdated": 0,
+      "past_deadline": false
+    },
+    {
+      "package": "stripe",
+      "current": "15.0.1",
+      "latest": "15.1.0",
+      "severity": "minor",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-26",
+      "days_outdated": 0,
+      "past_deadline": false
+    }
+  ],
+  "past_deadline": [],
+  "deferred": [
+    {
+      "package": "pdfminer.six",
+      "current": "20251230",
+      "latest": "20260107",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": true,
+      "deferral_reason": "Calendar-versioned release; waiting on downstream compatibility confirmation",
+      "deferral_review_by": "2026-04-30"
+    }
+  ],
+  "top5_updates": [
+    {
+      "package": "cryptography",
+      "current": "46.0.7",
+      "latest": "47.0.0",
+      "severity": "major",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-26",
+      "days_outdated": 0,
+      "past_deadline": false
+    },
+    {
+      "package": "anthropic",
+      "current": "0.96.0",
+      "latest": "0.97.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "certifi",
+      "current": "2026.2.25",
+      "latest": "2026.4.22",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "packaging",
+      "current": "26.1",
+      "latest": "26.2",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pathspec",
+      "current": "1.0.4",
+      "latest": "1.1.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "summary": "Backend: 13 outdated. Frontend: 1 outdated. 3 security-relevant packages have updates. 1 deferred."
+}

--- a/reports/nightly/.dependency_sentinel_2026-04-27.json
+++ b/reports/nightly/.dependency_sentinel_2026-04-27.json
@@ -1,0 +1,241 @@
+{
+  "agent": "dependency_sentinel",
+  "status": "red",
+  "backend_outdated": [
+    {
+      "package": "anthropic",
+      "current": "0.96.0",
+      "latest": "0.97.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "certifi",
+      "current": "2026.2.25",
+      "latest": "2026.4.22",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "click",
+      "current": "8.3.2",
+      "latest": "8.3.3",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "cryptography",
+      "current": "46.0.7",
+      "latest": "47.0.0",
+      "severity": "major",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-26",
+      "days_outdated": 1,
+      "past_deadline": false
+    },
+    {
+      "package": "fastapi",
+      "current": "0.136.0",
+      "latest": "0.136.1",
+      "severity": "patch",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-26",
+      "days_outdated": 1,
+      "past_deadline": false
+    },
+    {
+      "package": "hypothesis",
+      "current": "6.152.1",
+      "latest": "6.152.3",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "packaging",
+      "current": "26.1",
+      "latest": "26.2",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pathspec",
+      "current": "1.0.4",
+      "latest": "1.1.1",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pdfminer.six",
+      "current": "20251230",
+      "latest": "20260107",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": true,
+      "deferral_reason": "Calendar-versioned release; waiting on downstream compatibility confirmation",
+      "deferral_review_by": "2026-04-30"
+    },
+    {
+      "package": "pip",
+      "current": "26.0.1",
+      "latest": "26.1",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "ruff",
+      "current": "0.15.11",
+      "latest": "0.15.12",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "stripe",
+      "current": "15.0.1",
+      "latest": "15.1.0",
+      "severity": "minor",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-26",
+      "days_outdated": 1,
+      "past_deadline": false
+    },
+    {
+      "package": "tzdata",
+      "current": "2026.1",
+      "latest": "2026.2",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "uvicorn",
+      "current": "0.45.0",
+      "latest": "0.46.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "frontend_outdated": [
+    {
+      "package": "@sentry/nextjs",
+      "current": "10.49.0",
+      "latest": "10.50.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "postcss",
+      "current": "8.5.10",
+      "latest": "8.5.12",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "security_flagged": [
+    {
+      "package": "cryptography",
+      "current": "46.0.7",
+      "latest": "47.0.0",
+      "severity": "major",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-26",
+      "days_outdated": 1,
+      "past_deadline": false
+    },
+    {
+      "package": "fastapi",
+      "current": "0.136.0",
+      "latest": "0.136.1",
+      "severity": "patch",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-26",
+      "days_outdated": 1,
+      "past_deadline": false
+    },
+    {
+      "package": "stripe",
+      "current": "15.0.1",
+      "latest": "15.1.0",
+      "severity": "minor",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-26",
+      "days_outdated": 1,
+      "past_deadline": false
+    }
+  ],
+  "past_deadline": [],
+  "deferred": [
+    {
+      "package": "pdfminer.six",
+      "current": "20251230",
+      "latest": "20260107",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": true,
+      "deferral_reason": "Calendar-versioned release; waiting on downstream compatibility confirmation",
+      "deferral_review_by": "2026-04-30"
+    }
+  ],
+  "top5_updates": [
+    {
+      "package": "cryptography",
+      "current": "46.0.7",
+      "latest": "47.0.0",
+      "severity": "major",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-26",
+      "days_outdated": 1,
+      "past_deadline": false
+    },
+    {
+      "package": "anthropic",
+      "current": "0.96.0",
+      "latest": "0.97.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "certifi",
+      "current": "2026.2.25",
+      "latest": "2026.4.22",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "packaging",
+      "current": "26.1",
+      "latest": "26.2",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pathspec",
+      "current": "1.0.4",
+      "latest": "1.1.1",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "summary": "Backend: 14 outdated. Frontend: 2 outdated. 3 security-relevant packages have updates. 1 deferred."
+}

--- a/reports/nightly/.dependency_sentinel_2026-04-28.json
+++ b/reports/nightly/.dependency_sentinel_2026-04-28.json
@@ -1,0 +1,273 @@
+{
+  "agent": "dependency_sentinel",
+  "status": "red",
+  "backend_outdated": [
+    {
+      "package": "anthropic",
+      "current": "0.96.0",
+      "latest": "0.97.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "certifi",
+      "current": "2026.2.25",
+      "latest": "2026.4.22",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "click",
+      "current": "8.3.2",
+      "latest": "8.3.3",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "cryptography",
+      "current": "46.0.7",
+      "latest": "47.0.0",
+      "severity": "major",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-28",
+      "days_outdated": 0,
+      "past_deadline": false
+    },
+    {
+      "package": "fastapi",
+      "current": "0.136.0",
+      "latest": "0.136.1",
+      "severity": "patch",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-28",
+      "days_outdated": 0,
+      "past_deadline": false
+    },
+    {
+      "package": "greenlet",
+      "current": "3.4.0",
+      "latest": "3.5.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "hypothesis",
+      "current": "6.152.1",
+      "latest": "6.152.4",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "packaging",
+      "current": "26.1",
+      "latest": "26.2",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pathspec",
+      "current": "1.0.4",
+      "latest": "1.1.1",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "pdfminer.six",
+      "current": "20251230",
+      "latest": "20260107",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": true,
+      "deferral_reason": "Calendar-versioned release; waiting on downstream compatibility confirmation",
+      "deferral_review_by": "2026-04-30"
+    },
+    {
+      "package": "pip",
+      "current": "26.0.1",
+      "latest": "26.1",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "python-multipart",
+      "current": "0.0.26",
+      "latest": "0.0.27",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "ruff",
+      "current": "0.15.11",
+      "latest": "0.15.12",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "stripe",
+      "current": "15.0.1",
+      "latest": "15.1.0",
+      "severity": "minor",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-28",
+      "days_outdated": 0,
+      "past_deadline": false
+    },
+    {
+      "package": "tzdata",
+      "current": "2026.1",
+      "latest": "2026.2",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "uvicorn",
+      "current": "0.45.0",
+      "latest": "0.46.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "frontend_outdated": [
+    {
+      "package": "@sentry/nextjs",
+      "current": "10.49.0",
+      "latest": "10.50.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "@typescript-eslint/eslint-plugin",
+      "current": "8.59.0",
+      "latest": "8.59.1",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "@typescript-eslint/parser",
+      "current": "8.59.0",
+      "latest": "8.59.1",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "postcss",
+      "current": "8.5.10",
+      "latest": "8.5.12",
+      "severity": "patch",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "security_flagged": [
+    {
+      "package": "cryptography",
+      "current": "46.0.7",
+      "latest": "47.0.0",
+      "severity": "major",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-28",
+      "days_outdated": 0,
+      "past_deadline": false
+    },
+    {
+      "package": "fastapi",
+      "current": "0.136.0",
+      "latest": "0.136.1",
+      "severity": "patch",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-28",
+      "days_outdated": 0,
+      "past_deadline": false
+    },
+    {
+      "package": "stripe",
+      "current": "15.0.1",
+      "latest": "15.1.0",
+      "severity": "minor",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-28",
+      "days_outdated": 0,
+      "past_deadline": false
+    }
+  ],
+  "past_deadline": [],
+  "deferred": [
+    {
+      "package": "pdfminer.six",
+      "current": "20251230",
+      "latest": "20260107",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": true,
+      "deferral_reason": "Calendar-versioned release; waiting on downstream compatibility confirmation",
+      "deferral_review_by": "2026-04-30"
+    }
+  ],
+  "top5_updates": [
+    {
+      "package": "cryptography",
+      "current": "46.0.7",
+      "latest": "47.0.0",
+      "severity": "major",
+      "watchlist": true,
+      "deferred": false,
+      "first_seen": "2026-04-28",
+      "days_outdated": 0,
+      "past_deadline": false
+    },
+    {
+      "package": "anthropic",
+      "current": "0.96.0",
+      "latest": "0.97.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "certifi",
+      "current": "2026.2.25",
+      "latest": "2026.4.22",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "greenlet",
+      "current": "3.4.0",
+      "latest": "3.5.0",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    },
+    {
+      "package": "packaging",
+      "current": "26.1",
+      "latest": "26.2",
+      "severity": "minor",
+      "watchlist": false,
+      "deferred": false
+    }
+  ],
+  "summary": "Backend: 16 outdated. Frontend: 4 outdated. 3 security-relevant packages have updates. 1 deferred."
+}

--- a/reports/nightly/.qa_warden_2026-04-23.json
+++ b/reports/nightly/.qa_warden_2026-04-23.json
@@ -1,0 +1,20 @@
+{
+  "agent": "qa_warden",
+  "status": "green",
+  "backend": {
+    "passed": 8046,
+    "failed": 0,
+    "errors": 0,
+    "duration_s": 626.2,
+    "failing_tests": [],
+    "collection_error": null,
+    "new_failures": [],
+    "resolved": []
+  },
+  "frontend": {
+    "passed": 1887,
+    "failed": 0,
+    "duration_s": 39.1
+  },
+  "summary": "Backend: 8046 passed / 0 failed in 626.2s. Frontend: 1887 passed / 0 failed in 39.1s."
+}

--- a/reports/nightly/.qa_warden_2026-04-24.json
+++ b/reports/nightly/.qa_warden_2026-04-24.json
@@ -1,0 +1,20 @@
+{
+  "agent": "qa_warden",
+  "status": "green",
+  "backend": {
+    "passed": 8095,
+    "failed": 0,
+    "errors": 0,
+    "duration_s": 637.5,
+    "failing_tests": [],
+    "collection_error": null,
+    "new_failures": [],
+    "resolved": []
+  },
+  "frontend": {
+    "passed": 1915,
+    "failed": 0,
+    "duration_s": 49.8
+  },
+  "summary": "Backend: 8095 passed / 0 failed in 637.5s. Frontend: 1915 passed / 0 failed in 49.8s."
+}

--- a/reports/nightly/.qa_warden_2026-04-25.json
+++ b/reports/nightly/.qa_warden_2026-04-25.json
@@ -1,0 +1,34 @@
+{
+  "agent": "qa_warden",
+  "status": "red",
+  "backend": {
+    "passed": 8175,
+    "failed": 6,
+    "errors": 0,
+    "duration_s": 592.8,
+    "failing_tests": [
+      "tests/test_security_hardening_2026_04_20.py::TestPasscodeRoutePolicy::test_get_on_passcode_share_returns_403[asyncio]",
+      "tests/test_security_hardening_2026_04_20.py::TestPasscodeRoutePolicy::test_query_string_passcode_ignored[asyncio]",
+      "tests/test_security_hardening_2026_04_20.py::TestCSRFRefreshLogout::test_production_rejects_x_requested_with_only[asyncio]",
+      "tests/test_security_hardening_2026_04_20.py::TestCSRFRefreshLogout::test_dev_still_accepts_x_requested_with[asyncio]",
+      "tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_strict_mode_defaults_true_in_production",
+      "tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_valid_override_allowed"
+    ],
+    "collection_error": null,
+    "new_failures": [
+      "tests/test_security_hardening_2026_04_20.py::TestCSRFRefreshLogout::test_dev_still_accepts_x_requested_with[asyncio]",
+      "tests/test_security_hardening_2026_04_20.py::TestCSRFRefreshLogout::test_production_rejects_x_requested_with_only[asyncio]",
+      "tests/test_security_hardening_2026_04_20.py::TestPasscodeRoutePolicy::test_get_on_passcode_share_returns_403[asyncio]",
+      "tests/test_security_hardening_2026_04_20.py::TestPasscodeRoutePolicy::test_query_string_passcode_ignored[asyncio]",
+      "tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_strict_mode_defaults_true_in_production",
+      "tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_valid_override_allowed"
+    ],
+    "resolved": []
+  },
+  "frontend": {
+    "passed": 1915,
+    "failed": 0,
+    "duration_s": 46.5
+  },
+  "summary": "Backend: 8175 passed / 6 failed in 592.8s. Frontend: 1915 passed / 0 failed in 46.5s. 6 new failure(s) since yesterday."
+}

--- a/reports/nightly/.qa_warden_2026-04-26.json
+++ b/reports/nightly/.qa_warden_2026-04-26.json
@@ -1,0 +1,28 @@
+{
+  "agent": "qa_warden",
+  "status": "yellow",
+  "backend": {
+    "passed": 8316,
+    "failed": 4,
+    "errors": 0,
+    "duration_s": 632.7,
+    "failing_tests": [
+      "tests/test_security_hardening_2026_04_20.py::TestCSRFRefreshLogout::test_production_rejects_x_requested_with_only[asyncio]",
+      "tests/test_security_hardening_2026_04_20.py::TestCSRFRefreshLogout::test_dev_still_accepts_x_requested_with[asyncio]",
+      "tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_strict_mode_defaults_true_in_production",
+      "tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_valid_override_allowed"
+    ],
+    "collection_error": null,
+    "new_failures": [],
+    "resolved": [
+      "tests/test_security_hardening_2026_04_20.py::TestPasscodeRoutePolicy::test_get_on_passcode_share_returns_403[asyncio]",
+      "tests/test_security_hardening_2026_04_20.py::TestPasscodeRoutePolicy::test_query_string_passcode_ignored[asyncio]"
+    ]
+  },
+  "frontend": {
+    "passed": 1915,
+    "failed": 0,
+    "duration_s": 54.9
+  },
+  "summary": "Backend: 8316 passed / 4 failed in 632.7s. Frontend: 1915 passed / 0 failed in 54.9s. 2 failure(s) resolved."
+}

--- a/reports/nightly/.qa_warden_2026-04-27.json
+++ b/reports/nightly/.qa_warden_2026-04-27.json
@@ -1,0 +1,25 @@
+{
+  "agent": "qa_warden",
+  "status": "yellow",
+  "backend": {
+    "passed": 8472,
+    "failed": 4,
+    "errors": 0,
+    "duration_s": 745.9,
+    "failing_tests": [
+      "tests/test_security_hardening_2026_04_20.py::TestCSRFRefreshLogout::test_production_rejects_x_requested_with_only[asyncio]",
+      "tests/test_security_hardening_2026_04_20.py::TestCSRFRefreshLogout::test_dev_still_accepts_x_requested_with[asyncio]",
+      "tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_strict_mode_defaults_true_in_production",
+      "tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_valid_override_allowed"
+    ],
+    "collection_error": null,
+    "new_failures": [],
+    "resolved": []
+  },
+  "frontend": {
+    "passed": 1937,
+    "failed": 0,
+    "duration_s": 21.9
+  },
+  "summary": "Backend: 8472 passed / 4 failed in 745.9s. Frontend: 1937 passed / 0 failed in 21.9s."
+}

--- a/reports/nightly/.qa_warden_2026-04-28.json
+++ b/reports/nightly/.qa_warden_2026-04-28.json
@@ -1,0 +1,30 @@
+{
+  "agent": "qa_warden",
+  "status": "red",
+  "backend": {
+    "passed": 8481,
+    "failed": 4,
+    "errors": 0,
+    "duration_s": 750.2,
+    "failing_tests": [
+      "tests/test_no_helpers_reexports.py::TestNoHelpersReexports::test_no_disallowed_imports",
+      "tests/test_no_helpers_reexports.py::TestNoHelpersReexports::test_allowlist_matches_helpers_module_publics",
+      "tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_strict_mode_defaults_true_in_production",
+      "tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_valid_override_allowed"
+    ],
+    "collection_error": null,
+    "new_failures": [
+      "tests/test_no_helpers_reexports.py::TestNoHelpersReexports::test_allowlist_matches_helpers_module_publics",
+      "tests/test_no_helpers_reexports.py::TestNoHelpersReexports::test_no_disallowed_imports",
+      "tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_strict_mode_defaults_true_in_production",
+      "tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_valid_override_allowed"
+    ],
+    "resolved": []
+  },
+  "frontend": {
+    "passed": 1957,
+    "failed": 0,
+    "duration_s": 49.8
+  },
+  "summary": "Backend: 8481 passed / 4 failed in 750.2s. Frontend: 1957 passed / 0 failed in 49.8s. 4 new failure(s) since yesterday."
+}

--- a/reports/nightly/.report_auditor_2026-04-23.json
+++ b/reports/nightly/.report_auditor_2026-04-23.json
@@ -1,0 +1,48 @@
+{
+  "agent": "report_auditor",
+  "status": "green",
+  "meridian_tests": {
+    "passed": 0,
+    "failed": 0,
+    "failures": []
+  },
+  "bug_tracker": {
+    "BUG-001": {
+      "description": "Suggested procedures rotation bug \u2014 procedures repeat rather than rotate across reports",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-002": {
+      "description": "Hardcoded risk tier labels \u2014 labels do not reflect dynamic risk scoring",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-003": {
+      "description": "PDF cell overflow \u2014 long text overflows table cells in generated PDFs",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-004": {
+      "description": "Orphaned ASC 250-10 references \u2014 appear in reports where not applicable",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-005": {
+      "description": "PP&E ampersand escaping \u2014 & renders as &amp; in PDF output",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-006": {
+      "description": "Identical data quality scores \u2014 multiple reports return same score regardless of input",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-007": {
+      "description": "Empty drill-down stubs \u2014 drill-down sections render with no content",
+      "status": "CLOSED",
+      "changed_today": false
+    }
+  },
+  "open_bug_count": 0,
+  "summary": "Meridian tests: 0 passed, 0 failed. 0/7 known bugs confirmed open."
+}

--- a/reports/nightly/.report_auditor_2026-04-24.json
+++ b/reports/nightly/.report_auditor_2026-04-24.json
@@ -1,0 +1,48 @@
+{
+  "agent": "report_auditor",
+  "status": "green",
+  "meridian_tests": {
+    "passed": 0,
+    "failed": 0,
+    "failures": []
+  },
+  "bug_tracker": {
+    "BUG-001": {
+      "description": "Suggested procedures rotation bug \u2014 procedures repeat rather than rotate across reports",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-002": {
+      "description": "Hardcoded risk tier labels \u2014 labels do not reflect dynamic risk scoring",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-003": {
+      "description": "PDF cell overflow \u2014 long text overflows table cells in generated PDFs",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-004": {
+      "description": "Orphaned ASC 250-10 references \u2014 appear in reports where not applicable",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-005": {
+      "description": "PP&E ampersand escaping \u2014 & renders as &amp; in PDF output",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-006": {
+      "description": "Identical data quality scores \u2014 multiple reports return same score regardless of input",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-007": {
+      "description": "Empty drill-down stubs \u2014 drill-down sections render with no content",
+      "status": "CLOSED",
+      "changed_today": false
+    }
+  },
+  "open_bug_count": 0,
+  "summary": "Meridian tests: 0 passed, 0 failed. 0/7 known bugs confirmed open."
+}

--- a/reports/nightly/.report_auditor_2026-04-25.json
+++ b/reports/nightly/.report_auditor_2026-04-25.json
@@ -1,0 +1,48 @@
+{
+  "agent": "report_auditor",
+  "status": "green",
+  "meridian_tests": {
+    "passed": 2,
+    "failed": 0,
+    "failures": []
+  },
+  "bug_tracker": {
+    "BUG-001": {
+      "description": "Suggested procedures rotation bug \u2014 procedures repeat rather than rotate across reports",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-002": {
+      "description": "Hardcoded risk tier labels \u2014 labels do not reflect dynamic risk scoring",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-003": {
+      "description": "PDF cell overflow \u2014 long text overflows table cells in generated PDFs",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-004": {
+      "description": "Orphaned ASC 250-10 references \u2014 appear in reports where not applicable",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-005": {
+      "description": "PP&E ampersand escaping \u2014 & renders as &amp; in PDF output",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-006": {
+      "description": "Identical data quality scores \u2014 multiple reports return same score regardless of input",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-007": {
+      "description": "Empty drill-down stubs \u2014 drill-down sections render with no content",
+      "status": "CLOSED",
+      "changed_today": false
+    }
+  },
+  "open_bug_count": 0,
+  "summary": "Meridian tests: 2 passed, 0 failed. 0/7 known bugs confirmed open."
+}

--- a/reports/nightly/.report_auditor_2026-04-26.json
+++ b/reports/nightly/.report_auditor_2026-04-26.json
@@ -1,0 +1,48 @@
+{
+  "agent": "report_auditor",
+  "status": "green",
+  "meridian_tests": {
+    "passed": 2,
+    "failed": 0,
+    "failures": []
+  },
+  "bug_tracker": {
+    "BUG-001": {
+      "description": "Suggested procedures rotation bug \u2014 procedures repeat rather than rotate across reports",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-002": {
+      "description": "Hardcoded risk tier labels \u2014 labels do not reflect dynamic risk scoring",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-003": {
+      "description": "PDF cell overflow \u2014 long text overflows table cells in generated PDFs",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-004": {
+      "description": "Orphaned ASC 250-10 references \u2014 appear in reports where not applicable",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-005": {
+      "description": "PP&E ampersand escaping \u2014 & renders as &amp; in PDF output",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-006": {
+      "description": "Identical data quality scores \u2014 multiple reports return same score regardless of input",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-007": {
+      "description": "Empty drill-down stubs \u2014 drill-down sections render with no content",
+      "status": "CLOSED",
+      "changed_today": false
+    }
+  },
+  "open_bug_count": 0,
+  "summary": "Meridian tests: 2 passed, 0 failed. 0/7 known bugs confirmed open."
+}

--- a/reports/nightly/.report_auditor_2026-04-27.json
+++ b/reports/nightly/.report_auditor_2026-04-27.json
@@ -1,0 +1,48 @@
+{
+  "agent": "report_auditor",
+  "status": "green",
+  "meridian_tests": {
+    "passed": 2,
+    "failed": 0,
+    "failures": []
+  },
+  "bug_tracker": {
+    "BUG-001": {
+      "description": "Suggested procedures rotation bug \u2014 procedures repeat rather than rotate across reports",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-002": {
+      "description": "Hardcoded risk tier labels \u2014 labels do not reflect dynamic risk scoring",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-003": {
+      "description": "PDF cell overflow \u2014 long text overflows table cells in generated PDFs",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-004": {
+      "description": "Orphaned ASC 250-10 references \u2014 appear in reports where not applicable",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-005": {
+      "description": "PP&E ampersand escaping \u2014 & renders as &amp; in PDF output",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-006": {
+      "description": "Identical data quality scores \u2014 multiple reports return same score regardless of input",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-007": {
+      "description": "Empty drill-down stubs \u2014 drill-down sections render with no content",
+      "status": "CLOSED",
+      "changed_today": false
+    }
+  },
+  "open_bug_count": 0,
+  "summary": "Meridian tests: 2 passed, 0 failed. 0/7 known bugs confirmed open."
+}

--- a/reports/nightly/.report_auditor_2026-04-28.json
+++ b/reports/nightly/.report_auditor_2026-04-28.json
@@ -1,0 +1,48 @@
+{
+  "agent": "report_auditor",
+  "status": "green",
+  "meridian_tests": {
+    "passed": 2,
+    "failed": 0,
+    "failures": []
+  },
+  "bug_tracker": {
+    "BUG-001": {
+      "description": "Suggested procedures rotation bug \u2014 procedures repeat rather than rotate across reports",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-002": {
+      "description": "Hardcoded risk tier labels \u2014 labels do not reflect dynamic risk scoring",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-003": {
+      "description": "PDF cell overflow \u2014 long text overflows table cells in generated PDFs",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-004": {
+      "description": "Orphaned ASC 250-10 references \u2014 appear in reports where not applicable",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-005": {
+      "description": "PP&E ampersand escaping \u2014 & renders as &amp; in PDF output",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-006": {
+      "description": "Identical data quality scores \u2014 multiple reports return same score regardless of input",
+      "status": "CLOSED",
+      "changed_today": false
+    },
+    "BUG-007": {
+      "description": "Empty drill-down stubs \u2014 drill-down sections render with no content",
+      "status": "CLOSED",
+      "changed_today": false
+    }
+  },
+  "open_bug_count": 0,
+  "summary": "Meridian tests: 2 passed, 0 failed. 0/7 known bugs confirmed open."
+}

--- a/reports/nightly/.run_log_2026-04-23.txt
+++ b/reports/nightly/.run_log_2026-04-23.txt
@@ -1,0 +1,66 @@
+[02:00:01] === Paciolus Overnight Run — 2026-04-23 ===
+[02:00:01] Start time: 2026-04-23T02:00:01.609216
+[02:00:01]   Target 02:00 already passed — starting immediately.
+[02:00:01] --- Agent: qa_warden ---
+[02:00:01]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\qa_warden.py
+[02:11:44]   stdout:     "failed": 0,
+[02:11:44]   stdout:     "duration_s": 39.1
+[02:11:44]   stdout:   },
+[02:11:44]   stdout:   "summary": "Backend: 8046 passed / 0 failed in 626.2s. Frontend: 1887 passed / 0 failed in 39.1s."
+[02:11:44]   stdout: }
+[02:11:44]   Completed successfully in 702.5s
+[02:11:49]   Sleeping 191s until 02:15...
+[02:15:00] --- Agent: report_auditor ---
+[02:15:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\report_auditor.py
+[02:15:21]   stdout:     }
+[02:15:21]   stdout:   },
+[02:15:21]   stdout:   "open_bug_count": 0,
+[02:15:21]   stdout:   "summary": "Meridian tests: 0 passed, 0 failed. 0/7 known bugs confirmed open."
+[02:15:21]   stdout: }
+[02:15:21]   Completed successfully in 21.6s
+[02:15:26]   Sleeping 1773s until 02:45...
+[02:45:00] --- Agent: scout ---
+[02:45:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\scout.py
+[02:49:27]   stdout:   "status": "green",
+[02:49:27]   stdout:   "total_leads": 0,
+[02:49:27]   stdout:   "leads": [],
+[02:49:27]   stdout:   "summary": "Found 0 leads across 5 themes. Top platform: none. Highest urgency: "
+[02:49:27]   stdout: }
+[02:49:27]   Completed successfully in 267.0s
+[02:49:32]   Sleeping 628s until 03:00...
+[03:00:00] --- Agent: coverage_sentinel ---
+[03:00:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\coverage_sentinel.py
+[03:13:56]   stdout:   ],
+[03:13:56]   stdout:   "non_production_excluded": 3,
+[03:13:56]   stdout:   "reasons": [],
+[03:13:56]   stdout:   "summary": "Backend coverage: 92.71% (88,974/95,974 statements, 7,000 uncovered). 7-day mean: 92.46% (+0.25pp). Non-production excluded: 3 file(s)."
+[03:13:56]   stdout: }
+[03:13:56]   Completed successfully in 836.4s
+[03:14:01]   Sleeping 959s until 03:30...
+[03:30:00] --- Agent: sprint_shepherd ---
+[03:30:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\sprint_shepherd.py
+[03:30:00]   stdout:     "pct": 0
+[03:30:00]   stdout:   },
+[03:30:00]   stdout:   "open_items": [],
+[03:30:00]   stdout:   "summary": "19 commits in last 24h, 107 in last 7d."
+[03:30:00]   stdout: }
+[03:30:00]   Completed successfully in 0.9s
+[03:30:05]   Sleeping 894s until 03:45...
+[03:45:00] --- Agent: dependency_sentinel ---
+[03:45:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\dependency_sentinel.py
+[03:45:26]   stdout:       "deferred": false
+[03:45:26]   stdout:     }
+[03:45:26]   stdout:   ],
+[03:45:26]   stdout:   "summary": "Backend: 5 outdated. Frontend: 0 outdated. 0 security-relevant packages have updates. 1 deferred."
+[03:45:26]   stdout: }
+[03:45:26]   Completed successfully in 26.0s
+[03:45:31]   Sleeping 869s until 04:00...
+[04:00:00] --- Agent: briefing_compiler ---
+[04:00:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\briefing_compiler.py
+[04:00:01]   stdout:   "agent": "briefing_compiler",
+[04:00:01]   stdout:   "status": "green",
+[04:00:01]   stdout:   "agents_run": 6,
+[04:00:01]   stdout:   "report_path": "D:\\Dev\\Paciolus\\reports\\nightly\\2026-04-23.md"
+[04:00:01]   stdout: }
+[04:00:01]   Completed successfully in 1.9s
+[04:00:01] === Run complete: 7/7 agents succeeded in 7200.3s ===

--- a/reports/nightly/.run_log_2026-04-24.txt
+++ b/reports/nightly/.run_log_2026-04-24.txt
@@ -1,0 +1,66 @@
+[02:00:01] === Paciolus Overnight Run — 2026-04-24 ===
+[02:00:01] Start time: 2026-04-24T02:00:01.236593
+[02:00:01]   Target 02:00 already passed — starting immediately.
+[02:00:01] --- Agent: qa_warden ---
+[02:00:01]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\qa_warden.py
+[02:12:09]   stdout:     "failed": 0,
+[02:12:09]   stdout:     "duration_s": 49.8
+[02:12:09]   stdout:   },
+[02:12:09]   stdout:   "summary": "Backend: 8095 passed / 0 failed in 637.5s. Frontend: 1915 passed / 0 failed in 49.8s."
+[02:12:09]   stdout: }
+[02:12:09]   Completed successfully in 728.3s
+[02:12:14]   Sleeping 165s until 02:15...
+[02:15:00] --- Agent: report_auditor ---
+[02:15:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\report_auditor.py
+[02:15:19]   stdout:     }
+[02:15:19]   stdout:   },
+[02:15:19]   stdout:   "open_bug_count": 0,
+[02:15:19]   stdout:   "summary": "Meridian tests: 0 passed, 0 failed. 0/7 known bugs confirmed open."
+[02:15:19]   stdout: }
+[02:15:19]   Completed successfully in 19.9s
+[02:15:24]   Sleeping 1775s until 02:45...
+[02:45:00] --- Agent: scout ---
+[02:45:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\scout.py
+[02:49:27]   stdout:   "status": "green",
+[02:49:27]   stdout:   "total_leads": 0,
+[02:49:27]   stdout:   "leads": [],
+[02:49:27]   stdout:   "summary": "Found 0 leads across 5 themes. Top platform: none. Highest urgency: "
+[02:49:27]   stdout: }
+[02:49:27]   Completed successfully in 267.2s
+[02:49:32]   Sleeping 628s until 03:00...
+[03:00:00] --- Agent: coverage_sentinel ---
+[03:00:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\coverage_sentinel.py
+[03:14:37]   stdout:   ],
+[03:14:37]   stdout:   "non_production_excluded": 3,
+[03:14:37]   stdout:   "reasons": [],
+[03:14:37]   stdout:   "summary": "Backend coverage: 92.89% (90,088/96,980 statements, 6,892 uncovered). 7-day mean: 92.55% (+0.34pp). Non-production excluded: 3 file(s)."
+[03:14:37]   stdout: }
+[03:14:37]   Completed successfully in 877.7s
+[03:14:42]   Sleeping 917s until 03:30...
+[03:30:00] --- Agent: sprint_shepherd ---
+[03:30:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\sprint_shepherd.py
+[03:30:00]   stdout:     "pct": 0
+[03:30:00]   stdout:   },
+[03:30:00]   stdout:   "open_items": [],
+[03:30:00]   stdout:   "summary": "4 commits in last 24h, 81 in last 7d. 1 risk signal(s) detected."
+[03:30:00]   stdout: }
+[03:30:00]   Completed successfully in 0.3s
+[03:30:05]   Sleeping 895s until 03:45...
+[03:45:00] --- Agent: dependency_sentinel ---
+[03:45:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\dependency_sentinel.py
+[03:45:18]   stdout:       "deferred": false
+[03:45:18]   stdout:     }
+[03:45:18]   stdout:   ],
+[03:45:18]   stdout:   "summary": "Backend: 9 outdated. Frontend: 1 outdated. 2 security-relevant packages have updates. 1 deferred."
+[03:45:18]   stdout: }
+[03:45:18]   Completed successfully in 18.6s
+[03:45:23]   Sleeping 876s until 04:00...
+[04:00:00] --- Agent: briefing_compiler ---
+[04:00:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\briefing_compiler.py
+[04:00:02]   stdout:   "agent": "briefing_compiler",
+[04:00:02]   stdout:   "status": "yellow",
+[04:00:02]   stdout:   "agents_run": 6,
+[04:00:02]   stdout:   "report_path": "D:\\Dev\\Paciolus\\reports\\nightly\\2026-04-24.md"
+[04:00:02]   stdout: }
+[04:00:02]   Completed successfully in 2.1s
+[04:00:02] === Run complete: 7/7 agents succeeded in 7200.9s ===

--- a/reports/nightly/.run_log_2026-04-25.txt
+++ b/reports/nightly/.run_log_2026-04-25.txt
@@ -1,0 +1,66 @@
+[02:00:01] === Paciolus Overnight Run — 2026-04-25 ===
+[02:00:01] Start time: 2026-04-25T02:00:01.661955
+[02:00:01]   Target 02:00 already passed — starting immediately.
+[02:00:01] --- Agent: qa_warden ---
+[02:00:01]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\qa_warden.py
+[02:11:17]   stdout:     "failed": 0,
+[02:11:17]   stdout:     "duration_s": 46.5
+[02:11:17]   stdout:   },
+[02:11:17]   stdout:   "summary": "Backend: 8175 passed / 6 failed in 592.8s. Frontend: 1915 passed / 0 failed in 46.5s. 6 new failure(s) since yesterday."
+[02:11:17]   stdout: }
+[02:11:17]   Completed successfully in 675.7s
+[02:11:22]   Sleeping 218s until 02:15...
+[02:15:00] --- Agent: report_auditor ---
+[02:15:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\report_auditor.py
+[02:15:16]   stdout:     }
+[02:15:16]   stdout:   },
+[02:15:16]   stdout:   "open_bug_count": 0,
+[02:15:16]   stdout:   "summary": "Meridian tests: 2 passed, 0 failed. 0/7 known bugs confirmed open."
+[02:15:16]   stdout: }
+[02:15:16]   Completed successfully in 16.5s
+[02:15:21]   Sleeping 1779s until 02:45...
+[02:45:00] --- Agent: scout ---
+[02:45:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\scout.py
+[02:49:27]   stdout:   "status": "green",
+[02:49:27]   stdout:   "total_leads": 0,
+[02:49:27]   stdout:   "leads": [],
+[02:49:27]   stdout:   "summary": "Found 0 leads across 5 themes. Top platform: none. Highest urgency: "
+[02:49:27]   stdout: }
+[02:49:27]   Completed successfully in 267.3s
+[02:49:32]   Sleeping 628s until 03:00...
+[03:00:00] --- Agent: coverage_sentinel ---
+[03:00:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\coverage_sentinel.py
+[03:13:30]   stdout:   ],
+[03:13:30]   stdout:   "non_production_excluded": 3,
+[03:13:30]   stdout:   "reasons": [],
+[03:13:30]   stdout:   "summary": "Backend coverage: 92.83% (90,720/97,722 statements, 7,002 uncovered). 7-day mean: 92.46% (+0.37pp). Non-production excluded: 3 file(s)."
+[03:13:30]   stdout: }
+[03:13:30]   Completed successfully in 810.7s
+[03:13:35]   Sleeping 984s until 03:30...
+[03:30:00] --- Agent: sprint_shepherd ---
+[03:30:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\sprint_shepherd.py
+[03:30:00]   stdout:     "pct": 0
+[03:30:00]   stdout:   },
+[03:30:00]   stdout:   "open_items": [],
+[03:30:00]   stdout:   "summary": "8 commits in last 24h, 80 in last 7d."
+[03:30:00]   stdout: }
+[03:30:00]   Completed successfully in 0.9s
+[03:30:05]   Sleeping 894s until 03:45...
+[03:45:00] --- Agent: dependency_sentinel ---
+[03:45:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\dependency_sentinel.py
+[03:45:27]   stdout:       "deferred": false
+[03:45:27]   stdout:     }
+[03:45:27]   stdout:   ],
+[03:45:27]   stdout:   "summary": "Backend: 13 outdated. Frontend: 1 outdated. 3 security-relevant packages have updates. 1 deferred."
+[03:45:27]   stdout: }
+[03:45:27]   Completed successfully in 27.7s
+[03:45:32]   Sleeping 867s until 04:00...
+[04:00:00] --- Agent: briefing_compiler ---
+[04:00:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\briefing_compiler.py
+[04:00:01]   stdout:   "agent": "briefing_compiler",
+[04:00:01]   stdout:   "status": "red",
+[04:00:01]   stdout:   "agents_run": 6,
+[04:00:01]   stdout:   "report_path": "D:\\Dev\\Paciolus\\reports\\nightly\\2026-04-25.md"
+[04:00:01]   stdout: }
+[04:00:01]   Completed successfully in 1.9s
+[04:00:01] === Run complete: 7/7 agents succeeded in 7200.2s ===

--- a/reports/nightly/.run_log_2026-04-26.txt
+++ b/reports/nightly/.run_log_2026-04-26.txt
@@ -1,0 +1,66 @@
+[02:00:01] === Paciolus Overnight Run — 2026-04-26 ===
+[02:00:01] Start time: 2026-04-26T02:00:01.531191
+[02:00:01]   Target 02:00 already passed — starting immediately.
+[02:00:01] --- Agent: qa_warden ---
+[02:00:01]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\qa_warden.py
+[02:12:04]   stdout:     "failed": 0,
+[02:12:04]   stdout:     "duration_s": 54.9
+[02:12:04]   stdout:   },
+[02:12:04]   stdout:   "summary": "Backend: 8316 passed / 4 failed in 632.7s. Frontend: 1915 passed / 0 failed in 54.9s. 2 failure(s) resolved."
+[02:12:04]   stdout: }
+[02:12:04]   Completed successfully in 723.4s
+[02:12:09]   Sleeping 170s until 02:15...
+[02:15:00] --- Agent: report_auditor ---
+[02:15:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\report_auditor.py
+[02:15:14]   stdout:     }
+[02:15:14]   stdout:   },
+[02:15:14]   stdout:   "open_bug_count": 0,
+[02:15:14]   stdout:   "summary": "Meridian tests: 2 passed, 0 failed. 0/7 known bugs confirmed open."
+[02:15:14]   stdout: }
+[02:15:14]   Completed successfully in 14.6s
+[02:15:19]   Sleeping 1780s until 02:45...
+[02:45:00] --- Agent: scout ---
+[02:45:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\scout.py
+[02:49:27]   stdout:   "status": "green",
+[02:49:27]   stdout:   "total_leads": 0,
+[02:49:27]   stdout:   "leads": [],
+[02:49:27]   stdout:   "summary": "Found 0 leads across 5 themes. Top platform: none. Highest urgency: "
+[02:49:27]   stdout: }
+[02:49:27]   Completed successfully in 267.1s
+[02:49:32]   Sleeping 628s until 03:00...
+[03:00:00] --- Agent: coverage_sentinel ---
+[03:00:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\coverage_sentinel.py
+[03:14:26]   stdout:   ],
+[03:14:26]   stdout:   "non_production_excluded": 3,
+[03:14:26]   stdout:   "reasons": [],
+[03:14:26]   stdout:   "summary": "Backend coverage: 92.82% (91,483/98,556 statements, 7,073 uncovered). 7-day mean: 92.57% (+0.25pp). Non-production excluded: 3 file(s)."
+[03:14:26]   stdout: }
+[03:14:26]   Completed successfully in 866.5s
+[03:14:31]   Sleeping 928s until 03:30...
+[03:30:00] --- Agent: sprint_shepherd ---
+[03:30:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\sprint_shepherd.py
+[03:30:00]   stdout:     "pct": 0
+[03:30:00]   stdout:   },
+[03:30:00]   stdout:   "open_items": [],
+[03:30:00]   stdout:   "summary": "10 commits in last 24h, 79 in last 7d."
+[03:30:00]   stdout: }
+[03:30:00]   Completed successfully in 0.5s
+[03:30:05]   Sleeping 894s until 03:45...
+[03:45:00] --- Agent: dependency_sentinel ---
+[03:45:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\dependency_sentinel.py
+[03:45:19]   stdout:       "deferred": false
+[03:45:19]   stdout:     }
+[03:45:19]   stdout:   ],
+[03:45:19]   stdout:   "summary": "Backend: 13 outdated. Frontend: 1 outdated. 3 security-relevant packages have updates. 1 deferred."
+[03:45:19]   stdout: }
+[03:45:19]   Completed successfully in 19.6s
+[03:45:24]   Sleeping 875s until 04:00...
+[04:00:00] --- Agent: briefing_compiler ---
+[04:00:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\briefing_compiler.py
+[04:00:01]   stdout:   "agent": "briefing_compiler",
+[04:00:01]   stdout:   "status": "red",
+[04:00:01]   stdout:   "agents_run": 6,
+[04:00:01]   stdout:   "report_path": "D:\\Dev\\Paciolus\\reports\\nightly\\2026-04-26.md"
+[04:00:01]   stdout: }
+[04:00:01]   Completed successfully in 1.9s
+[04:00:01] === Run complete: 7/7 agents succeeded in 7200.4s ===

--- a/reports/nightly/.run_log_2026-04-27.txt
+++ b/reports/nightly/.run_log_2026-04-27.txt
@@ -1,0 +1,66 @@
+[02:00:02] === Paciolus Overnight Run — 2026-04-27 ===
+[02:00:02] Start time: 2026-04-27T02:00:02.045101
+[02:00:02]   Target 02:00 already passed — starting immediately.
+[02:00:02] --- Agent: qa_warden ---
+[02:00:02]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\qa_warden.py
+[02:13:13]   stdout:     "failed": 0,
+[02:13:13]   stdout:     "duration_s": 21.9
+[02:13:13]   stdout:   },
+[02:13:13]   stdout:   "summary": "Backend: 8472 passed / 4 failed in 745.9s. Frontend: 1937 passed / 0 failed in 21.9s."
+[02:13:13]   stdout: }
+[02:13:13]   Completed successfully in 791.7s
+[02:13:18]   Sleeping 101s until 02:15...
+[02:15:00] --- Agent: report_auditor ---
+[02:15:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\report_auditor.py
+[02:15:22]   stdout:     }
+[02:15:22]   stdout:   },
+[02:15:22]   stdout:   "open_bug_count": 0,
+[02:15:22]   stdout:   "summary": "Meridian tests: 2 passed, 0 failed. 0/7 known bugs confirmed open."
+[02:15:22]   stdout: }
+[02:15:22]   Completed successfully in 22.3s
+[02:15:27]   Sleeping 1773s until 02:45...
+[02:45:00] --- Agent: scout ---
+[02:45:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\scout.py
+[02:49:28]   stdout:   "status": "green",
+[02:49:28]   stdout:   "total_leads": 0,
+[02:49:28]   stdout:   "leads": [],
+[02:49:28]   stdout:   "summary": "Found 0 leads across 5 themes. Top platform: none. Highest urgency: "
+[02:49:28]   stdout: }
+[02:49:28]   Completed successfully in 268.1s
+[02:49:33]   Sleeping 627s until 03:00...
+[03:00:00] --- Agent: coverage_sentinel ---
+[03:00:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\coverage_sentinel.py
+[03:16:30]   stdout:   ],
+[03:16:30]   stdout:   "non_production_excluded": 3,
+[03:16:30]   stdout:   "reasons": [],
+[03:16:30]   stdout:   "summary": "Backend coverage: 92.85% (93,720/100,932 statements, 7,212 uncovered). 7-day mean: 92.67% (+0.18pp). Non-production excluded: 3 file(s)."
+[03:16:30]   stdout: }
+[03:16:30]   Completed successfully in 990.1s
+[03:16:35]   Sleeping 805s until 03:30...
+[03:30:00] --- Agent: sprint_shepherd ---
+[03:30:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\sprint_shepherd.py
+[03:30:00]   stdout:     "pct": 0
+[03:30:00]   stdout:   },
+[03:30:00]   stdout:   "open_items": [],
+[03:30:00]   stdout:   "summary": "11 commits in last 24h, 86 in last 7d."
+[03:30:00]   stdout: }
+[03:30:00]   Completed successfully in 0.7s
+[03:30:05]   Sleeping 894s until 03:45...
+[03:45:00] --- Agent: dependency_sentinel ---
+[03:45:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\dependency_sentinel.py
+[03:45:19]   stdout:       "deferred": false
+[03:45:19]   stdout:     }
+[03:45:19]   stdout:   ],
+[03:45:19]   stdout:   "summary": "Backend: 14 outdated. Frontend: 2 outdated. 3 security-relevant packages have updates. 1 deferred."
+[03:45:19]   stdout: }
+[03:45:19]   Completed successfully in 19.8s
+[03:45:24]   Sleeping 875s until 04:00...
+[04:00:00] --- Agent: briefing_compiler ---
+[04:00:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\briefing_compiler.py
+[04:00:02]   stdout:   "agent": "briefing_compiler",
+[04:00:02]   stdout:   "status": "red",
+[04:00:02]   stdout:   "agents_run": 6,
+[04:00:02]   stdout:   "report_path": "D:\\Dev\\Paciolus\\reports\\nightly\\2026-04-27.md"
+[04:00:02]   stdout: }
+[04:00:02]   Completed successfully in 2.2s
+[04:00:02] === Run complete: 7/7 agents succeeded in 7200.1s ===

--- a/reports/nightly/.run_log_2026-04-28.txt
+++ b/reports/nightly/.run_log_2026-04-28.txt
@@ -1,0 +1,66 @@
+[02:00:01] === Paciolus Overnight Run — 2026-04-28 ===
+[02:00:01] Start time: 2026-04-28T02:00:01.646676
+[02:00:01]   Target 02:00 already passed — starting immediately.
+[02:00:01] --- Agent: qa_warden ---
+[02:00:01]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\qa_warden.py
+[02:14:11]   stdout:     "failed": 0,
+[02:14:11]   stdout:     "duration_s": 49.8
+[02:14:11]   stdout:   },
+[02:14:11]   stdout:   "summary": "Backend: 8481 passed / 4 failed in 750.2s. Frontend: 1957 passed / 0 failed in 49.8s. 4 new failure(s) since yesterday."
+[02:14:11]   stdout: }
+[02:14:11]   Completed successfully in 849.7s
+[02:14:16]   Sleeping 44s until 02:15...
+[02:15:00] --- Agent: report_auditor ---
+[02:15:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\report_auditor.py
+[02:15:12]   stdout:     }
+[02:15:12]   stdout:   },
+[02:15:12]   stdout:   "open_bug_count": 0,
+[02:15:12]   stdout:   "summary": "Meridian tests: 2 passed, 0 failed. 0/7 known bugs confirmed open."
+[02:15:12]   stdout: }
+[02:15:12]   Completed successfully in 12.9s
+[02:15:17]   Sleeping 1782s until 02:45...
+[02:45:00] --- Agent: scout ---
+[02:45:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\scout.py
+[02:49:28]   stdout:   "status": "green",
+[02:49:28]   stdout:   "total_leads": 0,
+[02:49:28]   stdout:   "leads": [],
+[02:49:28]   stdout:   "summary": "Found 0 leads across 5 themes. Top platform: none. Highest urgency: "
+[02:49:28]   stdout: }
+[02:49:28]   Completed successfully in 268.3s
+[02:49:33]   Sleeping 627s until 03:00...
+[03:00:00] --- Agent: coverage_sentinel ---
+[03:00:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\coverage_sentinel.py
+[03:16:14]   stdout:   ],
+[03:16:14]   stdout:   "non_production_excluded": 3,
+[03:16:14]   stdout:   "reasons": [],
+[03:16:14]   stdout:   "summary": "Backend coverage: 93.13% (94,151/101,099 statements, 6,948 uncovered). 7-day mean: 92.46% (+0.67pp). Non-production excluded: 3 file(s)."
+[03:16:14]   stdout: }
+[03:16:14]   Completed successfully in 974.9s
+[03:16:19]   Sleeping 820s until 03:30...
+[03:30:00] --- Agent: sprint_shepherd ---
+[03:30:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\sprint_shepherd.py
+[03:30:00]   stdout:     "pct": 0
+[03:30:00]   stdout:   },
+[03:30:00]   stdout:   "open_items": [],
+[03:30:00]   stdout:   "summary": "12 commits in last 24h, 89 in last 7d."
+[03:30:00]   stdout: }
+[03:30:00]   Completed successfully in 0.3s
+[03:30:05]   Sleeping 895s until 03:45...
+[03:45:00] --- Agent: dependency_sentinel ---
+[03:45:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\agents\dependency_sentinel.py
+[03:45:25]   stdout:       "deferred": false
+[03:45:25]   stdout:     }
+[03:45:25]   stdout:   ],
+[03:45:25]   stdout:   "summary": "Backend: 16 outdated. Frontend: 4 outdated. 3 security-relevant packages have updates. 1 deferred."
+[03:45:25]   stdout: }
+[03:45:25]   Completed successfully in 25.3s
+[03:45:30]   Sleeping 870s until 04:00...
+[04:00:00] --- Agent: briefing_compiler ---
+[04:00:00]   Executing: D:\Dev\Paciolus\backend\venv\Scripts\python.exe D:\Dev\Paciolus\scripts\overnight\briefing_compiler.py
+[04:00:01]   stdout:   "agent": "briefing_compiler",
+[04:00:01]   stdout:   "status": "red",
+[04:00:01]   stdout:   "agents_run": 6,
+[04:00:01]   stdout:   "report_path": "D:\\Dev\\Paciolus\\reports\\nightly\\2026-04-28.md"
+[04:00:01]   stdout: }
+[04:00:01]   Completed successfully in 2.0s
+[04:00:01] === Run complete: 7/7 agents succeeded in 7200.3s ===

--- a/reports/nightly/.scout_2026-04-23.json
+++ b/reports/nightly/.scout_2026-04-23.json
@@ -1,0 +1,7 @@
+{
+  "agent": "scout",
+  "status": "green",
+  "total_leads": 0,
+  "leads": [],
+  "summary": "Found 0 leads across 5 themes. Top platform: none. Highest urgency: "
+}

--- a/reports/nightly/.scout_2026-04-24.json
+++ b/reports/nightly/.scout_2026-04-24.json
@@ -1,0 +1,7 @@
+{
+  "agent": "scout",
+  "status": "green",
+  "total_leads": 0,
+  "leads": [],
+  "summary": "Found 0 leads across 5 themes. Top platform: none. Highest urgency: "
+}

--- a/reports/nightly/.scout_2026-04-25.json
+++ b/reports/nightly/.scout_2026-04-25.json
@@ -1,0 +1,7 @@
+{
+  "agent": "scout",
+  "status": "green",
+  "total_leads": 0,
+  "leads": [],
+  "summary": "Found 0 leads across 5 themes. Top platform: none. Highest urgency: "
+}

--- a/reports/nightly/.scout_2026-04-26.json
+++ b/reports/nightly/.scout_2026-04-26.json
@@ -1,0 +1,7 @@
+{
+  "agent": "scout",
+  "status": "green",
+  "total_leads": 0,
+  "leads": [],
+  "summary": "Found 0 leads across 5 themes. Top platform: none. Highest urgency: "
+}

--- a/reports/nightly/.scout_2026-04-27.json
+++ b/reports/nightly/.scout_2026-04-27.json
@@ -1,0 +1,7 @@
+{
+  "agent": "scout",
+  "status": "green",
+  "total_leads": 0,
+  "leads": [],
+  "summary": "Found 0 leads across 5 themes. Top platform: none. Highest urgency: "
+}

--- a/reports/nightly/.scout_2026-04-28.json
+++ b/reports/nightly/.scout_2026-04-28.json
@@ -1,0 +1,7 @@
+{
+  "agent": "scout",
+  "status": "green",
+  "total_leads": 0,
+  "leads": [],
+  "summary": "Found 0 leads across 5 themes. Top platform: none. Highest urgency: "
+}

--- a/reports/nightly/.sprint_shepherd_2026-04-23.json
+++ b/reports/nightly/.sprint_shepherd_2026-04-23.json
@@ -1,0 +1,20 @@
+{
+  "agent": "sprint_shepherd",
+  "status": "green",
+  "commits_last_24h": 19,
+  "commits_last_7d": 107,
+  "work_categories_24h": {
+    "bug fix": 8,
+    "report": 9,
+    "other": 2
+  },
+  "risk_commits": [],
+  "sprint_checklist": {
+    "found": false,
+    "total": 0,
+    "completed": 0,
+    "pct": 0
+  },
+  "open_items": [],
+  "summary": "19 commits in last 24h, 107 in last 7d."
+}

--- a/reports/nightly/.sprint_shepherd_2026-04-24.json
+++ b/reports/nightly/.sprint_shepherd_2026-04-24.json
@@ -1,0 +1,26 @@
+{
+  "agent": "sprint_shepherd",
+  "status": "yellow",
+  "commits_last_24h": 4,
+  "commits_last_7d": 81,
+  "work_categories_24h": {
+    "bug fix": 1,
+    "report": 2,
+    "other": 1
+  },
+  "risk_commits": [
+    {
+      "hash": "a275fa58",
+      "message": "fix: record Sprint 713 commit SHA in tasks/todo.md",
+      "keyword": "TODO"
+    }
+  ],
+  "sprint_checklist": {
+    "found": false,
+    "total": 0,
+    "completed": 0,
+    "pct": 0
+  },
+  "open_items": [],
+  "summary": "4 commits in last 24h, 81 in last 7d. 1 risk signal(s) detected."
+}

--- a/reports/nightly/.sprint_shepherd_2026-04-25.json
+++ b/reports/nightly/.sprint_shepherd_2026-04-25.json
@@ -1,0 +1,19 @@
+{
+  "agent": "sprint_shepherd",
+  "status": "green",
+  "commits_last_24h": 8,
+  "commits_last_7d": 80,
+  "work_categories_24h": {
+    "report": 4,
+    "bug fix": 4
+  },
+  "risk_commits": [],
+  "sprint_checklist": {
+    "found": false,
+    "total": 0,
+    "completed": 0,
+    "pct": 0
+  },
+  "open_items": [],
+  "summary": "8 commits in last 24h, 80 in last 7d."
+}

--- a/reports/nightly/.sprint_shepherd_2026-04-26.json
+++ b/reports/nightly/.sprint_shepherd_2026-04-26.json
@@ -1,0 +1,19 @@
+{
+  "agent": "sprint_shepherd",
+  "status": "green",
+  "commits_last_24h": 10,
+  "commits_last_7d": 79,
+  "work_categories_24h": {
+    "audit": 1,
+    "report": 9
+  },
+  "risk_commits": [],
+  "sprint_checklist": {
+    "found": false,
+    "total": 0,
+    "completed": 0,
+    "pct": 0
+  },
+  "open_items": [],
+  "summary": "10 commits in last 24h, 79 in last 7d."
+}

--- a/reports/nightly/.sprint_shepherd_2026-04-27.json
+++ b/reports/nightly/.sprint_shepherd_2026-04-27.json
@@ -1,0 +1,20 @@
+{
+  "agent": "sprint_shepherd",
+  "status": "green",
+  "commits_last_24h": 11,
+  "commits_last_7d": 86,
+  "work_categories_24h": {
+    "bug fix": 2,
+    "report": 7,
+    "audit": 2
+  },
+  "risk_commits": [],
+  "sprint_checklist": {
+    "found": false,
+    "total": 0,
+    "completed": 0,
+    "pct": 0
+  },
+  "open_items": [],
+  "summary": "11 commits in last 24h, 86 in last 7d."
+}

--- a/reports/nightly/.sprint_shepherd_2026-04-28.json
+++ b/reports/nightly/.sprint_shepherd_2026-04-28.json
@@ -1,0 +1,22 @@
+{
+  "agent": "sprint_shepherd",
+  "status": "green",
+  "commits_last_24h": 12,
+  "commits_last_7d": 89,
+  "work_categories_24h": {
+    "ui": 1,
+    "report": 4,
+    "bug fix": 4,
+    "test": 1,
+    "other": 2
+  },
+  "risk_commits": [],
+  "sprint_checklist": {
+    "found": false,
+    "total": 0,
+    "completed": 0,
+    "pct": 0
+  },
+  "open_items": [],
+  "summary": "12 commits in last 24h, 89 in last 7d."
+}

--- a/reports/nightly/2026-04-23.md
+++ b/reports/nightly/2026-04-23.md
@@ -1,0 +1,81 @@
+# 🌅 Paciolus Overnight Brief — 2026-04-23
+**Overall Status:** 🟢 GREEN
+**Report generated:** 04:00 AM | **Agents run:** 6/6
+
+Backend: 8046 passed / 0 failed in 626.2s. Frontend: 1887 passed / 0 failed in 39.1s. Meridian tests: 0 passed, 0 failed. 0/7 known bugs confirmed open. Found 0 leads across 5 themes. Top platform: none. Highest urgency:  19 commits in last 24h, 107 in last 7d. Backend: 5 outdated. Frontend: 0 outdated. 0 security-relevant packages have updates. 1 deferred. Backend coverage: 92.71% (88,974/95,974 statements, 7,000 uncovered). 7-day mean: 92.46% (+0.25pp). Non-production excluded: 3 file(s).
+
+---
+
+## 🧪 QA Warden — 🟢 GREEN
+**Backend:** 8046 passed, 0 failed (626.2s)  
+**Frontend:** 1887 passed, 0 failed (39.1s)  
+
+---
+
+## 📋 Report Auditor — 🟢 GREEN
+**Meridian Tests:** 0/0 passing  
+**Open Bugs:** 0/7 confirmed open
+
+| Bug | Description | Status | Changed Today |
+|-----|-------------|--------|---------------|
+| BUG-001 | Suggested procedures rotation bug — procedures repeat rather than rotate across reports | CLOSED | no |
+| BUG-002 | Hardcoded risk tier labels — labels do not reflect dynamic risk scoring | CLOSED | no |
+| BUG-003 | PDF cell overflow — long text overflows table cells in generated PDFs | CLOSED | no |
+| BUG-004 | Orphaned ASC 250-10 references — appear in reports where not applicable | CLOSED | no |
+| BUG-005 | PP&E ampersand escaping — & renders as &amp; in PDF output | CLOSED | no |
+| BUG-006 | Identical data quality scores — multiple reports return same score regardless of input | CLOSED | no |
+| BUG-007 | Empty drill-down stubs — drill-down sections render with no content | CLOSED | no |
+
+---
+
+## 📊 Coverage Sentinel — 🟢 GREEN
+**Backend line coverage:** 92.71% (88,974/95,974 statements, 7,000 uncovered)  
+**7-day mean:** 92.46%  |  **Delta:** ↑ +0.25pp  
+
+**Top uncovered files** (by missing statement count):
+
+| File | Coverage | Missing | Statements |
+|------|---------:|--------:|-----------:|
+| `excel_generator.py` | 45.7% | 328 | 604 |
+| `billing\webhook_handler.py` | 57.4% | 185 | 434 |
+| `population_profile_memo.py` | 39.7% | 170 | 282 |
+| `workbook_inspector.py` | 18.6% | 136 | 167 |
+| `pdf\sections\diagnostic.py` | 64.9% | 134 | 382 |
+| `leadsheet_generator.py` | 11.4% | 124 | 140 |
+| `scripts\create_dev_user.py` | 0.0% | 111 | 111 |
+| `config.py` | 54.5% | 96 | 211 |
+| `main.py` | 44.2% | 92 | 165 |
+| `preflight_engine.py` | 84.1% | 79 | 498 |
+
+---
+
+## 🔍 Scout — 🟢 GREEN
+**Leads found:** 0 across 5 search themes
+
+| # | Platform | Pain Point | Paciolus Feature | Urgency | Decision Maker |
+|---|----------|-----------|-----------------|---------|----------------|
+
+---
+
+## 🏃 Sprint Shepherd — 🟢 GREEN
+**Commits (24h):** 19 | **Commits (7d):** 107  
+**Work breakdown (24h):** bug fix: 8, report: 9, other: 2  
+
+---
+
+## 📦 Dependency Sentinel — 🟢 GREEN
+**Backend outdated:** 5 packages | **Frontend outdated:** 0 packages  
+
+**Deferred (1):** monitored, not affecting status
+- ~pdfminer.six~ 20251230 → 20260107 — Calendar-versioned release; waiting on downstream compatibility confirmation (review by 2026-04-30)
+
+| Package | Current | Latest | Severity | Note |
+|---------|---------|--------|----------|------|
+| certifi | 2026.2.25 | 2026.4.22 | minor |  |
+| pathspec | 1.0.4 | 1.1.0 | minor |  |
+| uvicorn | 0.45.0 | 0.46.0 | minor |  |
+| click | 8.3.2 | 8.3.3 | patch |  |
+
+---
+*Next run: tomorrow at 2:00 AM | Output: reports/nightly/2026-04-24.md*
+---

--- a/reports/nightly/2026-04-24.md
+++ b/reports/nightly/2026-04-24.md
@@ -1,0 +1,93 @@
+# 🌅 Paciolus Overnight Brief — 2026-04-24
+**Overall Status:** 🟡 YELLOW
+**Report generated:** 04:00 AM | **Agents run:** 6/6
+
+Backend: 8095 passed / 0 failed in 637.5s. Frontend: 1915 passed / 0 failed in 49.8s. Meridian tests: 0 passed, 0 failed. 0/7 known bugs confirmed open. Found 0 leads across 5 themes. Top platform: none. Highest urgency:  4 commits in last 24h, 81 in last 7d. 1 risk signal(s) detected. Backend: 9 outdated. Frontend: 1 outdated. 2 security-relevant packages have updates. 1 deferred. Backend coverage: 92.89% (90,088/96,980 statements, 6,892 uncovered). 7-day mean: 92.55% (+0.34pp). Non-production excluded: 3 file(s).
+
+---
+
+## 🧪 QA Warden — 🟢 GREEN
+**Backend:** 8095 passed, 0 failed (637.5s)  
+**Frontend:** 1915 passed, 0 failed (49.8s)  
+
+---
+
+## 📋 Report Auditor — 🟢 GREEN
+**Meridian Tests:** 0/0 passing  
+**Open Bugs:** 0/7 confirmed open
+
+| Bug | Description | Status | Changed Today |
+|-----|-------------|--------|---------------|
+| BUG-001 | Suggested procedures rotation bug — procedures repeat rather than rotate across reports | CLOSED | no |
+| BUG-002 | Hardcoded risk tier labels — labels do not reflect dynamic risk scoring | CLOSED | no |
+| BUG-003 | PDF cell overflow — long text overflows table cells in generated PDFs | CLOSED | no |
+| BUG-004 | Orphaned ASC 250-10 references — appear in reports where not applicable | CLOSED | no |
+| BUG-005 | PP&E ampersand escaping — & renders as &amp; in PDF output | CLOSED | no |
+| BUG-006 | Identical data quality scores — multiple reports return same score regardless of input | CLOSED | no |
+| BUG-007 | Empty drill-down stubs — drill-down sections render with no content | CLOSED | no |
+
+---
+
+## 📊 Coverage Sentinel — 🟢 GREEN
+**Backend line coverage:** 92.89% (90,088/96,980 statements, 6,892 uncovered)  
+**7-day mean:** 92.55%  |  **Delta:** ↑ +0.34pp  
+
+**Top uncovered files** (by missing statement count):
+
+| File | Coverage | Missing | Statements |
+|------|---------:|--------:|-----------:|
+| `excel_generator.py` | 45.7% | 328 | 604 |
+| `billing\webhook_handler.py` | 57.4% | 185 | 434 |
+| `population_profile_memo.py` | 39.7% | 170 | 282 |
+| `workbook_inspector.py` | 18.6% | 136 | 167 |
+| `pdf\sections\diagnostic.py` | 64.9% | 134 | 382 |
+| `leadsheet_generator.py` | 11.4% | 124 | 140 |
+| `scripts\create_dev_user.py` | 0.0% | 111 | 111 |
+| `config.py` | 54.5% | 96 | 211 |
+| `main.py` | 44.2% | 92 | 165 |
+| `preflight_engine.py` | 84.1% | 79 | 498 |
+
+---
+
+## 🔍 Scout — 🟢 GREEN
+**Leads found:** 0 across 5 search themes
+
+| # | Platform | Pain Point | Paciolus Feature | Urgency | Decision Maker |
+|---|----------|-----------|-----------------|---------|----------------|
+
+---
+
+## 🏃 Sprint Shepherd — 🟡 YELLOW
+**Commits (24h):** 4 | **Commits (7d):** 81  
+**Work breakdown (24h):** bug fix: 1, report: 2, other: 1  
+
+⚠️ **Risk signals:**
+- `a275fa58` fix: record Sprint 713 commit SHA in tasks/todo.md (keyword: TODO)
+
+---
+
+## 📦 Dependency Sentinel — 🟡 YELLOW
+**Backend outdated:** 9 packages | **Frontend outdated:** 1 packages  
+
+🔒 **Security-relevant updates available:**
+- **fastapi**: 0.136.0 → 0.136.1 (patch)
+- **stripe**: 15.0.1 → 15.1.0 (minor)
+
+**Deferred (1):** monitored, not affecting status
+- ~pdfminer.six~ 20251230 → 20260107 — Calendar-versioned release; waiting on downstream compatibility confirmation (review by 2026-04-30)
+
+| Package | Current | Latest | Severity | Note |
+|---------|---------|--------|----------|------|
+| anthropic | 0.96.0 | 0.97.0 | minor |  |
+| certifi | 2026.2.25 | 2026.4.22 | minor |  |
+| pathspec | 1.0.4 | 1.1.0 | minor |  |
+| stripe | 15.0.1 | 15.1.0 | minor |  |
+| uvicorn | 0.45.0 | 0.46.0 | minor |  |
+| @sentry/nextjs | 10.49.0 | 10.50.0 | minor |  |
+| click | 8.3.2 | 8.3.3 | patch |  |
+| fastapi | 0.136.0 | 0.136.1 | patch |  |
+| hypothesis | 6.152.1 | 6.152.2 | patch |  |
+
+---
+*Next run: tomorrow at 2:00 AM | Output: reports/nightly/2026-04-25.md*
+---

--- a/reports/nightly/2026-04-25.md
+++ b/reports/nightly/2026-04-25.md
@@ -1,0 +1,103 @@
+# 🌅 Paciolus Overnight Brief — 2026-04-25
+**Overall Status:** 🔴 RED
+**Report generated:** 04:00 AM | **Agents run:** 6/6
+
+Backend: 8175 passed / 6 failed in 592.8s. Frontend: 1915 passed / 0 failed in 46.5s. 6 new failure(s) since yesterday. Meridian tests: 2 passed, 0 failed. 0/7 known bugs confirmed open. Found 0 leads across 5 themes. Top platform: none. Highest urgency:  8 commits in last 24h, 80 in last 7d. Backend: 13 outdated. Frontend: 1 outdated. 3 security-relevant packages have updates. 1 deferred. Backend coverage: 92.83% (90,720/97,722 statements, 7,002 uncovered). 7-day mean: 92.46% (+0.37pp). Non-production excluded: 3 file(s).
+
+---
+
+## 🧪 QA Warden — 🔴 RED
+**Backend:** 8175 passed, 6 failed (592.8s)  
+**Frontend:** 1915 passed, 0 failed (46.5s)  
+
+⚠️ **NEW FAILURES SINCE YESTERDAY:**
+- `tests/test_security_hardening_2026_04_20.py::TestCSRFRefreshLogout::test_dev_still_accepts_x_requested_with[asyncio]`
+- `tests/test_security_hardening_2026_04_20.py::TestCSRFRefreshLogout::test_production_rejects_x_requested_with_only[asyncio]`
+- `tests/test_security_hardening_2026_04_20.py::TestPasscodeRoutePolicy::test_get_on_passcode_share_returns_403[asyncio]`
+- `tests/test_security_hardening_2026_04_20.py::TestPasscodeRoutePolicy::test_query_string_passcode_ignored[asyncio]`
+- `tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_strict_mode_defaults_true_in_production`
+- `tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_valid_override_allowed`
+
+---
+
+## 📋 Report Auditor — 🟢 GREEN
+**Meridian Tests:** 2/2 passing  
+**Open Bugs:** 0/7 confirmed open
+
+| Bug | Description | Status | Changed Today |
+|-----|-------------|--------|---------------|
+| BUG-001 | Suggested procedures rotation bug — procedures repeat rather than rotate across reports | CLOSED | no |
+| BUG-002 | Hardcoded risk tier labels — labels do not reflect dynamic risk scoring | CLOSED | no |
+| BUG-003 | PDF cell overflow — long text overflows table cells in generated PDFs | CLOSED | no |
+| BUG-004 | Orphaned ASC 250-10 references — appear in reports where not applicable | CLOSED | no |
+| BUG-005 | PP&E ampersand escaping — & renders as &amp; in PDF output | CLOSED | no |
+| BUG-006 | Identical data quality scores — multiple reports return same score regardless of input | CLOSED | no |
+| BUG-007 | Empty drill-down stubs — drill-down sections render with no content | CLOSED | no |
+
+---
+
+## 📊 Coverage Sentinel — 🟢 GREEN
+**Backend line coverage:** 92.83% (90,720/97,722 statements, 7,002 uncovered)  
+**7-day mean:** 92.46%  |  **Delta:** ↑ +0.37pp  
+
+**Top uncovered files** (by missing statement count):
+
+| File | Coverage | Missing | Statements |
+|------|---------:|--------:|-----------:|
+| `excel_generator.py` | 45.7% | 328 | 604 |
+| `billing\webhook_handler.py` | 59.9% | 174 | 434 |
+| `population_profile_memo.py` | 39.7% | 170 | 282 |
+| `workbook_inspector.py` | 18.6% | 136 | 167 |
+| `pdf\sections\diagnostic.py` | 64.9% | 134 | 382 |
+| `leadsheet_generator.py` | 11.4% | 124 | 140 |
+| `scripts\create_dev_user.py` | 0.0% | 111 | 111 |
+| `config.py` | 57.4% | 98 | 230 |
+| `main.py` | 44.2% | 92 | 165 |
+| `routes\internal_admin.py` | 55.4% | 82 | 184 |
+
+---
+
+## 🔍 Scout — 🟢 GREEN
+**Leads found:** 0 across 5 search themes
+
+| # | Platform | Pain Point | Paciolus Feature | Urgency | Decision Maker |
+|---|----------|-----------|-----------------|---------|----------------|
+
+---
+
+## 🏃 Sprint Shepherd — 🟢 GREEN
+**Commits (24h):** 8 | **Commits (7d):** 80  
+**Work breakdown (24h):** report: 4, bug fix: 4  
+
+---
+
+## 📦 Dependency Sentinel — 🔴 RED
+**Backend outdated:** 13 packages | **Frontend outdated:** 1 packages  
+
+🔒 **Security-relevant updates available:**
+- **cryptography**: 46.0.7 → 47.0.0 (major)
+- **fastapi**: 0.136.0 → 0.136.1 (patch)
+- **stripe**: 15.0.1 → 15.1.0 (minor)
+
+**Deferred (1):** monitored, not affecting status
+- ~pdfminer.six~ 20251230 → 20260107 — Calendar-versioned release; waiting on downstream compatibility confirmation (review by 2026-04-30)
+
+| Package | Current | Latest | Severity | Note |
+|---------|---------|--------|----------|------|
+| cryptography | 46.0.7 | 47.0.0 | major |  |
+| anthropic | 0.96.0 | 0.97.0 | minor |  |
+| certifi | 2026.2.25 | 2026.4.22 | minor |  |
+| packaging | 26.1 | 26.2 | minor |  |
+| pathspec | 1.0.4 | 1.1.0 | minor |  |
+| stripe | 15.0.1 | 15.1.0 | minor |  |
+| tzdata | 2026.1 | 2026.2 | minor |  |
+| uvicorn | 0.45.0 | 0.46.0 | minor |  |
+| @sentry/nextjs | 10.49.0 | 10.50.0 | minor |  |
+| click | 8.3.2 | 8.3.3 | patch |  |
+| fastapi | 0.136.0 | 0.136.1 | patch |  |
+| hypothesis | 6.152.1 | 6.152.2 | patch |  |
+| ruff | 0.15.11 | 0.15.12 | patch |  |
+
+---
+*Next run: tomorrow at 2:00 AM | Output: reports/nightly/2026-04-26.md*
+---

--- a/reports/nightly/2026-04-26.md
+++ b/reports/nightly/2026-04-26.md
@@ -1,0 +1,99 @@
+# 🌅 Paciolus Overnight Brief — 2026-04-26
+**Overall Status:** 🔴 RED
+**Report generated:** 04:00 AM | **Agents run:** 6/6
+
+Backend: 8316 passed / 4 failed in 632.7s. Frontend: 1915 passed / 0 failed in 54.9s. 2 failure(s) resolved. Meridian tests: 2 passed, 0 failed. 0/7 known bugs confirmed open. Found 0 leads across 5 themes. Top platform: none. Highest urgency:  10 commits in last 24h, 79 in last 7d. Backend: 13 outdated. Frontend: 1 outdated. 3 security-relevant packages have updates. 1 deferred. Backend coverage: 92.82% (91,483/98,556 statements, 7,073 uncovered). 7-day mean: 92.57% (+0.25pp). Non-production excluded: 3 file(s).
+
+---
+
+## 🧪 QA Warden — 🟡 YELLOW
+**Backend:** 8316 passed, 4 failed (632.7s)  
+**Frontend:** 1915 passed, 0 failed (54.9s)  
+
+✅ **RESOLVED SINCE YESTERDAY:**
+- `tests/test_security_hardening_2026_04_20.py::TestPasscodeRoutePolicy::test_get_on_passcode_share_returns_403[asyncio]`
+- `tests/test_security_hardening_2026_04_20.py::TestPasscodeRoutePolicy::test_query_string_passcode_ignored[asyncio]`
+
+---
+
+## 📋 Report Auditor — 🟢 GREEN
+**Meridian Tests:** 2/2 passing  
+**Open Bugs:** 0/7 confirmed open
+
+| Bug | Description | Status | Changed Today |
+|-----|-------------|--------|---------------|
+| BUG-001 | Suggested procedures rotation bug — procedures repeat rather than rotate across reports | CLOSED | no |
+| BUG-002 | Hardcoded risk tier labels — labels do not reflect dynamic risk scoring | CLOSED | no |
+| BUG-003 | PDF cell overflow — long text overflows table cells in generated PDFs | CLOSED | no |
+| BUG-004 | Orphaned ASC 250-10 references — appear in reports where not applicable | CLOSED | no |
+| BUG-005 | PP&E ampersand escaping — & renders as &amp; in PDF output | CLOSED | no |
+| BUG-006 | Identical data quality scores — multiple reports return same score regardless of input | CLOSED | no |
+| BUG-007 | Empty drill-down stubs — drill-down sections render with no content | CLOSED | no |
+
+---
+
+## 📊 Coverage Sentinel — 🟢 GREEN
+**Backend line coverage:** 92.82% (91,483/98,556 statements, 7,073 uncovered)  
+**7-day mean:** 92.57%  |  **Delta:** ↑ +0.25pp  
+
+**Top uncovered files** (by missing statement count):
+
+| File | Coverage | Missing | Statements |
+|------|---------:|--------:|-----------:|
+| `excel_generator.py` | 45.7% | 328 | 604 |
+| `billing\webhook_handler.py` | 59.9% | 174 | 434 |
+| `population_profile_memo.py` | 39.7% | 170 | 282 |
+| `workbook_inspector.py` | 18.6% | 136 | 167 |
+| `pdf\sections\diagnostic.py` | 64.9% | 134 | 382 |
+| `leadsheet_generator.py` | 11.3% | 126 | 142 |
+| `scripts\create_dev_user.py` | 0.0% | 111 | 111 |
+| `config.py` | 57.4% | 98 | 230 |
+| `main.py` | 44.2% | 92 | 165 |
+| `routes\internal_admin.py` | 55.4% | 82 | 184 |
+
+---
+
+## 🔍 Scout — 🟢 GREEN
+**Leads found:** 0 across 5 search themes
+
+| # | Platform | Pain Point | Paciolus Feature | Urgency | Decision Maker |
+|---|----------|-----------|-----------------|---------|----------------|
+
+---
+
+## 🏃 Sprint Shepherd — 🟢 GREEN
+**Commits (24h):** 10 | **Commits (7d):** 79  
+**Work breakdown (24h):** audit: 1, report: 9  
+
+---
+
+## 📦 Dependency Sentinel — 🔴 RED
+**Backend outdated:** 13 packages | **Frontend outdated:** 1 packages  
+
+🔒 **Security-relevant updates available:**
+- **cryptography**: 46.0.7 → 47.0.0 (major)
+- **fastapi**: 0.136.0 → 0.136.1 (patch)
+- **stripe**: 15.0.1 → 15.1.0 (minor)
+
+**Deferred (1):** monitored, not affecting status
+- ~pdfminer.six~ 20251230 → 20260107 — Calendar-versioned release; waiting on downstream compatibility confirmation (review by 2026-04-30)
+
+| Package | Current | Latest | Severity | Note |
+|---------|---------|--------|----------|------|
+| cryptography | 46.0.7 | 47.0.0 | major |  |
+| anthropic | 0.96.0 | 0.97.0 | minor |  |
+| certifi | 2026.2.25 | 2026.4.22 | minor |  |
+| packaging | 26.1 | 26.2 | minor |  |
+| pathspec | 1.0.4 | 1.1.0 | minor |  |
+| stripe | 15.0.1 | 15.1.0 | minor |  |
+| tzdata | 2026.1 | 2026.2 | minor |  |
+| uvicorn | 0.45.0 | 0.46.0 | minor |  |
+| @sentry/nextjs | 10.49.0 | 10.50.0 | minor |  |
+| click | 8.3.2 | 8.3.3 | patch |  |
+| fastapi | 0.136.0 | 0.136.1 | patch |  |
+| hypothesis | 6.152.1 | 6.152.2 | patch |  |
+| ruff | 0.15.11 | 0.15.12 | patch |  |
+
+---
+*Next run: tomorrow at 2:00 AM | Output: reports/nightly/2026-04-27.md*
+---

--- a/reports/nightly/2026-04-27.md
+++ b/reports/nightly/2026-04-27.md
@@ -1,0 +1,97 @@
+# 🌅 Paciolus Overnight Brief — 2026-04-27
+**Overall Status:** 🔴 RED
+**Report generated:** 04:00 AM | **Agents run:** 6/6
+
+Backend: 8472 passed / 4 failed in 745.9s. Frontend: 1937 passed / 0 failed in 21.9s. Meridian tests: 2 passed, 0 failed. 0/7 known bugs confirmed open. Found 0 leads across 5 themes. Top platform: none. Highest urgency:  11 commits in last 24h, 86 in last 7d. Backend: 14 outdated. Frontend: 2 outdated. 3 security-relevant packages have updates. 1 deferred. Backend coverage: 92.85% (93,720/100,932 statements, 7,212 uncovered). 7-day mean: 92.67% (+0.18pp). Non-production excluded: 3 file(s).
+
+---
+
+## 🧪 QA Warden — 🟡 YELLOW
+**Backend:** 8472 passed, 4 failed (745.9s)  
+**Frontend:** 1937 passed, 0 failed (21.9s)  
+
+---
+
+## 📋 Report Auditor — 🟢 GREEN
+**Meridian Tests:** 2/2 passing  
+**Open Bugs:** 0/7 confirmed open
+
+| Bug | Description | Status | Changed Today |
+|-----|-------------|--------|---------------|
+| BUG-001 | Suggested procedures rotation bug — procedures repeat rather than rotate across reports | CLOSED | no |
+| BUG-002 | Hardcoded risk tier labels — labels do not reflect dynamic risk scoring | CLOSED | no |
+| BUG-003 | PDF cell overflow — long text overflows table cells in generated PDFs | CLOSED | no |
+| BUG-004 | Orphaned ASC 250-10 references — appear in reports where not applicable | CLOSED | no |
+| BUG-005 | PP&E ampersand escaping — & renders as &amp; in PDF output | CLOSED | no |
+| BUG-006 | Identical data quality scores — multiple reports return same score regardless of input | CLOSED | no |
+| BUG-007 | Empty drill-down stubs — drill-down sections render with no content | CLOSED | no |
+
+---
+
+## 📊 Coverage Sentinel — 🟢 GREEN
+**Backend line coverage:** 92.85% (93,720/100,932 statements, 7,212 uncovered)  
+**7-day mean:** 92.67%  |  **Delta:** ↑ +0.18pp  
+
+**Top uncovered files** (by missing statement count):
+
+| File | Coverage | Missing | Statements |
+|------|---------:|--------:|-----------:|
+| `excel_generator.py` | 45.7% | 328 | 604 |
+| `billing\webhook_handler.py` | 59.9% | 174 | 434 |
+| `population_profile_memo.py` | 39.7% | 170 | 282 |
+| `workbook_inspector.py` | 18.6% | 136 | 167 |
+| `pdf\sections\diagnostic.py` | 64.9% | 134 | 382 |
+| `leadsheet_generator.py` | 11.3% | 126 | 142 |
+| `scripts\create_dev_user.py` | 0.0% | 111 | 111 |
+| `config.py` | 57.4% | 98 | 230 |
+| `main.py` | 44.2% | 92 | 165 |
+| `routes\internal_admin.py` | 55.4% | 82 | 184 |
+
+---
+
+## 🔍 Scout — 🟢 GREEN
+**Leads found:** 0 across 5 search themes
+
+| # | Platform | Pain Point | Paciolus Feature | Urgency | Decision Maker |
+|---|----------|-----------|-----------------|---------|----------------|
+
+---
+
+## 🏃 Sprint Shepherd — 🟢 GREEN
+**Commits (24h):** 11 | **Commits (7d):** 86  
+**Work breakdown (24h):** bug fix: 2, report: 7, audit: 2  
+
+---
+
+## 📦 Dependency Sentinel — 🔴 RED
+**Backend outdated:** 14 packages | **Frontend outdated:** 2 packages  
+
+🔒 **Security-relevant updates available:**
+- **cryptography**: 46.0.7 → 47.0.0 (major)
+- **fastapi**: 0.136.0 → 0.136.1 (patch)
+- **stripe**: 15.0.1 → 15.1.0 (minor)
+
+**Deferred (1):** monitored, not affecting status
+- ~pdfminer.six~ 20251230 → 20260107 — Calendar-versioned release; waiting on downstream compatibility confirmation (review by 2026-04-30)
+
+| Package | Current | Latest | Severity | Note |
+|---------|---------|--------|----------|------|
+| cryptography | 46.0.7 | 47.0.0 | major |  |
+| anthropic | 0.96.0 | 0.97.0 | minor |  |
+| certifi | 2026.2.25 | 2026.4.22 | minor |  |
+| packaging | 26.1 | 26.2 | minor |  |
+| pathspec | 1.0.4 | 1.1.1 | minor |  |
+| pip | 26.0.1 | 26.1 | minor |  |
+| stripe | 15.0.1 | 15.1.0 | minor |  |
+| tzdata | 2026.1 | 2026.2 | minor |  |
+| uvicorn | 0.45.0 | 0.46.0 | minor |  |
+| @sentry/nextjs | 10.49.0 | 10.50.0 | minor |  |
+| click | 8.3.2 | 8.3.3 | patch |  |
+| fastapi | 0.136.0 | 0.136.1 | patch |  |
+| hypothesis | 6.152.1 | 6.152.3 | patch |  |
+| ruff | 0.15.11 | 0.15.12 | patch |  |
+| postcss | 8.5.10 | 8.5.12 | patch |  |
+
+---
+*Next run: tomorrow at 2:00 AM | Output: reports/nightly/2026-04-28.md*
+---

--- a/reports/nightly/2026-04-28.md
+++ b/reports/nightly/2026-04-28.md
@@ -1,0 +1,107 @@
+# 🌅 Paciolus Overnight Brief — 2026-04-28
+**Overall Status:** 🔴 RED
+**Report generated:** 04:00 AM | **Agents run:** 6/6
+
+Backend: 8481 passed / 4 failed in 750.2s. Frontend: 1957 passed / 0 failed in 49.8s. 4 new failure(s) since yesterday. Meridian tests: 2 passed, 0 failed. 0/7 known bugs confirmed open. Found 0 leads across 5 themes. Top platform: none. Highest urgency:  12 commits in last 24h, 89 in last 7d. Backend: 16 outdated. Frontend: 4 outdated. 3 security-relevant packages have updates. 1 deferred. Backend coverage: 93.13% (94,151/101,099 statements, 6,948 uncovered). 7-day mean: 92.46% (+0.67pp). Non-production excluded: 3 file(s).
+
+---
+
+## 🧪 QA Warden — 🔴 RED
+**Backend:** 8481 passed, 4 failed (750.2s)  
+**Frontend:** 1957 passed, 0 failed (49.8s)  
+
+⚠️ **NEW FAILURES SINCE YESTERDAY:**
+- `tests/test_no_helpers_reexports.py::TestNoHelpersReexports::test_allowlist_matches_helpers_module_publics`
+- `tests/test_no_helpers_reexports.py::TestNoHelpersReexports::test_no_disallowed_imports`
+- `tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_strict_mode_defaults_true_in_production`
+- `tests/test_security_hardening_2026_04_20.py::TestRateLimitFailClosed::test_valid_override_allowed`
+
+---
+
+## 📋 Report Auditor — 🟢 GREEN
+**Meridian Tests:** 2/2 passing  
+**Open Bugs:** 0/7 confirmed open
+
+| Bug | Description | Status | Changed Today |
+|-----|-------------|--------|---------------|
+| BUG-001 | Suggested procedures rotation bug — procedures repeat rather than rotate across reports | CLOSED | no |
+| BUG-002 | Hardcoded risk tier labels — labels do not reflect dynamic risk scoring | CLOSED | no |
+| BUG-003 | PDF cell overflow — long text overflows table cells in generated PDFs | CLOSED | no |
+| BUG-004 | Orphaned ASC 250-10 references — appear in reports where not applicable | CLOSED | no |
+| BUG-005 | PP&E ampersand escaping — & renders as &amp; in PDF output | CLOSED | no |
+| BUG-006 | Identical data quality scores — multiple reports return same score regardless of input | CLOSED | no |
+| BUG-007 | Empty drill-down stubs — drill-down sections render with no content | CLOSED | no |
+
+---
+
+## 📊 Coverage Sentinel — 🟢 GREEN
+**Backend line coverage:** 93.13% (94,151/101,099 statements, 6,948 uncovered)  
+**7-day mean:** 92.46%  |  **Delta:** ↑ +0.67pp  
+
+**Top uncovered files** (by missing statement count):
+
+| File | Coverage | Missing | Statements |
+|------|---------:|--------:|-----------:|
+| `excel_generator.py` | 45.7% | 328 | 604 |
+| `billing\webhook_handler.py` | 59.9% | 174 | 434 |
+| `population_profile_memo.py` | 39.7% | 170 | 282 |
+| `workbook_inspector.py` | 18.6% | 136 | 167 |
+| `pdf\sections\diagnostic.py` | 64.9% | 134 | 382 |
+| `leadsheet_generator.py` | 11.3% | 126 | 142 |
+| `scripts\create_dev_user.py` | 0.0% | 111 | 111 |
+| `config.py` | 57.4% | 98 | 230 |
+| `main.py` | 44.2% | 92 | 165 |
+| `routes\internal_admin.py` | 55.4% | 82 | 184 |
+
+---
+
+## 🔍 Scout — 🟢 GREEN
+**Leads found:** 0 across 5 search themes
+
+| # | Platform | Pain Point | Paciolus Feature | Urgency | Decision Maker |
+|---|----------|-----------|-----------------|---------|----------------|
+
+---
+
+## 🏃 Sprint Shepherd — 🟢 GREEN
+**Commits (24h):** 12 | **Commits (7d):** 89  
+**Work breakdown (24h):** ui: 1, report: 4, bug fix: 4, test: 1, other: 2  
+
+---
+
+## 📦 Dependency Sentinel — 🔴 RED
+**Backend outdated:** 16 packages | **Frontend outdated:** 4 packages  
+
+🔒 **Security-relevant updates available:**
+- **cryptography**: 46.0.7 → 47.0.0 (major)
+- **fastapi**: 0.136.0 → 0.136.1 (patch)
+- **stripe**: 15.0.1 → 15.1.0 (minor)
+
+**Deferred (1):** monitored, not affecting status
+- ~pdfminer.six~ 20251230 → 20260107 — Calendar-versioned release; waiting on downstream compatibility confirmation (review by 2026-04-30)
+
+| Package | Current | Latest | Severity | Note |
+|---------|---------|--------|----------|------|
+| cryptography | 46.0.7 | 47.0.0 | major |  |
+| anthropic | 0.96.0 | 0.97.0 | minor |  |
+| certifi | 2026.2.25 | 2026.4.22 | minor |  |
+| greenlet | 3.4.0 | 3.5.0 | minor |  |
+| packaging | 26.1 | 26.2 | minor |  |
+| pathspec | 1.0.4 | 1.1.1 | minor |  |
+| pip | 26.0.1 | 26.1 | minor |  |
+| stripe | 15.0.1 | 15.1.0 | minor |  |
+| tzdata | 2026.1 | 2026.2 | minor |  |
+| uvicorn | 0.45.0 | 0.46.0 | minor |  |
+| @sentry/nextjs | 10.49.0 | 10.50.0 | minor |  |
+| click | 8.3.2 | 8.3.3 | patch |  |
+| fastapi | 0.136.0 | 0.136.1 | patch |  |
+| hypothesis | 6.152.1 | 6.152.4 | patch |  |
+| python-multipart | 0.0.26 | 0.0.27 | patch |  |
+| ruff | 0.15.11 | 0.15.12 | patch |  |
+| @typescript-eslint/eslint-plugin | 8.59.0 | 8.59.1 | patch |  |
+| @typescript-eslint/parser | 8.59.0 | 8.59.1 | patch |  |
+| postcss | 8.5.10 | 8.5.12 | patch |  |
+
+---
+*Next run: tomorrow at 2:00 AM | Output: reports/nightly/2026-04-29.md*
+---

--- a/tasks/sprint-plan-agent-sweep-2026-04-24.md
+++ b/tasks/sprint-plan-agent-sweep-2026-04-24.md
@@ -1,0 +1,539 @@
+# Sprint Plan — Agent Sweep Remediation (2026-04-24)
+
+**Purpose:** Convert the consolidated punch list (`reports/agent-sweep-consolidated-2026-04-24.md`) into discrete sprints with explicit recurrence-prevention. Each sprint has ONE prevention boundary so the same class of bug cannot silently return.
+
+**Sprint design rules used:**
+1. Group items by **prevention story**, not by file or by effort. A sprint should leave behind a guardrail (CI test, lint rule, runbook gate, or architectural invariant) that catches the problem next time.
+2. Every fix lands with a **regression test** that would have caught it.
+3. Every guardrail is **mechanical** (CI / hook / lint), not procedural ("remember to…").
+4. Documentation drift is treated as a class of bug — fix the underlying coupling, don't manually re-sync.
+
+**Sequencing principle:** Pre-Stripe-cutover sprints first (717–720), then pre-Phase-3-completion (721–722), then architectural cleanup while traffic is light (723–727), then post-launch product (728–729), then ongoing ops/hygiene (730–731). Time estimates omitted intentionally.
+
+---
+
+## Sprint 717 — Catalog & Citation Single-Source-of-Truth
+
+**Origin:** Punch list 1.1, 1.2, 2.2 + Hallucination Audit + Accounting Methodology Audit.
+
+**Problem class:** Stated truth in marketing/docs/memos drifts from actual code behavior. Today's symptoms are tool-count drift (12 vs 18 across 11 surfaces), the AS 1215 fabricated citation on 5 customer-facing files, and PR-T12/T13 missing from `PAYROLL_TEST_DESCRIPTIONS`. Each is a hand-maintained mirror of code state.
+
+**Goal:** Eliminate the mirrors. Make every claim in marketing/docs/memos either (a) generated from code, or (b) verified against code by CI.
+
+### Scope
+- **Tool catalog single source.** Create `backend/tools_registry.py` that enumerates the 18 tools with: slug, display name, engine module, test count (computed from the engine's test list, not hand-typed), tier requirement, and citation list.
+- **Generate `frontend/src/content/tool-ledger.ts` from registry** via a build-step or `scripts/generate_tool_ledger.py`. Tool counts, test counts, and tier badges all derive from one source.
+- **Bump `CANONICAL_TOOL_COUNT`** to be a derived constant, not a hand-edited literal.
+- **Citation registry.** `backend/standards_registry.py` lists every PCAOB AS / ISA / ASC / AICPA standard the platform actually cites, with the codepoint(s) where each is used. Marketing pages, Trust page, USER_GUIDE, and CLAUDE.md may cite only standards that appear in the registry.
+- **Replace AS 1215 with AS 2401** in the 5 customer-facing surfaces; verify each by registry lookup, not text search.
+- **Backfill PR-T12 and PR-T13 in `payroll_testing_memo_generator.py::PAYROLL_TEST_DESCRIPTIONS`.**
+- **Sync `CLAUDE.md` "Key Capabilities"** + `memory/MEMORY.md` Project Status to derive from registry (or be checked against it).
+- **Update `tasks/ceo-actions.md` Phase 3 checklist** to enumerate all 18 tools by name.
+
+### Recurrence prevention (the work that ensures this never happens again)
+1. **CI test `tests/test_catalog_consistency.py`:**
+   - Reads `tools_registry.py`. Asserts every tool's `test_count` equals `len(engine.TESTS)` at runtime.
+   - Asserts every test ID in every engine has a matching key in the corresponding memo's descriptions dict.
+   - Asserts `tool-ledger.ts` is byte-identical to the generator output (i.e., committers cannot hand-edit it).
+2. **CI test `tests/test_citation_consistency.py`:**
+   - Reads `standards_registry.py`. Greps every customer-facing surface (`frontend/src/app/(marketing)/**`, `docs/07-user-facing/**`, `CLAUDE.md`, `frontend/src/content/standards-specimen.ts`, the trust page) for any `AS \d+` / `ISA \d+` / `ASC \d+` token. Fails if a cited standard is not in the registry.
+3. **Pre-commit hook addition:** if any of `tool-ledger.ts`, marketing pricing/terms pages, or the trust page are staged but the registry is not, warn the committer to regenerate.
+4. **`BANNED_PATTERNS` extension** in memo generators: literal "AS 1215" added as a banned token unless `# allow-citation: AS 1215` annotation is present (for legitimate retention-rule references, if they ever exist).
+5. **Sprint-close template addition:** "registry diff reviewed; CI catalog tests green" checkbox.
+
+### Definition of Done
+- All 11 drift surfaces in 1.1 corrected; AS 1215 removed from 5 surfaces; PR-T12/T13 added to memo.
+- Catalog and citation CI tests authored, green, and required-status on `main`.
+- `tool-ledger.ts` and `tools-page.tsx` test counts derive from registry.
+- A failing test exists demonstrating each guardrail's bite (i.e., temporarily flip a count → CI fails → revert).
+
+### Acceptance evidence
+- `git log` shows `tools_registry.py` and `standards_registry.py` introduced.
+- CI run on a deliberately-bad-registry branch fails with the expected error message.
+- `frontend/src/content/tool-ledger.ts` header comment says "GENERATED — do not edit by hand."
+
+---
+
+## Sprint 718 — Auth Surface Hardening + Cookie-Bearer Parity
+
+**Origin:** Punch list 1.3, 2.4, 2.5, 2.6 + Security Review.
+
+**Problem class:** Auth helpers were written assuming Bearer-token clients (the original CLI/test path), but the production browser path uses HttpOnly cookies. The mismatch surfaces as silently-degraded security guarantees.
+
+**Goal:** Make every auth helper Bearer/cookie-symmetric by construction. Eliminate process-local auth state. Make admin recovery a tested feature.
+
+### Scope
+- **Fix `_extract_user_id_from_auth`** at `backend/security_middleware.py:485-509` to read `ACCESS_COOKIE_NAME` cookie when no `Authorization: Bearer` header is present.
+- **Verify and document** every other auth-context-extracting function: `require_current_user`, `require_verified_user`, `get_current_user_optional`, CSRF token binding, audit-log user attribution, rate-limit keying, share-passcode IP throttle. Each must work for both Bearer and cookie clients.
+- **Migrate `_ip_failure_tracker`** at `backend/security_middleware.py:619-674` from process-local `dict` to Redis (reuse `slowapi` storage URI). Per-IP throttle survives deploys and is shared across workers.
+- **Collapse share-endpoint enumeration** at `backend/routes/export_sharing.py:471-481`: passcode-protected and unknown share tokens both return 404. Move "passcode required" signal to a separate authenticated probe endpoint.
+- **Add admin lockout-recovery endpoint** `/admin/security/clear-throttle` (CEO-only): clears per-IP and per-token throttle counters for a specified key. Authenticated, audit-logged, rate-limited 1/min.
+
+### Recurrence prevention
+1. **CI test `tests/test_auth_parity.py`:** every auth-extracting helper is invoked twice per test, once with Bearer and once with cookie; both must yield identical user resolution. Parametrized over the full helper list.
+2. **CI test `tests/test_no_process_local_auth_state.py`:** AST scan of `backend/security_middleware.py` and `backend/auth.py` for module-level mutable state (`dict`, `list`, `set`, `OrderedDict`). Allowlist any read-only constants. Fails on new mutable globals.
+3. **CI test `tests/test_share_enumeration.py`:** asserts that every error response from `routes/export_sharing.py` for unknown / expired / passcode-required / IP-throttled / token-revoked tokens is byte-identical (modulo the response timing).
+4. **Auth helper invariant added to `backend/auth.py` module docstring:** "Every helper must accept Bearer headers AND HttpOnly cookies. Adding a new helper without the symmetric path will fail `test_auth_parity.py`."
+5. **Admin lockout-recovery is itself tested** — admin-recovery endpoint integration test in `test_admin_routes.py`.
+
+### Definition of Done
+- All 4 fixes landed, regression tests added, parity test green for the full helper list.
+- A failing test demonstrating each guardrail (e.g., add a mutable global → `test_no_process_local_auth_state.py` fails).
+- Runbook `docs/05-runbooks/admin-lockout-recovery.md` documents how to use the recovery endpoint.
+
+### Acceptance evidence
+- `tests/test_auth_parity.py` parametrize list includes every auth helper imported by any route.
+- Redis `iptracker:*` keys visible in Upstash dashboard after a deliberate failed-login burst.
+
+---
+
+## Sprint 719 — Stripe Live-Mode Webhook Resilience
+
+**Origin:** Punch list 1.5, 1.6, 3.4 + Guardian.
+
+**Problem class:** The webhook handler is the single point where Stripe live-mode events become Paciolus state changes. Today it has 57.4% coverage, an off-by-one, and silent failure on misconfigured secret.
+
+**Goal:** Make the webhook handler the most-tested file in the codebase. Make secret misconfiguration impossible to deploy. Make every event type idempotent and replay-safe.
+
+### Scope
+- **Fix off-by-one** at `backend/billing/webhook_handler.py:978`: `event_time < sub_updated` → `event_time <= sub_updated` with a fixture replay test for equal-time events.
+- **Add startup secret validation:** on production boot, `STRIPE_WEBHOOK_SECRET` is ping-tested against Stripe's secret-format regex (`whsec_…`); a bare `whsec_test_…` secret in `production` mode hard-fails startup.
+- **Cover every webhook event type the handler claims to handle:** `customer.subscription.created/updated/deleted`, `invoice.paid/payment_failed`, `customer.subscription.trial_will_end`, `charge.dispute.created/closed`, `customer.deleted`. One fixture-replay test per event type, including the "duplicate event" replay-safety case.
+- **Webhook coverage floor:** raise `backend/billing/webhook_handler.py` to ≥80% in `coverage_sentinel`. Coverage floor is a CI-blocking check, not advisory.
+- **Wire and verify Sentry alert** on the log message "Webhook signature verification failed."
+- **Add 24h rolling 4xx-rate alert** on `/billing/webhook` at >5%. Tested by deliberately sending malformed signatures during a smoke window.
+- **Pre-cutover smoke runner** `scripts/stripe_live_preflight.py`: invokes Stripe CLI to fire every event type once against the live endpoint and asserts each returns 200. Mandatory pre-cutover step in Phase 4.1.
+
+### Recurrence prevention
+1. **CI gate: webhook handler coverage ≥80%** is required-status. Drop below → red build.
+2. **Idempotency contract test `tests/test_webhook_idempotency.py`:** every handler is invoked twice with identical event payload and identical event_id; the second invocation must produce zero state change. Parametrized over every supported event type.
+3. **Equal-time guard test:** event_time == sub_updated must be processed exactly once, never both skipped and processed depending on race.
+4. **Pre-cutover gate in `tasks/ceo-actions.md` Phase 4.1:** "preflight script run with all-200 output captured" is a checklist item, not optional.
+5. **Sentry alert validation test** — an integration test that posts a malformed signature, then asserts the Sentry SDK was invoked with the expected error class. Catches alert regressions.
+6. **Webhook secret format check at startup** — production env-var validation in `backend/config.py` with a hard-fail on test-prefix in prod mode.
+
+### Definition of Done
+- Webhook coverage ≥80% (currently 57.4%).
+- Idempotency, off-by-one, secret-format CI tests added and green.
+- `scripts/stripe_live_preflight.py` runnable against live mode; output captured in Phase 4.1 checklist as evidence.
+- Sentry alert and 4xx-rate alert configured and verified in dashboard.
+
+### Acceptance evidence
+- Coverage report shows handler at ≥80%.
+- Stripe CLI replay shows duplicate events produce no second state mutation.
+- `STRIPE_WEBHOOK_SECRET=whsec_test_xxx ENV_MODE=production python -c "import backend.config"` exits non-zero.
+
+---
+
+## Sprint 720 — Multi-Worker State Discipline
+
+**Origin:** Punch list 1.4 + Guardian.
+
+**Problem class:** `bulk_upload.py` carries job state in a module-global `OrderedDict`, which works in a single worker but breaks under multi-worker Render. The class is "in-process state used in a request handler" — easy to introduce, hard to spot in review.
+
+**Goal:** Move bulk-upload state to durable storage and make this entire class of bug mechanically catchable.
+
+### Scope
+- **Migrate `_bulk_jobs` and friends to Postgres.** New tables: `bulk_upload_jobs` (job_id, user_id, tier, created_at, expires_at, status, total_files, completed_files, error_summary) and `bulk_upload_files` (job_id, file_index, filename, status, finding_count, error). Eviction handled by a `cleanup_scheduler` job, not in-process LRU.
+- **Replace `asyncio.create_task` fire-and-forget** with a queue-driven worker (Postgres-backed via `cleanup_scheduler` task table, or Redis queue if simpler). A worker recycle does not lose job state.
+- **Multi-worker pytest harness** `tests/test_multiworker_bulk_upload.py`: spins up two FastAPI app instances against shared test Postgres, POSTs to A and polls from B, asserts state visible.
+- **Document the invariant** — `docs/architecture/runtime-state.md` (new file) states: "Mutable runtime state lives in Postgres or Redis. Module-global mutable state in route handlers is forbidden."
+
+### Recurrence prevention
+1. **AST lint rule `scripts/lint_no_module_global_state.py`:** scans `backend/routes/**.py` and `backend/security_middleware.py` for module-level assignments to mutable types (`dict`, `list`, `set`, `OrderedDict`, `defaultdict`, `Lock`, `RLock`). Allowlist read-only constants by `Final[…]` annotation or all-caps name. Wired into `ci.yml` as a required check.
+2. **CI test `tests/test_routes_multiworker_safe.py`:** loads each route module twice in separate processes, asserts no shared in-memory state observed.
+3. **PR template addition:** "Does this change introduce in-process state? If yes, justify why Postgres/Redis is unsuitable."
+4. **`scripts/find_module_global_state.py` runbook entry** — quick scan for periodic audits.
+
+### Definition of Done
+- Bulk upload survives a worker recycle and works on Render's multi-worker config.
+- Multi-worker harness test green.
+- Lint rule wired into CI; a deliberately-bad commit (re-add `_bulk_jobs = {}`) fails the lint check.
+- ADR or runtime-state doc committed.
+
+### Acceptance evidence
+- Render deploy with `numInstances=2` (or `gunicorn workers=2`) accepting bulk-upload POSTs and serving status polls cross-worker.
+- Lint rule output captures the historical bad pattern as a known violation if reintroduced.
+
+---
+
+## Sprint 721 — Memo Output Quality & ISA 265 Boundary
+
+**Origin:** Punch list 2.3 + Accounting Methodology Audit.
+
+**Problem class:** Memo generators contain language that drifts toward auditor-judgment territory (deficiency classification, misstatement conclusions). Today's `BANNED_PATTERNS` regex catches the hardest cases, but softer phrases slip through.
+
+**Goal:** Make boundary phrasing mechanically detectable. Establish an "auditing lexicon" so future memo authors know what's safe.
+
+### Scope
+- **Rephrase `three_way_match_memo_generator.py`** to drop "systemic review of procure-to-pay controls recommended" → anomaly-indicator language ("match-rate threshold breached; auditor judgment required to determine cause").
+- **Rephrase `ar_aging_memo_generator.py`** to drop "potential understatement of credit loss expense" → "aging-bucket distribution suggests further inquiry into credit-loss estimation."
+- **Build `docs/03-engineering/auditing-lexicon.md`** with explicit allow/deny phrase list, organized by ISA/AS reference. Allow: "anomaly indicator," "data signal," "warrants inquiry," "threshold breached." Deny: "deficiency," "misstatement," "control failure," "should be," "recommended remediation."
+- **Strengthen `BANNED_PATTERNS`** in memo generators to include the "soft" cases caught by the audit. Pattern list reviewed against the auditing lexicon's deny list.
+- **Snapshot tests** for every memo generator: render against synthetic engagement fixtures, assert the rendered text contains zero banned-pattern hits.
+
+### Recurrence prevention
+1. **CI test `tests/test_memo_boundary_phrasing.py`:** every memo generator runs against a standardized synthetic engagement; the output text is grepped against the full deny list. Fails on any hit.
+2. **Sprint-close template addition:** "memo language reviewed against auditing lexicon" checkbox for any sprint that touches a `*_memo_generator.py`.
+3. **PR template gate:** PRs touching memo generators must link to the lexicon entry justifying any new phrase that pattern-matches the deny regex.
+
+### Definition of Done
+- Both flagged memo generators rephrased.
+- Auditing lexicon committed.
+- BANNED_PATTERNS regex extended; snapshot tests green for all 18 memo generators against synthetic fixtures.
+- A deliberately-bad memo edit (insert "deficiency") fails CI.
+
+### Acceptance evidence
+- Diff of `BANNED_PATTERNS` + auditing-lexicon entries.
+- CI run on a memo-edit branch with bad phrasing fails with the expected pattern hit.
+
+---
+
+## Sprint 722 — Memory Budget for Memo Generation
+
+**Origin:** Punch list 2.1 + Guardian.
+
+**Problem class:** ReportLab + openpyxl accumulate in RAM. On Render Standard 2 GB, generating 18 memos back-to-back risks OOM-killing the worker. The risk is invisible until production load hits it.
+
+**Goal:** Establish and enforce a per-request memory budget; recycle workers before they breach it; regression-test the back-to-back path.
+
+### Scope
+- **Add `gc.collect()` between memo generations** in any handler that produces multiple memos sequentially (e.g., diagnostic-package ZIP generation).
+- **Configure Render `maxRequestsPerWorker`** so workers recycle every N requests before pressure builds. N tuned via load test.
+- **Add memory probe logging** at memo-generator boundaries: log RSS before and after each memo. Threshold-exceeded → Sentry warning.
+- **Sentry alert on worker memory >85%** of dyno limit.
+- **Memory regression test `tests/test_memo_generation_memory.py`:** generates all 18 memos sequentially in CI, fails if peak RSS exceeds budget (e.g., 1.2 GB headroom on Render's 2 GB).
+- **Runbook `docs/05-runbooks/memory-pressure.md`:** how to read memory probe logs, what to do when the alert fires.
+
+### Recurrence prevention
+1. **Memory budget CI test** runs on every PR that touches `*_memo_generator.py`, `pdf/sections/**`, or `excel_generator.py`. Regression caught at PR time, not deploy time.
+2. **Sentry alert wired and tested** with a deliberate memory burn fixture (only in staging).
+3. **Runbook entry** in the memory-pressure doc points future engineers to the test and the alert.
+
+### Definition of Done
+- Memory regression test green; deliberately-bad change (remove `gc.collect`) fails the test.
+- Render `maxRequestsPerWorker` set; deploy logs show worker recycling at expected cadence.
+- Sentry alert configured and tested.
+
+### Acceptance evidence
+- CI artifact showing peak RSS per-memo over the 18-memo run.
+- Render deploy log showing `maxRequestsPerWorker` recycling.
+
+---
+
+## Sprint 723 — Coverage Floor Enforcement (Foundational)
+
+**Origin:** Punch list 3.5 + Guardian + Coverage Sentinel report.
+
+**Problem class:** The 10 lowest-coverage files in the codebase are also the most production-critical (parsers, generators, webhook handler). Coverage degradation goes unnoticed because coverage_sentinel is informational, not blocking.
+
+**Goal:** Establish per-file coverage floors for the high-risk files. Make sentinels blocking. Catch coverage regressions at PR time.
+
+### Scope
+- **Set per-file coverage floors** for the 10 lowest-coverage critical files:
+  - `excel_generator.py` (45.7% → floor 70%)
+  - `billing/webhook_handler.py` (57.4% → floor 80%, see Sprint 719)
+  - `population_profile_memo.py` (39.7% → floor 70%)
+  - `workbook_inspector.py` (18.6% → floor 75%) — first-touch on every upload, highest priority
+  - `pdf/sections/diagnostic.py` (64.9% → floor 80%)
+  - `leadsheet_generator.py` (11.4% → floor 75%)
+  - `config.py` (54.5% → floor 75%)
+  - `main.py` (44.2% → floor 70%)
+  - `preflight_engine.py` (84.1% → floor 85%)
+  - `routes/bulk_upload.py` (after Sprint 720) → floor 80%
+- **Add backfill tests** for `workbook_inspector.py` adversarial inputs: password-protected xlsx, malformed ods, XML bombs, zip slip, corrupted CSV, Unicode normalization edge cases.
+- **Add backfill tests** for `leadsheet_generator.py` style-collision path (`_register_styles` swallowing ValueError on duplicate NamedStyle — surface and fix).
+- **Backfill tests** for the remaining 6 files following the same adversarial-fixture pattern.
+- **Promote `coverage_sentinel`** from advisory nightly artifact to PR-blocking CI check. Floors stored in `coverage_floors.yaml`; lowering a floor requires CODEOWNERS approval.
+
+### Recurrence prevention
+1. **Coverage-floor CI gate:** any file in `coverage_floors.yaml` that drops below its floor fails CI. Lowering a floor requires a PR with explicit CODEOWNERS approval.
+2. **Floor-list expansion gate:** a PR that adds a new high-risk module (parser, generator, webhook handler, route module) must add it to `coverage_floors.yaml`. Enforced by a CI script that diffs new module additions against the floor list.
+3. **Adversarial fixture corpus** added to `backend/tests/fixtures/adversarial/` with a README pointing future authors to use it.
+
+### Definition of Done
+- 10 floors set; all 10 files at or above floor.
+- `coverage_floors.yaml` is a required-status gate.
+- A deliberately-bad PR (delete a test) fails CI with the expected floor-drop message.
+
+### Acceptance evidence
+- `coverage_floors.yaml` committed; CI run shows floor enforcement passing.
+- Adversarial fixture corpus has at least 5 inputs per high-risk parser.
+
+---
+
+## Sprint 724 — `shared/helpers.py` Shim Removal
+
+**Origin:** Punch list 3.2 + BackendCritic.
+
+**Problem class:** A decomposition refactor (2026-04-20) split `helpers.py` into domain modules but left a 35-symbol re-export shim for backwards compatibility. 62 call sites still go through the shim vs 6 direct. The shim is winning because there is no mechanical pressure to migrate.
+
+**Goal:** Delete the shim entirely. Make new shim imports impossible.
+
+### Scope
+- **Sweep all 62 call sites** and rewrite imports to point at the appropriate domain module.
+- **Delete `backend/shared/helpers.py`** and its tests.
+- **Verify private symbols (`_XLS_MAGIC`, `_parse_csv`, `_log_tool_activity`)** that were re-exported are now properly scoped to their owning module; if they had legitimate cross-module callers, promote them to public names in their owning module.
+
+### Recurrence prevention
+1. **Import-ban CI rule** in `pyproject.toml` (ruff `flake8-tidy-imports` or equivalent): `from backend.shared.helpers import …` is a hard error after the deletion. Catches accidental resurrection.
+2. **CI test `tests/test_no_shared_helpers_import.py`:** AST scan of `backend/**.py` for `import backend.shared.helpers` or `from backend.shared.helpers`. Fails on any match.
+3. **Architecture doc update:** `docs/03-engineering/module-boundaries.md` documents the domain-module pattern and explicitly notes that `shared/helpers.py` is deprecated forever.
+
+### Definition of Done
+- `backend/shared/helpers.py` deleted.
+- All 62 call sites migrated and tests still green.
+- Lint rule + AST test both fail on a deliberately-bad PR (re-add the shim).
+
+### Acceptance evidence
+- `git log -- backend/shared/helpers.py` ends with the deletion commit.
+- `grep -r "shared.helpers" backend/ src/` returns zero matches.
+
+---
+
+## Sprint 725 — Export Endpoint Consolidation
+
+**Origin:** Punch list 3.3 + BackendCritic.
+
+**Problem class:** `routes/export_diagnostics.py` (689 LoC) has 7 copy-pasted CSV-writer endpoints. Sister `routes/export_testing.py` already collapsed the same pattern via `csv_export_handler()` (Sprints 218-219). Every bug fix or schema change today hits 7 sites in `export_diagnostics.py`.
+
+**Goal:** Apply the existing `csv_export_handler()` pattern to `export_diagnostics.py`. Make the pattern mandatory for any future export route.
+
+### Scope
+- **Refactor `routes/export_diagnostics.py`** so all 7 CSV endpoints route through `csv_export_handler()`.
+- **Golden-file test per endpoint** (snapshot of CSV output) so the refactor is byte-identical, not just behaviorally equivalent.
+- **Promote `csv_export_handler()`** from `routes/export_testing.py` to `backend/shared/csv_export.py` if not already there, so both routers use the same canonical implementation.
+
+### Recurrence prevention
+1. **CI test `tests/test_export_routes_use_handler.py`:** AST scan of `backend/routes/export_*.py`. Any function-decorated-with-`@router.get` whose body does not call `csv_export_handler` (or other approved factory) fails the check.
+2. **CODEOWNERS rule:** PRs touching `routes/export_*.py` require export-domain owner review; reduces "I'll just inline this one" drift.
+3. **Architecture doc update:** `docs/03-engineering/export-pattern.md` describes the handler factory pattern; PR template asks "are you adding a new export endpoint? If so, why isn't it using `csv_export_handler`?"
+
+### Definition of Done
+- `routes/export_diagnostics.py` LoC reduced ~50%.
+- Golden-file tests green; output byte-identical pre/post refactor.
+- Lint rule fails on a deliberately-bad PR (inline a CSV writer).
+
+### Acceptance evidence
+- Diff shows 7 hand-written endpoints replaced by 7 calls to `csv_export_handler`.
+- Golden-file fixture set committed.
+
+---
+
+## Sprint 726 — `AuditEngineBase` Migration, Phase 1 (Revenue, AR, FA, Inventory)
+
+**Origin:** Punch list 3.1 + BackendCritic.
+
+**Problem class:** `engine_framework.py` defines a clean 10-step pipeline ABC, but only 3 of 12 testing engines (JE, AP, Payroll) subclass it. The other 9 reimplement the pipeline as top-level `run_*()` procedural functions. Sprint 689 expanded the catalog to 18 tools while this fork was still open, so the inconsistency is now broader.
+
+**Goal:** Convert the 4 largest off-pattern engines (Revenue, AR, FA, Inventory — combined ~7,800 LoC) onto `AuditEngineBase`. Establish a lint rule so the remaining 5 follow in Phase 2.
+
+### Scope
+- **Migrate Revenue, AR Aging, Fixed Assets, Inventory engines** to subclass `AuditEngineBase`.
+- **Behavioral parity tests** for each: regression suite of synthetic TBs run against pre- and post-migration engine; output must match modulo dataclass field ordering.
+- **Add `engine_base_lint.py`** that scans `backend/*_engine.py` and `backend/*_testing_engine.py` for top-level `run_*()` functions that should be class methods. Phase 1 wires it as a CI **warning** (not blocking) so the remaining 5 engines still build.
+- **Phase 1 ADR `docs/03-engineering/adr-013-audit-engine-base.md`** explains the pattern, the migration approach, and the lint rule.
+
+### Recurrence prevention
+1. **`engine_base_lint.py`** as a CI warning in Phase 1. Promoted to error in Sprint 727 (Phase 2).
+2. **Behavioral parity test pattern** documented; any future engine refactor must produce a parity test before being merged.
+3. **PR template gate:** "Are you adding a new engine? Subclass `AuditEngineBase`."
+
+### Definition of Done
+- 4 engines migrated; parity tests green.
+- Engine-base lint rule landed as warning.
+- ADR committed.
+
+### Acceptance evidence
+- `git log` shows the 4 engine migrations as discrete commits (one per engine for bisect-friendliness).
+- Parity test artifacts in CI runs.
+
+---
+
+## Sprint 727 — `AuditEngineBase` Migration, Phase 2 + Lint Promotion
+
+**Origin:** Sprint 726 follow-on.
+
+**Goal:** Migrate the remaining 5 off-pattern engines (3-way match, accrual completeness, population profile, sampling, cash flow projector) and promote the lint rule to error.
+
+### Scope
+- **Migrate the 5 remaining engines** following Sprint 726's pattern with parity tests for each.
+- **Promote `engine_base_lint.py`** from CI warning to CI error.
+- **Update ADR-013** to mark the migration complete.
+
+### Recurrence prevention
+1. **Lint rule promoted to error** — any future engine that does not subclass `AuditEngineBase` fails CI.
+2. **Engine pattern is now load-bearing** — any new tool added to the catalog must follow it. Reinforces Sprint 717's catalog single-source.
+
+### Definition of Done
+- All 12 testing engines on `AuditEngineBase` (or 18 if Sprint 689's promoted tools count as engines — verify against `tools_registry.py`).
+- Lint rule at error.
+- ADR-013 marked complete.
+
+### Acceptance evidence
+- A deliberately-bad PR (top-level `run_*` engine function) fails CI with the lint error.
+
+---
+
+## Sprint 728 — ISA 520 Expectation-Formation Workflow
+
+**Origin:** Punch list 4.1 + Accounting Methodology Audit.
+
+**Problem class:** The platform's analytical procedures (flux, ratio, multi-period TB) produce observed-vs-prior comparisons. ISA 520.5(a) / AS 2305.10 require a **structured expectation with stated precision and corroboration basis** when analytics are used as a primary substantive procedure. CPAs intending to rely on flux/ratio output as their primary procedure evidence will hit this gap immediately.
+
+**Goal:** Add an expectation-formation surface to the analytical tools that satisfies ISA 520. This is a feature-shaped product gap, not a bug.
+
+### Scope
+- **New engagement-layer entity `AnalyticalExpectation`:** procedure target (account/balance/ratio), expected value, expected range / precision threshold, corroboration basis (free text + structured tags: industry data, prior period, budget, regression model), CPA notes.
+- **Wire into flux, ratio, and multi-period TB tools:** before running, the tool prompts (or reads pre-supplied) expectations. Tool output compares actual vs expected, flags variance > precision threshold.
+- **New memo generator `analytical_expectation_memo_generator.py`** producing the expectation workpaper.
+- **Engagement-completion-gate update:** any engagement that used analytical procedures as primary substantive evidence requires expectations to be on file.
+- **Methodology gap closure** documented in `docs/04-compliance/isa-520-coverage.md`.
+
+### Recurrence prevention
+1. **Methodology coverage CI test** (extends Sprint 717's citation registry): any tool whose memo cites ISA 520 must have an expectation-input surface.
+2. **Engagement completion gate test:** an engagement that used analytical tools as primary procedure but has no `AnalyticalExpectation` records fails the completion gate.
+
+### Definition of Done
+- Feature shipped; flux/ratio/multi-period prompt for or accept expectations.
+- Memo generator outputs the expectation workpaper.
+- Completion gate enforces expectation presence when applicable.
+
+### Acceptance evidence
+- End-to-end test: engagement using flux as primary procedure cannot reach completion without expectations on file.
+
+---
+
+## Sprint 729 — ISA 450 Summary of Uncorrected Misstatements (SUM) Schedule
+
+**Origin:** Punch list 4.2 + Accounting Methodology Audit.
+
+**Problem class:** ISA 450 / AU-C 450 requires a running SUM schedule consolidating passed adjustments + sample-projected misstatements + aggregate vs materiality. Today the platform has approval-gated adjusting entries and sampling UEL output, but no consolidation surface. Every CPA completing an engagement reaches for this and finds nothing.
+
+**Goal:** Add the SUM consolidation surface. Wire into the engagement completion gate.
+
+### Scope
+- **New engagement-layer entity `UncorrectedMisstatement`:** source (adjusting entry passed / sample projection / known error), amount, account(s) affected, classification (factual / judgmental / projected), F/S impact, materiality assessment.
+- **SUM schedule view** in the engagement layer that auto-aggregates from `AdjustingEntry` (status=passed), `SampleProjection` (UEL > tolerable), and CPA-entered known errors.
+- **Materiality comparison surface:** SUM aggregate vs engagement materiality (set at planning), with bucket: clearly trivial / immaterial / approaching material / material.
+- **New memo generator `sum_schedule_memo_generator.py`** producing the SUM workpaper for archival.
+- **Engagement completion gate update:** completion requires SUM review on file (CPA marks each item as "auditor proposes correction" or "auditor accepts as immaterial").
+
+### Recurrence prevention
+1. **Engagement completion gate test:** an engagement with passed adjustments or sampling UEL output but no SUM review fails the gate.
+2. **SUM aggregate sanity test:** if total SUM > materiality and engagement is marked complete, hard-error.
+
+### Definition of Done
+- Feature shipped; SUM aggregates from existing data sources automatically.
+- Memo generator outputs the SUM workpaper.
+- Completion gate enforces SUM review.
+
+### Acceptance evidence
+- End-to-end test: engagement with $X of passed adjustments and Y sample-projected misstatements produces SUM = X + Y in the workpaper.
+
+---
+
+## Sprint 730 — Operational Observability Polish
+
+**Origin:** Punch list Tier 5 + Guardian post-launch monitoring gaps.
+
+**Problem class:** Several "operational" gaps surfaced where production state changes are not detectable until users complain. Each is small individually; together they leave gaps in the post-launch monitoring story.
+
+**Goal:** Close the four operational gaps with mechanical health checks and tested alerts.
+
+### Scope
+- **Redis (Upstash) blip detection:** add `/health/redis` ping endpoint; Sentry alert on `RedisStorage` exceptions (slowapi fail-open warning is currently silent).
+- **R2 transient-vs-permanent distinction in `export_share_storage.download()`:** transient (5xx from R2 / connection error) → 503 to client; permanent (404) → 410 to client. Mass 410s currently look like permanent data loss.
+- **`/health/r2` sentinel GET:** lightweight HEAD against a fixed sentinel object in `paciolus-exports`. Cron'd uptime check hits this.
+- **Sprint Shepherd regex fix:** today's risk-signal regex matches the literal substring `TODO` even inside hotfix descriptions (false-positive on commit `a275fa58`). Tighten to require word-boundaries and exclude descriptions.
+- **Lessons consolidation:** roll up the three Sprint 716-era "verify against live system" lessons (`tasks/lessons.md`) into one canonical lesson titled "Trust the live system over the documented contract." Add a 4-line verify-against-live checklist to the sprint-close template.
+
+### Recurrence prevention
+1. **Health-endpoint test pattern:** every `/health/*` endpoint has a dedicated integration test that simulates the failure mode and asserts the alert fires.
+2. **Sprint Shepherd regex unit-test:** the false-positive commit message is committed as a fixture; regression test asserts no false positive.
+3. **Sprint-close checklist** with the 4-line verify-against-live block; lessons.md no longer accumulates near-duplicates.
+
+### Definition of Done
+- All 4 health/alert gaps closed and tested.
+- Sprint Shepherd no longer YELLOWs on hotfix descriptions containing "TODO."
+- Three near-duplicate lessons consolidated.
+
+### Acceptance evidence
+- `/health/redis` and `/health/r2` documented in `docs/05-runbooks/health-endpoints.md`.
+- A deliberately-flaky Redis simulation in staging triggers Sentry alert as expected.
+
+---
+
+## Sprint 731 — Dependency Hygiene Cadence
+
+**Origin:** Punch list Tier 5 (security-relevant patches) + Project Auditor.
+
+**Problem class:** Two security-relevant updates have been available since 2026-04-22 (fastapi 0.136.0 → 0.136.1 patch, stripe 15.0.1 → 15.1.0 minor). Today's nightly Dependency Sentinel is YELLOW. The current process treats sentinel YELLOW as "fyi" rather than "act."
+
+**Goal:** Land the available patches and codify a cadence policy so security-relevant updates land within a fixed window.
+
+### Scope
+- **Patch fastapi 0.136.0 → 0.136.1, stripe 15.0.1 → 15.1.0** (with regression run).
+- **Add cadence policy to `docs/03-engineering/dependency-policy.md`:**
+  - Security-relevant patch (CVE-tagged or marked security-relevant by sentinel): land within **7 days** of detection.
+  - Security-relevant minor: land within **14 days**.
+  - Major dep upgrades: scheduled sprint, no deadline pressure.
+  - Calendar-versioned packages (e.g., pdfminer.six): default 30-day soak before update.
+- **Dependency Sentinel becomes blocking** for security-relevant items past the deadline. Prior to deadline, status is YELLOW; past deadline, RED → CI block.
+- **Auto-PR bot** (Dependabot, Renovate, or a tiny GitHub Action) opens a PR per security-relevant update on detection, so the engineer step is review + merge, not authoring.
+
+### Recurrence prevention
+1. **Sentinel deadline gate** turns "fyi" into "deadline." Past deadline → CI red.
+2. **Auto-PR removes the cold-start cost** of patch-bumping; the deadline forces review.
+3. **Policy doc** is the canonical reference for "do I need to act on this dep?"
+
+### Definition of Done
+- Patches landed, regression green.
+- Policy doc committed; Sentinel deadline gate live.
+- Auto-PR bot configured and producing PRs against `main`.
+
+### Acceptance evidence
+- A deliberately-late simulated dep (fixture) produces a RED sentinel and CI block.
+- Auto-PR bot has opened ≥1 successful PR by sprint close.
+
+---
+
+## Sequencing Summary
+
+| Sprint | Title | Why now |
+|---|---|---|
+| 717 | Catalog & Citation SSOT | Production-visible drift; legal-surface (ToS) involvement |
+| 718 | Auth Surface Hardening | High-severity CSRF binding bug; pre-Stripe |
+| 719 | Stripe Live-Mode Webhook Resilience | Real-money traffic about to fly |
+| 720 | Multi-Worker State Discipline | Bulk upload broken in production right now |
+| 721 | Memo Output Quality & ISA 265 | Pre-Phase-3 walkthrough; legal/methodology risk |
+| 722 | Memory Budget for Memo Generation | Pre-Phase-3 walkthrough; OOM risk on 18-memo run |
+| 723 | Coverage Floor Enforcement | Foundational for all later refactors |
+| 724 | `shared/helpers.py` Shim Removal | Should land before engine refactors that may import shim |
+| 725 | Export Endpoint Consolidation | Independent; can land any time post-723 |
+| 726 | AuditEngineBase Phase 1 | After 723's coverage floors are protecting refactor |
+| 727 | AuditEngineBase Phase 2 + lint promotion | Closes the engine-pattern fork |
+| 728 | ISA 520 Expectation Workflow | Post-launch product feature; CPA retention |
+| 729 | ISA 450 SUM Schedule | Post-launch product feature; CPA retention |
+| 730 | Operational Observability Polish | Continuous; anytime post-launch |
+| 731 | Dependency Hygiene Cadence | Continuous; first execution lands the two pending patches |
+
+---
+
+## Cross-cutting Prevention Themes
+
+After grouping, four prevention patterns recur across multiple sprints. Naming them explicitly so they become reusable:
+
+**1. Single Source of Truth + CI consistency check.** (Sprints 717, 723) Every claim in human-edited content must derive from machine-readable source, or be CI-verified against it.
+
+**2. Symmetry/parity tests.** (Sprints 718, 719, 720) Every code path that has two surface forms (Bearer/cookie, single-event/duplicate-event, single-worker/multi-worker) gets a parity test that runs both forms and asserts equivalence.
+
+**3. AST/lint guardrails for "easy to reintroduce" bugs.** (Sprints 718, 720, 724, 725, 726, 727) Anywhere a bug class can be reintroduced via an innocent-looking PR, a mechanical scanner makes the bug class impossible to merge.
+
+**4. Sentinel YELLOW → CI RED with deadlines.** (Sprints 723, 731) Coverage and dependency sentinels become blocking past their deadline thresholds. "FYI" becomes "act."
+
+These four patterns should be cited in any future sprint that introduces a new prevention guardrail, so the codebase accumulates a recognizable shape rather than ad-hoc one-offs.
+
+---
+
+*Generated 2026-04-24 by IntegratorLead from the consolidated agent-sweep punch list.*


### PR DESCRIPTION
## Summary

Batch-commit of operational audit artifacts that accumulated locally between 2026-04-23 and 2026-04-28. Brings github in sync with local for the audit trail Codex (the github-only code reviewer) needs to see when consulted on project decisions. Matches existing project pattern — see prior hotfix commits `9820bb2`, `7915d77`, `22e16dc` for similar batch-commits of nightly artifacts.

## Why this matters

Codex sees only github state. When local audit artifacts run ahead of github, Codex's recommendations can be based on stale audit data while Claude (which has local access) reasons from ground truth. This commit closes that gap for the 2026-04-23 → 28 window. Process improvement to prevent recurrence is filed separately.

## Contents (59 files, ~5,800 lines)

- `reports/nightly/2026-04-{23..28}.md` — 6 daily audit reports
- `reports/nightly/.{coverage,dependency,qa_warden,report_auditor,scout,sprint_shepherd}_sentinel_2026-04-{23..28}.json` — 36 sentinel JSONs (6 days × 6 sentinels)
- `reports/nightly/.run_log_2026-04-{23..28}.txt` — 6 nightly run logs
- `reports/nightly/.baseline.json` — modified to reflect Sprint 711-740 test-count growth (incl. cleanup_scheduler 29 → 30 from Sprint 740's contract test)
- `reports/agent-sweep-consolidated-2026-04-24.md` — multi-agent audit sweep from 2026-04-24
- `reports/audit-{accounting-methodology,critic,deadcode,guardian,hallucination,project-auditor,scout,security}-2026-04-24.md` — 8 per-agent reports from the same sweep
- `tasks/sprint-plan-agent-sweep-2026-04-24.md` — sprint-plan generated by that sweep

## Excluded (intentionally not staged)

- `.hypothesis/` — pytest hypothesis cache
- `frontend/playwright-report/` — ephemeral HTML reports
- `tmp_report.py` — scratch file from earlier session

## Test plan
- [x] No code/test/config changes; no test execution required
- [ ] CI green on doc-only diff (frontend build/lint, dep-compliance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)