### PR TITLE
Sprint 763-767: Financial Calculation Correctness initiative (Path B)

### DIFF
--- a/backend/audit/rules/relationships.py
+++ b/backend/audit/rules/relationships.py
@@ -84,9 +84,51 @@ def detect_intercompany_imbalances(
     classifier: AccountClassifier,
     provided_account_types: dict[str, str],
     provided_account_names: dict[str, str],
+    counterparty_mapping: dict[str, str] | None = None,
+    mapping_source: str = "none",
 ) -> list[dict[str, Any]]:
-    """Detect intercompany accounts with elimination gaps."""
-    ic_accounts: list[tuple[str, str, float, dict]] = []
+    """Detect intercompany accounts with elimination gaps.
+
+    Sprint 764 \u2014 layered detection.  When ``counterparty_mapping`` is
+    supplied (resolved via ``shared.intercompany_resolver``), the metadata
+    path is consulted first for each candidate account; the heuristic
+    separator parser only runs when metadata does not name the
+    counterparty.  Each finding carries:
+
+    - ``detection_method``: ``"metadata_exact"`` | ``"heuristic_separator"``
+      | ``"heuristic_keyword"`` \u2014 explainability for ISA 230 documentation.
+    - ``mapping_source``: ``"request"`` | ``"engagement"`` | ``"none"`` \u2014
+      where the metadata mapping originated.
+    - ``confidence``: 1.0 for metadata-exact matches, 0.85 for separator-
+      parsed heuristic matches, 0.65 for keyword-only matches with no
+      counterparty extracted.
+
+    Backward-compatible: when ``counterparty_mapping`` is ``None`` or
+    empty and ``mapping_source == "none"``, behavior matches the legacy
+    heuristic-only path with appropriate detection_method labels.
+    """
+    mapping = counterparty_mapping or {}
+
+    def _metadata_lookup(account_key: str, display: str) -> str | None:
+        """Resolve a counterparty from the supplied mapping.
+
+        Tries multiple key shapes because the display string is
+        ``"{account_key} — {provided_name}"`` (em-dash join) when a
+        provided name exists.  Auditors typically populate the mapping
+        with the bare provided name, not the joined display.
+        """
+        if not mapping:
+            return None
+        candidates = [display.lower(), account_key.lower()]
+        provided = provided_account_names.get(account_key)
+        if provided:
+            candidates.append(provided.lower())
+        for key in candidates:
+            if key in mapping:
+                return mapping[key]
+        return None
+
+    ic_accounts: list[tuple[str, str, float, dict, str | None]] = []
     for account_key, balances in account_balances.items():
         net_balance = balances["debit"] - balances["credit"]
         if abs(Decimal(str(net_balance))) < BALANCE_TOLERANCE:
@@ -94,13 +136,17 @@ def detect_intercompany_imbalances(
 
         display = build_display_name(account_key, provided_account_names)
         search_text = display.lower()
-        if any(kw in search_text for kw, _w, _p in INTERCOMPANY_KEYWORDS):
-            ic_accounts.append((account_key, display, net_balance, balances))
+
+        # Metadata-flagged accounts always count as IC even if they don't
+        # contain a keyword (auditor judgment overrides the heuristic).
+        metadata_cp = _metadata_lookup(account_key, display)
+        if metadata_cp or any(kw in search_text for kw, _w, _p in INTERCOMPANY_KEYWORDS):
+            ic_accounts.append((account_key, display, net_balance, balances, metadata_cp))
 
     if not ic_accounts:
         return []
 
-    def _extract_counterparty(name: str) -> str:
+    def _extract_counterparty_heuristic(name: str) -> str:
         lower = name.lower()
         for sep in [" \u2014 ", " \u2013 ", " - ", "\u2014", "\u2013", "-"]:
             if sep in lower:
@@ -110,20 +156,33 @@ def detect_intercompany_imbalances(
                     return cp
         return ""
 
-    counterparty_groups: dict[str, list[tuple[str, str, float, dict]]] = {}
-    for key, display, net, bals in ic_accounts:
-        cp = _extract_counterparty(display)
+    # Layered counterparty resolution per account: metadata first, then
+    # heuristic.  The fifth element of each ic_accounts tuple carries the
+    # already-resolved metadata counterparty (or None).
+    counterparty_groups: dict[str, list[tuple[str, str, float, dict, str]]] = {}
+    for key, display, net, bals, metadata_cp in ic_accounts:
+        if metadata_cp:
+            cp = metadata_cp.lower()
+            method = "metadata_exact"
+        else:
+            heuristic_cp = _extract_counterparty_heuristic(display)
+            if heuristic_cp:
+                cp = heuristic_cp
+                method = "heuristic_separator"
+            else:
+                cp = ""
+                method = "heuristic_keyword"
         if cp:
-            counterparty_groups.setdefault(cp, []).append((key, display, net, bals))
+            counterparty_groups.setdefault(cp, []).append((key, display, net, bals, method))
 
     findings: list[dict[str, Any]] = []
     for cp_name, accounts in counterparty_groups.items():
-        net_total = sum(net for _, _, net, _ in accounts)
+        net_total = sum(net for _, _, net, _, _ in accounts)
         if abs(Decimal(str(net_total))) < BALANCE_TOLERANCE:
             continue
 
-        has_debit = any(net > 0 for _, _, net, _ in accounts)
-        has_credit = any(net < 0 for _, _, net, _ in accounts)
+        has_debit = any(net > 0 for _, _, net, _, _ in accounts)
+        has_credit = any(net < 0 for _, _, net, _, _ in accounts)
 
         if has_debit and has_credit:
             issue = f"Intercompany elimination gap of ${abs(net_total):,.2f} with {cp_name.title()}"
@@ -132,7 +191,7 @@ def detect_intercompany_imbalances(
         else:
             issue = f"Intercompany payable to {cp_name.title()} \u2014 no offsetting receivable found"
 
-        for key, display, net, bals in accounts:
+        for key, display, net, bals, method in accounts:
             if abs(net) < 0.01:
                 continue
             abs_amount = abs(net)
@@ -145,6 +204,17 @@ def detect_intercompany_imbalances(
             )
             is_material = abs_amount >= materiality_threshold
 
+            # Confidence reflects detection quality: metadata is auditor-
+            # vetted (1.0); heuristic separator parsing is reliable but
+            # not authoritative (0.85); keyword-only with no counterparty
+            # is the weakest signal (0.65).
+            if method == "metadata_exact":
+                confidence = 1.0
+            elif method == "heuristic_separator":
+                confidence = 0.85
+            else:
+                confidence = 0.65
+
             findings.append(
                 {
                     "account": display,
@@ -155,13 +225,16 @@ def detect_intercompany_imbalances(
                     "credit": round(bals["credit"], 2),
                     "materiality": "material" if is_material else "immaterial",
                     "category": category.value,
-                    "confidence": 0.85,
+                    "confidence": confidence,
                     "matched_keywords": ["intercompany"],
                     "requires_review": True,
                     "anomaly_type": "intercompany_imbalance",
                     "severity": "high" if is_material else "medium",
                     "suggestions": [],
                     "cross_reference_note": f"Counterparty: {cp_name.title()} \u2014 net exposure: ${abs(net_total):,.2f}",
+                    # Sprint 764: explainability fields.
+                    "detection_method": method,
+                    "mapping_source": mapping_source,
                 }
             )
 

--- a/backend/audit/streaming_auditor.py
+++ b/backend/audit/streaming_auditor.py
@@ -419,14 +419,26 @@ class StreamingAuditor:
             self.provided_account_names,
         )
 
-    def detect_intercompany_imbalances(self) -> list[dict[str, Any]]:
-        """Detect intercompany accounts with elimination gaps."""
+    def detect_intercompany_imbalances(
+        self,
+        counterparty_mapping: dict[str, str] | None = None,
+        mapping_source: str = "none",
+    ) -> list[dict[str, Any]]:
+        """Detect intercompany accounts with elimination gaps.
+
+        Sprint 764: forwards the resolved counterparty mapping + source
+        tag through to the layered detection layer.  Defaults preserve
+        the legacy heuristic-only behavior for callers that have not
+        been wired to the resolver yet.
+        """
         return _detect_intercompany_imbalances(
             self.account_balances,
             self.materiality_threshold,
             self.classifier,
             self.provided_account_types,
             self.provided_account_names,
+            counterparty_mapping=counterparty_mapping,
+            mapping_source=mapping_source,
         )
 
     def detect_equity_signals(self) -> list[dict[str, Any]]:

--- a/backend/bank_reconciliation.py
+++ b/backend/bank_reconciliation.py
@@ -27,7 +27,22 @@ from typing import Optional
 
 from shared.column_detector import ColumnFieldConfig, detect_columns
 from shared.filenames import sanitize_csv_value
+from shared.monetary import quantize_monetary
 from shared.parsing_helpers import parse_date, safe_decimal, safe_str
+
+
+def _money(value: Decimal | float | int | None) -> float:
+    """Sprint 766: serialize a monetary value at the response boundary.
+
+    Quantizes to 2dp ROUND_HALF_UP via ``quantize_monetary`` and returns a
+    Python float so JSON wire format is unchanged.  Replaces the
+    pre-existing ``round(value, 2)`` patterns which used Python's
+    banker's rounding (HALF_EVEN) at the boundary.
+    """
+    if value is None:
+        return 0.0
+    return float(quantize_monetary(value))
+
 
 # =============================================================================
 # ENUMS & CONFIG
@@ -56,14 +71,45 @@ class SuggestedJEKind(str, Enum):
     OTHER = "other"
 
 
+# Documented defaults for bank-rec thresholds.  Sprint 763: kept in module
+# scope so callers can introspect what the engine treats as "no caller
+# override supplied".  Values mirror the historical hard-codes — the
+# remediation is exposing them, not changing them.
+DEFAULT_AMOUNT_TOLERANCE: Decimal = Decimal("0.01")
+DEFAULT_BANK_REC_MATERIALITY: Decimal = Decimal("50000.00")
+DEFAULT_BANK_REC_PERFORMANCE_MATERIALITY: Decimal = Decimal("50000.00")
+
+
 @dataclass
 class BankRecConfig:
-    """Configurable thresholds for bank reconciliation."""
+    """Configurable thresholds for bank reconciliation.
 
-    amount_tolerance: float = 0.01  # Match tolerance in dollars
-    date_tolerance_days: int = 0  # Days of date tolerance for matching
-    materiality: float = 50_000.0  # Materiality for high-value transaction testing
-    performance_materiality: float = 50_000.0  # Performance materiality for risk scoring
+    Sprint 763 (RPT-10 finish): monetary fields are stored as ``Decimal``
+    for precision-safe comparison.  The route layer still passes
+    ``float`` from form fields; ``__post_init__`` coerces via
+    ``safe_decimal`` for backward compatibility.
+    """
+
+    amount_tolerance: Decimal = field(default_factory=lambda: DEFAULT_AMOUNT_TOLERANCE)
+    date_tolerance_days: int = 0
+    materiality: Decimal = field(default_factory=lambda: DEFAULT_BANK_REC_MATERIALITY)
+    performance_materiality: Decimal = field(default_factory=lambda: DEFAULT_BANK_REC_PERFORMANCE_MATERIALITY)
+
+    def __post_init__(self) -> None:
+        # Coerce float / int / str inputs to Decimal so monetary
+        # comparisons downstream stay in Decimal space.  Negative
+        # thresholds are rejected explicitly — they would invert the
+        # high-value test.
+        self.amount_tolerance = safe_decimal(self.amount_tolerance)
+        self.materiality = safe_decimal(self.materiality)
+        self.performance_materiality = safe_decimal(self.performance_materiality)
+        if self.amount_tolerance < 0 or self.materiality < 0 or self.performance_materiality < 0:
+            raise ValueError(
+                "BankRecConfig thresholds must be non-negative; got "
+                f"amount_tolerance={self.amount_tolerance}, "
+                f"materiality={self.materiality}, "
+                f"performance_materiality={self.performance_materiality}"
+            )
 
 
 # =============================================================================
@@ -321,9 +367,14 @@ class SuggestedJE:
     kind: SuggestedJEKind
     debit_account: str
     credit_account: str
-    amount: float
+    amount: Decimal
     description: str
-    confidence: float  # 0.0–1.0
+    confidence: float  # 0.0–1.0; non-monetary, stays float
+
+    def __post_init__(self) -> None:
+        # Sprint 766: coerce amount to Decimal (engine generators may
+        # construct with float for legacy reasons).
+        self.amount = safe_decimal(self.amount)
 
     def to_dict(self) -> dict:
         return {
@@ -331,7 +382,7 @@ class SuggestedJE:
             "kind": self.kind.value,
             "debit_account": self.debit_account,
             "credit_account": self.credit_account,
-            "amount": round(self.amount, 2),
+            "amount": _money(self.amount),
             "description": self.description,
             "confidence": round(self.confidence, 2),
         }
@@ -339,30 +390,49 @@ class SuggestedJE:
 
 @dataclass
 class ReconciliationSummary:
-    """Summary of reconciliation results."""
+    """Summary of reconciliation results.
+
+    Sprint 766: monetary fields are stored as ``Decimal`` for
+    precision-safe arithmetic.  ``__post_init__`` coerces float / int /
+    str inputs via ``safe_decimal`` for backward compatibility with
+    callers that still pass floats (e.g., the CSV-export route that
+    rebuilds the summary from a JSON request body).
+    """
 
     matched_count: int = 0
-    matched_amount: float = 0.0
+    matched_amount: Decimal = field(default_factory=lambda: Decimal("0"))
     bank_only_count: int = 0
-    bank_only_amount: float = 0.0
+    bank_only_amount: Decimal = field(default_factory=lambda: Decimal("0"))
     ledger_only_count: int = 0
-    ledger_only_amount: float = 0.0
-    reconciling_difference: float = 0.0
-    total_bank: float = 0.0
-    total_ledger: float = 0.0
+    ledger_only_amount: Decimal = field(default_factory=lambda: Decimal("0"))
+    reconciling_difference: Decimal = field(default_factory=lambda: Decimal("0"))
+    total_bank: Decimal = field(default_factory=lambda: Decimal("0"))
+    total_ledger: Decimal = field(default_factory=lambda: Decimal("0"))
     matches: list[ReconciliationMatch] = field(default_factory=list)
 
+    def __post_init__(self) -> None:
+        # Coerce any float / int / str inputs to Decimal so arithmetic
+        # downstream (diagnostic score, CSV export) stays in Decimal space.
+        self.matched_amount = safe_decimal(self.matched_amount)
+        self.bank_only_amount = safe_decimal(self.bank_only_amount)
+        self.ledger_only_amount = safe_decimal(self.ledger_only_amount)
+        self.reconciling_difference = safe_decimal(self.reconciling_difference)
+        self.total_bank = safe_decimal(self.total_bank)
+        self.total_ledger = safe_decimal(self.total_ledger)
+
     def to_dict(self) -> dict:
+        # Sprint 766: HALF_UP quantization at the wire boundary (was
+        # round(x, 2) which is HALF_EVEN under Python's default).
         return {
             "matched_count": self.matched_count,
-            "matched_amount": round(self.matched_amount, 2),
+            "matched_amount": _money(self.matched_amount),
             "bank_only_count": self.bank_only_count,
-            "bank_only_amount": round(self.bank_only_amount, 2),
+            "bank_only_amount": _money(self.bank_only_amount),
             "ledger_only_count": self.ledger_only_count,
-            "ledger_only_amount": round(self.ledger_only_amount, 2),
-            "reconciling_difference": round(self.reconciling_difference, 2),
-            "total_bank": round(self.total_bank, 2),
-            "total_ledger": round(self.total_ledger, 2),
+            "ledger_only_amount": _money(self.ledger_only_amount),
+            "reconciling_difference": _money(self.reconciling_difference),
+            "total_bank": _money(self.total_bank),
+            "total_ledger": _money(self.total_ledger),
             "matches": [m.to_dict() for m in self.matches],
         }
 
@@ -378,6 +448,11 @@ class BankRecResult:
     outstanding_aging: list["OutstandingItemsAging"] = field(default_factory=list)
     composite_score: Optional[dict] = None
     suggested_journal_entries: list[SuggestedJE] = field(default_factory=list)  # Sprint 639
+    # Sprint 763 (RPT-10 finish): the materiality / performance materiality
+    # / amount tolerance the engine actually applied, plus a source tag
+    # ("caller" | "default") so memos, PDFs, and audit workpapers can
+    # disclose what shaped the high-value test and the diagnostic score.
+    active_thresholds: Optional[dict] = None
 
     def to_dict(self) -> dict:
         result: dict = {
@@ -393,6 +468,8 @@ class BankRecResult:
             result["composite_score"] = self.composite_score
         if self.suggested_journal_entries:
             result["suggested_journal_entries"] = [je.to_dict() for je in self.suggested_journal_entries]
+        if self.active_thresholds is not None:
+            result["active_thresholds"] = self.active_thresholds
         return result
 
 
@@ -844,16 +921,19 @@ def calculate_summary(matches: list[ReconciliationMatch]) -> ReconciliationSumma
 
     reconciling_difference = total_bank - total_ledger
 
+    # Sprint 766: keep aggregates in Decimal end-to-end.  Quantization to
+    # 2dp HALF_UP happens at the response boundary (``to_dict``) — no more
+    # float round-trip eroding precision before storage.
     return ReconciliationSummary(
         matched_count=matched_count,
-        matched_amount=float(round(matched_amount, 2)),
+        matched_amount=matched_amount,
         bank_only_count=bank_only_count,
-        bank_only_amount=float(round(bank_only_amount, 2)),
+        bank_only_amount=bank_only_amount,
         ledger_only_count=ledger_only_count,
-        ledger_only_amount=float(round(ledger_only_amount, 2)),
-        reconciling_difference=float(round(reconciling_difference, 2)),
-        total_bank=float(round(total_bank, 2)),
-        total_ledger=float(round(total_ledger, 2)),
+        ledger_only_amount=ledger_only_amount,
+        reconciling_difference=reconciling_difference,
+        total_bank=total_bank,
+        total_ledger=total_ledger,
         matches=matches,
     )
 
@@ -972,17 +1052,21 @@ class RecFlaggedItem:
 
     test_name: str
     description: str
-    amount: float = 0.0
+    amount: Decimal = field(default_factory=lambda: Decimal("0"))
     date: Optional[str] = None
     reference: Optional[str] = None
     severity: str = "medium"
     details: Optional[dict] = None
 
+    def __post_init__(self) -> None:
+        # Sprint 766: coerce float / int / str amount inputs to Decimal.
+        self.amount = safe_decimal(self.amount)
+
     def to_dict(self) -> dict:
         result: dict = {
             "test_name": self.test_name,
             "description": self.description,
-            "amount": round(self.amount, 2),
+            "amount": _money(self.amount),
             "severity": self.severity,
         }
         if self.date:
@@ -1022,7 +1106,11 @@ class OutstandingItemsAging:
     over_30_days: int = 0
     oldest_item_days: Optional[int] = None
     oldest_item_date: Optional[str] = None
-    oldest_item_amount: float = 0.0
+    oldest_item_amount: Decimal = field(default_factory=lambda: Decimal("0"))
+
+    def __post_init__(self) -> None:
+        # Sprint 766: coerce float / int / str inputs to Decimal.
+        self.oldest_item_amount = safe_decimal(self.oldest_item_amount)
 
     def to_dict(self) -> dict:
         return {
@@ -1032,7 +1120,7 @@ class OutstandingItemsAging:
             "over_30_days": self.over_30_days,
             "oldest_item_days": self.oldest_item_days,
             "oldest_item_date": self.oldest_item_date,
-            "oldest_item_amount": round(self.oldest_item_amount, 2),
+            "oldest_item_amount": _money(self.oldest_item_amount),
         }
 
 
@@ -1209,15 +1297,16 @@ def _test_interbank_transfers(
 
 def _test_high_value_transactions(
     all_items: list[ReconciliationMatch],
-    materiality: float = 50_000.0,
+    materiality: Decimal = DEFAULT_BANK_REC_MATERIALITY,
 ) -> RecTestResult:
     """Flag single transactions exceeding the materiality threshold."""
+    materiality_d = safe_decimal(materiality)
     flagged: list[RecFlaggedItem] = []
     for m in all_items:
         for source, txn in [("bank", m.bank_txn), ("ledger", m.ledger_txn)]:
             if not txn:
                 continue
-            if abs(txn.amount) >= materiality:
+            if abs(txn.amount) >= materiality_d:
                 flagged.append(
                     RecFlaggedItem(
                         test_name="High Value Transactions",
@@ -1226,7 +1315,7 @@ def _test_high_value_transactions(
                         date=txn.date,
                         reference=txn.reference,
                         severity="medium",
-                        details={"source": source, "materiality": materiality},
+                        details={"source": source, "materiality": float(materiality_d)},
                     )
                 )
 
@@ -1241,7 +1330,7 @@ def _test_high_value_transactions(
 
 def run_reconciliation_tests(
     matches: list[ReconciliationMatch],
-    materiality: float = 50_000.0,
+    materiality: Decimal = DEFAULT_BANK_REC_MATERIALITY,
     reference_date: Optional[date] = None,
 ) -> list[RecTestResult]:
     """Run all 5 reconciliation tests on the match results."""
@@ -1302,7 +1391,7 @@ def compute_outstanding_items_aging(
 def compute_bank_rec_diagnostic_score(
     rec_tests: list[RecTestResult],
     summary: ReconciliationSummary,
-    performance_materiality: float = 50_000.0,
+    performance_materiality: Decimal = DEFAULT_BANK_REC_PERFORMANCE_MATERIALITY,
 ) -> dict:
     """Compute composite diagnostic score for bank reconciliation.
 
@@ -1310,11 +1399,16 @@ def compute_bank_rec_diagnostic_score(
     flag_rate, tests_run, and top_findings.
     """
     score = 0.0
+    pm_d = safe_decimal(performance_materiality)
+    # Sprint 766: ``summary.reconciling_difference`` is now Decimal end
+    # to end — no coercion needed (kept ``safe_decimal`` for legacy
+    # float-typed callers that bypass ``calculate_summary``).
+    reconciling_diff = safe_decimal(summary.reconciling_difference)
 
-    has_diff = abs(summary.reconciling_difference) > 0.01
+    has_diff = abs(reconciling_diff) > Decimal("0.01")
     if has_diff:
         score += 15
-        if abs(summary.reconciling_difference) > performance_materiality:
+        if abs(reconciling_diff) > pm_d:
             score += 10
 
     total_outstanding = summary.bank_only_count + summary.ledger_only_count
@@ -1417,6 +1511,7 @@ def reconcile_bank_statement(
     config: Optional[BankRecConfig] = None,
     bank_mapping: Optional[dict] = None,
     ledger_mapping: Optional[dict] = None,
+    materiality_source: str = "default",
 ) -> BankRecResult:
     """Run the complete bank reconciliation pipeline.
 
@@ -1428,12 +1523,18 @@ def reconcile_bank_statement(
         config: Optional reconciliation configuration
         bank_mapping: Optional manual column mapping for bank file
         ledger_mapping: Optional manual column mapping for ledger file
+        materiality_source: ``"caller"`` when materiality / performance
+            materiality were supplied by the request layer, ``"default"``
+            when the engine fell back to documented defaults.  Surfaced in
+            ``BankRecResult.active_thresholds`` for auditability.
 
     Returns:
         BankRecResult with summary, column detection results
     """
     if config is None:
         config = BankRecConfig()
+    if materiality_source not in ("caller", "default"):
+        raise ValueError(f"materiality_source must be 'caller' or 'default'; got {materiality_source!r}")
 
     # 1. Detect columns for both files
     bank_detection = detect_bank_columns(bank_columns)
@@ -1490,6 +1591,17 @@ def reconcile_bank_statement(
     # 8. Sprint 639: Propose JEs for common BANK_ONLY items (fees, interest, NSF)
     suggested_jes = generate_suggested_journal_entries(matches)
 
+    # Sprint 763: emit the thresholds the engine actually applied so memos
+    # and PDFs can disclose them.  Decimals serialize to strings to
+    # preserve precision through JSON.
+    active_thresholds = {
+        "materiality": str(config.materiality),
+        "performance_materiality": str(config.performance_materiality),
+        "amount_tolerance": str(config.amount_tolerance),
+        "date_tolerance_days": config.date_tolerance_days,
+        "materiality_source": materiality_source,
+    }
+
     return BankRecResult(
         summary=summary,
         bank_column_detection=bank_detection,
@@ -1498,4 +1610,5 @@ def reconcile_bank_statement(
         outstanding_aging=outstanding_aging,
         composite_score=composite_score,
         suggested_journal_entries=suggested_jes,
+        active_thresholds=active_thresholds,
     )

--- a/backend/engagement_model.py
+++ b/backend/engagement_model.py
@@ -145,6 +145,18 @@ class Engagement(Base):
     completed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     completed_by: Mapped[int | None] = mapped_column(Integer, ForeignKey("users.id"), nullable=True)
 
+    # Sprint 764 (Intercompany layered detection): engagement-scoped
+    # counterparty mapping for ISA 550 related-party identification.
+    # JSON-encoded ``{"<account_name>": "<counterparty>", ...}`` — both
+    # sides case-folded by the resolver before lookup.  Null when the
+    # auditor has not yet recorded an explicit mapping; in that case the
+    # detection layer falls back to the heuristic separator parser.
+    # Per-run mappings (passed on the diagnostic request body) override
+    # this engagement-level default — see ``shared.intercompany_resolver``.
+    # Same Text+JSON pattern as ``ToolRun.flagged_accounts`` for cross-DB
+    # portability (SQLite + Postgres).
+    intercompany_counterparties: Mapped[str | None] = mapped_column(Text, nullable=True)
+
     # Audit trail
     created_by: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), nullable=False)
     creator: Mapped["User"] = relationship("User", back_populates="engagements", foreign_keys=[created_by])
@@ -191,6 +203,11 @@ class Engagement(Base):
             "trivial_threshold_factor": self.trivial_threshold_factor,
             "completed_at": self.completed_at.isoformat() if self.completed_at else None,
             "completed_by": self.completed_by,
+            # Sprint 764: surface counterparty mapping (JSON-decoded) so
+            # callers can pre-fill the form when planning the next run.
+            "intercompany_counterparties": (
+                json.loads(self.intercompany_counterparties) if self.intercompany_counterparties else None
+            ),
             "created_by": self.created_by,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,

--- a/backend/migrations/alembic/versions/b5c6d7e8f9a0_add_intercompany_counterparties_to_engagements.py
+++ b/backend/migrations/alembic/versions/b5c6d7e8f9a0_add_intercompany_counterparties_to_engagements.py
@@ -1,0 +1,35 @@
+"""add intercompany_counterparties to engagements
+
+Revision ID: b5c6d7e8f9a0
+Revises: a3b4c5d6e7f8
+Create Date: 2026-04-30 00:00:00.000000
+
+Sprint 764 — Intercompany Layered Detection.
+Adds engagement-scoped counterparty mapping for ISA 550 related-party
+identification.  JSON-encoded ``{"<account_name>": "<counterparty>"}``
+stored as Text (same pattern as ``ToolRun.flagged_accounts`` for
+cross-DB portability).  Nullable: auditor populates explicitly; the
+detection layer falls back to the heuristic separator parser when
+absent.  Per-run request mappings override this engagement-level
+default — see ``shared.intercompany_resolver``.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b5c6d7e8f9a0"
+down_revision = "a3b4c5d6e7f8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "engagements",
+        sa.Column("intercompany_counterparties", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("engagements", "intercompany_counterparties")

--- a/backend/multi_period_comparison.py
+++ b/backend/multi_period_comparison.py
@@ -32,13 +32,36 @@ from lead_sheet_mapping import (
     assign_lead_sheet,
 )
 from shared.filenames import sanitize_csv_value
+from shared.monetary import quantize_monetary
 from shared.parsing_helpers import safe_decimal
+
+
+def _money(value: float | Decimal | None) -> Optional[float]:
+    """Sprint 767: serialize a monetary value at the response boundary.
+
+    Quantizes to 2dp ROUND_HALF_UP via ``quantize_monetary`` and returns
+    a Python float so JSON wire format is unchanged.  ``None`` is
+    preserved (e.g., percent_variance when prior is near-zero — but
+    that's percent, not money; this helper only touches dollar fields).
+    """
+    if value is None:
+        return None
+    return float(quantize_monetary(value))
+
 
 # =============================================================================
 # CONSTANTS
 # =============================================================================
 
 NEAR_ZERO = 0.005  # Below any meaningful financial balance; guards division-by-near-zero
+
+# Sprint 765 (RPT-02/RPT-14 variance basis declaration): the denominator
+# used to compute change_percent (and budget variance_percent) is
+# ``abs(prior)``.  Emitted on every comparison response so memos / PDFs /
+# downstream consumers can disclose the formula. See
+# ``docs/04-compliance/variance-formula-policy.md``.
+VARIANCE_BASIS = "absolute_prior"
+VARIANCE_FORMULA = "(current - prior) / abs(prior) * 100"
 
 # Significance thresholds — DEFAULTS.  These constants preserve the historical
 # behaviour (10% / $10,000) and are used when no override is supplied.  Callers
@@ -185,11 +208,13 @@ class AccountMovement:
         return {
             "account_name": self.account_name,
             "account_type": self.account_type,
-            "prior_balance": self.prior_balance,
-            "current_balance": self.current_balance,
-            "change_amount": self.change_amount,
+            # Sprint 767: monetary outputs quantized 2dp HALF_UP at the
+            # response boundary.  Percent fields stay float (non-monetary).
+            "prior_balance": _money(self.prior_balance),
+            "current_balance": _money(self.current_balance),
+            "change_amount": _money(self.change_amount),
             "change_percent": self.change_percent,
-            "display_change_amount": display_change,
+            "display_change_amount": _money(display_change),
             "display_change_percent": display_pct,
             "movement_type": self.movement_type.value,
             "significance": self.significance.value,
@@ -231,11 +256,12 @@ class LeadSheetMovementSummary:
             "lead_sheet": self.lead_sheet,
             "lead_sheet_name": self.lead_sheet_name,
             "lead_sheet_category": self.lead_sheet_category,
-            "prior_total": self.prior_total,
-            "current_total": self.current_total,
-            "net_change": self.net_change,
+            # Sprint 767: monetary aggregates quantized 2dp HALF_UP.
+            "prior_total": _money(self.prior_total),
+            "current_total": _money(self.current_total),
+            "net_change": _money(self.net_change),
             "change_percent": self.change_percent,
-            "display_net_change": display_change,
+            "display_net_change": _money(display_change),
             "display_change_percent": display_pct,
             "is_credit_normal": self._is_credit_normal,
             "account_count": self.account_count,
@@ -287,13 +313,17 @@ class MovementSummary:
             "new_accounts": self.new_accounts,
             "closed_accounts": self.closed_accounts,
             "dormant_accounts": self.dormant_accounts,
-            "prior_total_debits": self.prior_total_debits,
-            "prior_total_credits": self.prior_total_credits,
-            "current_total_debits": self.current_total_debits,
-            "current_total_credits": self.current_total_credits,
+            # Sprint 767: TB total quantization at the boundary.
+            "prior_total_debits": _money(self.prior_total_debits),
+            "prior_total_credits": _money(self.prior_total_credits),
+            "current_total_debits": _money(self.current_total_debits),
+            "current_total_credits": _money(self.current_total_credits),
             "framework_note": self.framework_note,
             "duplicate_account_warnings": self.duplicate_account_warnings,
             "active_thresholds": self.active_thresholds,
+            # Sprint 765: declarative variance basis on the response.
+            "variance_basis": VARIANCE_BASIS,
+            "variance_formula": VARIANCE_FORMULA,
         }
 
 
@@ -774,8 +804,10 @@ class BudgetVariance:
 
     def to_dict(self) -> dict[str, Any]:
         d = {
-            "budget_balance": self.budget_balance,
-            "variance_amount": self.variance_amount,
+            # Sprint 767: budget variance dollar fields quantized at the
+            # boundary; variance_percent is non-monetary and stays raw.
+            "budget_balance": _money(self.budget_balance),
+            "variance_amount": _money(self.variance_amount),
             "variance_percent": self.variance_percent,
             "variance_significance": self.variance_significance.value,
             "variance_direction": self.variance_direction,
@@ -869,12 +901,13 @@ class ThreeWayLeadSheetSummary:
             "lead_sheet": self.lead_sheet,
             "lead_sheet_name": self.lead_sheet_name,
             "lead_sheet_category": self.lead_sheet_category,
-            "prior_total": self.prior_total,
-            "current_total": self.current_total,
-            "net_change": self.net_change,
+            # Sprint 767: monetary aggregates quantized; percent stays raw.
+            "prior_total": _money(self.prior_total),
+            "current_total": _money(self.current_total),
+            "net_change": _money(self.net_change),
             "change_percent": self.change_percent,
-            "budget_total": self.budget_total,
-            "budget_variance": self.budget_variance,
+            "budget_total": _money(self.budget_total),
+            "budget_variance": _money(self.budget_variance),
             "budget_variance_percent": self.budget_variance_percent,
             "account_count": self.account_count,
             "movements": self.movements,
@@ -938,12 +971,13 @@ class ThreeWayMovementSummary:
             "new_accounts": self.new_accounts,
             "closed_accounts": self.closed_accounts,
             "dormant_accounts": self.dormant_accounts,
-            "prior_total_debits": self.prior_total_debits,
-            "prior_total_credits": self.prior_total_credits,
-            "current_total_debits": self.current_total_debits,
-            "current_total_credits": self.current_total_credits,
-            "budget_total_debits": self.budget_total_debits,
-            "budget_total_credits": self.budget_total_credits,
+            # Sprint 767: TB-total aggregates quantized at the boundary.
+            "prior_total_debits": _money(self.prior_total_debits),
+            "prior_total_credits": _money(self.prior_total_credits),
+            "current_total_debits": _money(self.current_total_debits),
+            "current_total_credits": _money(self.current_total_credits),
+            "budget_total_debits": _money(self.budget_total_debits),
+            "budget_total_credits": _money(self.budget_total_credits),
             "budget_variances_by_significance": self.budget_variances_by_significance,
             "accounts_over_budget": self.accounts_over_budget,
             "accounts_under_budget": self.accounts_under_budget,
@@ -951,6 +985,10 @@ class ThreeWayMovementSummary:
             "framework_note": self.framework_note,
             "duplicate_account_warnings": self.duplicate_account_warnings,
             "active_thresholds": self.active_thresholds,
+            # Sprint 765: declarative variance basis (applies to both
+            # prior↔current and current↔budget comparisons).
+            "variance_basis": VARIANCE_BASIS,
+            "variance_formula": VARIANCE_FORMULA,
         }
 
 

--- a/backend/prior_period_comparison.py
+++ b/backend/prior_period_comparison.py
@@ -29,6 +29,13 @@ NEAR_ZERO = 0.005  # Below any meaningful financial balance; guards division-by-
 SIGNIFICANT_VARIANCE_PERCENT = 10.0  # Flag variances > 10%
 SIGNIFICANT_VARIANCE_AMOUNT = 10000.0  # Flag variances > $10,000
 
+# Sprint 765 (RPT-02/RPT-14 variance basis declaration): the denominator
+# used to compute percent_variance is ``abs(prior)``.  Surfaced in every
+# variance-emitting response so memos / PDFs / downstream consumers can
+# disclose the formula.  See ``docs/04-compliance/variance-formula-policy.md``.
+VARIANCE_BASIS = "absolute_prior"
+VARIANCE_FORMULA = "(current - prior) / abs(prior) * 100"
+
 # Categories for comparison
 BALANCE_SHEET_CATEGORIES = [
     ("total_assets", "Total Assets"),
@@ -178,6 +185,10 @@ class PeriodComparison:
             "significant_variance_count": self.significant_variance_count,
             "total_categories_compared": self.total_categories_compared,
             "framework_note": self.framework_note,
+            # Sprint 765: declarative variance basis so consumers can
+            # render the formula alongside the numbers.
+            "variance_basis": VARIANCE_BASIS,
+            "variance_formula": VARIANCE_FORMULA,
         }
 
 

--- a/backend/routes/bank_reconciliation.py
+++ b/backend/routes/bank_reconciliation.py
@@ -82,12 +82,17 @@ async def audit_bank_reconciliation(
             bank_filename = bank_file.filename or ""
             ledger_filename = ledger_file.filename or ""
 
-            config_kwargs = {}
+            config_kwargs: dict[str, Any] = {}
             if materiality is not None:
                 config_kwargs["materiality"] = materiality
             if performance_materiality is not None:
                 config_kwargs["performance_materiality"] = performance_materiality
-            rec_config = BankRecConfig(**config_kwargs) if config_kwargs else None  # type: ignore[arg-type]
+            rec_config = BankRecConfig(**config_kwargs) if config_kwargs else None
+            # Sprint 763 (RPT-10 finish): tag the materiality source so
+            # ``BankRecResult.active_thresholds`` discloses whether the
+            # request supplied thresholds or fell back to documented
+            # defaults.  Memos / PDFs render this in the workpaper.
+            materiality_source = "caller" if config_kwargs else "default"
 
             def _analyze() -> Any:
                 bank_columns, bank_rows = parse_uploaded_file(bank_bytes, bank_filename)
@@ -100,6 +105,7 @@ async def audit_bank_reconciliation(
                     config=rec_config,
                     bank_mapping=bank_mapping_dict,
                     ledger_mapping=ledger_mapping_dict,
+                    materiality_source=materiality_source,
                 )
 
             result = await asyncio.to_thread(_analyze)

--- a/backend/shared/diagnostic_response_schemas.py
+++ b/backend/shared/diagnostic_response_schemas.py
@@ -168,6 +168,9 @@ class PeriodComparisonResponse(BaseModel):
     significant_variance_count: int
     total_categories_compared: int
     framework_note: Optional[str] = None
+    # Sprint 765: declarative variance basis on the response.
+    variance_basis: Optional[str] = None
+    variance_formula: Optional[str] = None
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -233,6 +236,13 @@ class MovementSummaryResponse(BaseModel):
     current_total_credits: float
     framework_note: Optional[str] = None
     expectations_evaluated: list[ExpectationEvaluationResponse] = []
+    # Sprint 763: bank-rec materiality emission pattern; for multi-period,
+    # ``active_thresholds`` carries the significance thresholds applied.
+    active_thresholds: Optional[dict[str, Any]] = None
+    duplicate_account_warnings: list[dict[str, Any]] = []
+    # Sprint 765: declarative variance basis on the response.
+    variance_basis: Optional[str] = None
+    variance_formula: Optional[str] = None
 
 
 class BudgetVarianceResponse(BaseModel):
@@ -294,7 +304,14 @@ class ThreeWayMovementSummaryResponse(BaseModel):
     accounts_over_budget: int
     accounts_under_budget: int
     accounts_on_budget: int
+    framework_note: Optional[str] = None
+    duplicate_account_warnings: list[dict[str, Any]] = []
     expectations_evaluated: list[ExpectationEvaluationResponse] = []
+    # Sprint 763: active thresholds emission.
+    active_thresholds: Optional[dict[str, Any]] = None
+    # Sprint 765: declarative variance basis on the response.
+    variance_basis: Optional[str] = None
+    variance_formula: Optional[str] = None
 
 
 # ═══════════════════════════════════════════════════════════════

--- a/backend/shared/intercompany_resolver.py
+++ b/backend/shared/intercompany_resolver.py
@@ -1,0 +1,115 @@
+"""
+Sprint 764 — Intercompany counterparty mapping resolver.
+
+Resolves the active counterparty mapping for an intercompany detection
+run using a request → engagement → none cascade (mirrors the materiality
+cascade in ``shared.materiality_resolver``).
+
+Precedence (first match wins):
+1. **Manual override** — caller supplies ``request_mapping`` directly on
+   the diagnostic request body.  Source = "request".
+2. **Engagement default** — ``Engagement.intercompany_counterparties``
+   stored from a prior planning step.  Source = "engagement".
+3. **None** — no mapping; the detection layer falls back to the
+   heuristic separator parser.  Source = "none".
+
+The function is intentionally framework-light: it returns the resolved
+mapping dict (case-folded keys) plus the source tag.  Callers (route
+handlers, the streaming auditor) thread both into
+``detect_intercompany_imbalances()`` so findings carry an explicit
+``detection_method`` field.
+
+See ``docs/04-compliance/variance-formula-policy.md`` for the analogous
+materiality cascade pattern.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+MappingSource = str  # Literal["request", "engagement", "none"] — typed at call site
+
+
+def _normalize_mapping(raw: dict[str, str]) -> dict[str, str]:
+    """Case-fold both account-name keys and counterparty values.
+
+    Account names are stored verbatim in the trial balance, but matching
+    happens case-insensitively to absorb capitalization variance.
+    """
+    return {str(k).strip().lower(): str(v).strip() for k, v in raw.items() if k and v}
+
+
+def resolve_counterparty_mapping(
+    request_mapping: Optional[dict[str, str]],
+    engagement_id: Optional[int],
+    db: Optional[Session],
+) -> tuple[dict[str, str], MappingSource]:
+    """Resolve the active counterparty mapping for a detection run.
+
+    Args:
+        request_mapping: Mapping supplied on the request body, if any.
+            ``{"account_name": "counterparty", ...}``.  Wins over
+            engagement defaults.
+        engagement_id: Optional engagement to look up for stored mapping.
+            Ignored when ``request_mapping`` is provided.
+        db: SQLAlchemy session.  Required when looking up the engagement.
+
+    Returns:
+        Tuple of (mapping, source) where:
+            - mapping is a (possibly empty) dict with case-folded keys.
+            - source ∈ ``{"request", "engagement", "none"}``.
+
+    Empty dicts are treated as "no mapping" — they pass through as
+    ``({}, "none")`` rather than ``({}, "request")`` so downstream
+    findings reflect the practical absence of an override.
+    """
+    if request_mapping:
+        return _normalize_mapping(request_mapping), "request"
+
+    if engagement_id is not None and db is not None:
+        # Local import to avoid circular dependency: engagement_model
+        # imports from shared modules.
+        from engagement_model import Engagement
+
+        eng = db.query(Engagement).filter(Engagement.id == engagement_id).first()
+        if eng and eng.intercompany_counterparties:
+            try:
+                stored = json.loads(eng.intercompany_counterparties)
+            except (json.JSONDecodeError, TypeError):
+                logger.warning(
+                    "Engagement %s has malformed intercompany_counterparties JSON; falling back to heuristic detection",
+                    engagement_id,
+                )
+                return {}, "none"
+            if isinstance(stored, dict) and stored:
+                return _normalize_mapping(stored), "engagement"
+
+    return {}, "none"
+
+
+def detection_method_label(used_metadata: bool, separator_parsed: bool) -> str:
+    """Classify how a counterparty was identified for explainability.
+
+    Args:
+        used_metadata: True when the resolver supplied a non-empty
+            mapping AND the account in question was found in it.
+        separator_parsed: True when the heuristic separator parser
+            (em-dash / hyphen / etc.) extracted a counterparty.
+
+    Returns:
+        - ``"metadata_exact"`` when metadata supplied the counterparty.
+        - ``"heuristic_separator"`` when the separator parser succeeded.
+        - ``"heuristic_keyword"`` when neither produced a counterparty
+          but the keyword scan still flagged the account as IC.
+    """
+    if used_metadata:
+        return "metadata_exact"
+    if separator_parsed:
+        return "heuristic_separator"
+    return "heuristic_keyword"

--- a/backend/shared/monetary.py
+++ b/backend/shared/monetary.py
@@ -21,8 +21,18 @@ MONETARY_PRECISION = Decimal("0.01")
 # Canonical zero for monetary comparisons
 MONETARY_ZERO = Decimal("0.00")
 
-# Balance tolerance — replaces the float literal 0.01 in audit_engine.py
+# Balance tolerance — replaces the float literal 0.01 in audit_engine.py.
+# Use this for "are two amounts equal within rounding error" checks.
 BALANCE_TOLERANCE = MONETARY_PRECISION
+
+# Sprint 766: half-a-cent denominator guard for percent-variance calculations.
+# Use this for "is the prior balance large enough that dividing by it yields
+# a meaningful percent" checks.  Distinct from BALANCE_TOLERANCE: this is
+# the lower bound for division, not an equality tolerance.  Several engines
+# previously redefined this locally (three_way_match_engine.MONETARY_EPSILON,
+# scattered ``NEAR_ZERO = 0.005`` floats in multi_period_comparison /
+# prior_period_comparison) — consolidate to the canonical Decimal here.
+MONETARY_NEAR_ZERO = Decimal("0.005")
 
 
 def quantize_monetary(value: float | Decimal | str | int | None) -> Decimal:
@@ -63,8 +73,7 @@ def quantize_monetary(value: float | Decimal | str | int | None) -> Decimal:
     return dec.quantize(MONETARY_PRECISION, rounding=ROUND_HALF_UP)
 
 
-def monetary_equal(a: float | Decimal | str | int | None,
-                   b: float | Decimal | str | int | None) -> bool:
+def monetary_equal(a: float | Decimal | str | int | None, b: float | Decimal | str | int | None) -> bool:
     """Compare two monetary values for equality after quantization.
 
     Both values are quantized to 2dp ROUND_HALF_UP before comparison,

--- a/backend/shared/testing_response_schemas.py
+++ b/backend/shared/testing_response_schemas.py
@@ -327,6 +327,11 @@ class BankRecResponse(BaseModel):
     rec_tests: Optional[list[dict]] = None
     outstanding_aging: Optional[list[dict]] = None
     composite_score: Optional[dict] = None
+    # Sprint 763 (RPT-10 finish): the thresholds the engine actually
+    # applied (materiality / performance materiality / amount tolerance /
+    # date tolerance) plus a ``materiality_source`` tag of "caller" or
+    # "default".  Decimal values are stringified to preserve precision.
+    active_thresholds: Optional[dict] = None
 
 
 # ═══════════════════════════════════════════════════════════════

--- a/backend/tests/test_bank_rec_decimal_port.py
+++ b/backend/tests/test_bank_rec_decimal_port.py
@@ -1,0 +1,214 @@
+"""
+Sprint 766 — bank_reconciliation.py Decimal port tests.
+
+Covers:
+- ``ReconciliationSummary``, ``RecFlaggedItem``, ``OutstandingItemsAging``,
+  ``SuggestedJE`` monetary fields are stored as ``Decimal``.
+- ``__post_init__`` coerces float / int / str inputs for backward
+  compatibility with route layers that still pass float (e.g., the
+  CSV-export route that rebuilds the summary from a JSON request body).
+- ``calculate_summary`` keeps Decimal aggregates end-to-end (no
+  float-roundtrip eroding precision before storage).
+- ``to_dict`` quantizes 2dp HALF_UP at the wire boundary (was Python's
+  default HALF_EVEN under ``round(x, 2)``).
+- ``three_way_match_engine.MONETARY_EPSILON`` is the same object as
+  ``shared.monetary.MONETARY_NEAR_ZERO``.
+"""
+
+from decimal import Decimal
+
+from bank_reconciliation import (
+    BankTransaction,
+    LedgerTransaction,
+    MatchType,
+    OutstandingItemsAging,
+    RecFlaggedItem,
+    ReconciliationMatch,
+    ReconciliationSummary,
+    SuggestedJE,
+    SuggestedJEKind,
+    calculate_summary,
+)
+
+# ---------------------------------------------------------------------------
+# Dataclass field types and coercion
+# ---------------------------------------------------------------------------
+
+
+class TestReconciliationSummaryDecimal:
+    def test_default_fields_are_decimal(self) -> None:
+        s = ReconciliationSummary()
+        assert isinstance(s.matched_amount, Decimal)
+        assert isinstance(s.bank_only_amount, Decimal)
+        assert isinstance(s.ledger_only_amount, Decimal)
+        assert isinstance(s.reconciling_difference, Decimal)
+        assert isinstance(s.total_bank, Decimal)
+        assert isinstance(s.total_ledger, Decimal)
+
+    def test_float_kwargs_coerced_to_decimal(self) -> None:
+        # Legacy CSV-export route rebuilds summary from JSON body with
+        # float values — coercion must keep this path working.
+        s = ReconciliationSummary(
+            matched_amount=12345.67,
+            reconciling_difference=89.01,
+            total_bank=1000.0,
+        )
+        assert isinstance(s.matched_amount, Decimal)
+        assert s.matched_amount == Decimal("12345.67")
+        assert s.reconciling_difference == Decimal("89.01")
+        assert s.total_bank == Decimal("1000")
+
+    def test_str_kwargs_coerced_to_decimal(self) -> None:
+        s = ReconciliationSummary(matched_amount="999.99")
+        assert s.matched_amount == Decimal("999.99")
+
+    def test_to_dict_quantizes_half_up(self) -> None:
+        # 1234.005 → HALF_UP rounds to 1234.01.  Python's default
+        # round(x, 2) is HALF_EVEN and would round to 1234.00.
+        s = ReconciliationSummary(matched_amount=Decimal("1234.005"))
+        d = s.to_dict()
+        assert d["matched_amount"] == 1234.01
+
+    def test_to_dict_returns_floats_for_wire_compat(self) -> None:
+        s = ReconciliationSummary(matched_amount=Decimal("100.00"))
+        d = s.to_dict()
+        # Wire format remains float for JSON compatibility.
+        assert isinstance(d["matched_amount"], float)
+
+
+class TestRecFlaggedItemDecimal:
+    def test_amount_field_is_decimal(self) -> None:
+        item = RecFlaggedItem(test_name="t", description="d")
+        assert isinstance(item.amount, Decimal)
+
+    def test_float_amount_coerced(self) -> None:
+        item = RecFlaggedItem(test_name="t", description="d", amount=42.5)
+        assert isinstance(item.amount, Decimal)
+        assert item.amount == Decimal("42.5")
+
+    def test_to_dict_emits_quantized_float(self) -> None:
+        item = RecFlaggedItem(test_name="t", description="d", amount=Decimal("100.005"))
+        d = item.to_dict()
+        assert d["amount"] == 100.01  # HALF_UP
+
+
+class TestOutstandingItemsAgingDecimal:
+    def test_oldest_item_amount_field_is_decimal(self) -> None:
+        a = OutstandingItemsAging(category="bank_only")
+        assert isinstance(a.oldest_item_amount, Decimal)
+
+    def test_float_amount_coerced(self) -> None:
+        a = OutstandingItemsAging(category="bank_only", oldest_item_amount=99.99)
+        assert a.oldest_item_amount == Decimal("99.99")
+
+
+class TestSuggestedJEDecimal:
+    def test_amount_field_is_decimal(self) -> None:
+        bt = BankTransaction(amount=Decimal("25.00"))
+        je = SuggestedJE(
+            bank_txn=bt,
+            kind=SuggestedJEKind.BANK_FEE,
+            debit_account="Bank Service Fees",
+            credit_account="Cash",
+            amount=Decimal("25.00"),
+            description="Bank fee",
+            confidence=0.9,
+        )
+        assert isinstance(je.amount, Decimal)
+
+    def test_float_amount_coerced(self) -> None:
+        bt = BankTransaction(amount=Decimal("25.00"))
+        je = SuggestedJE(
+            bank_txn=bt,
+            kind=SuggestedJEKind.BANK_FEE,
+            debit_account="Bank Service Fees",
+            credit_account="Cash",
+            amount=25.0,
+            description="Bank fee",
+            confidence=0.9,
+        )
+        assert isinstance(je.amount, Decimal)
+        assert je.amount == Decimal("25")
+
+
+# ---------------------------------------------------------------------------
+# calculate_summary keeps Decimal end-to-end (no float roundtrip)
+# ---------------------------------------------------------------------------
+
+
+def _bank(amount: str) -> BankTransaction:
+    return BankTransaction(date="2026-01-15", description="b", amount=Decimal(amount))
+
+
+def _ledger(amount: str) -> LedgerTransaction:
+    return LedgerTransaction(date="2026-01-15", description="l", amount=Decimal(amount))
+
+
+class TestCalculateSummaryEndToEnd:
+    def test_aggregates_remain_decimal(self) -> None:
+        matches = [
+            ReconciliationMatch(
+                bank_txn=_bank("0.01"),
+                ledger_txn=_ledger("0.01"),
+                match_type=MatchType.MATCHED,
+            ),
+        ]
+        summary = calculate_summary(matches)
+        assert isinstance(summary.matched_amount, Decimal)
+        assert isinstance(summary.total_bank, Decimal)
+        assert isinstance(summary.reconciling_difference, Decimal)
+
+    def test_summing_pennies_is_exact(self) -> None:
+        # 100 × $0.01 should equal exactly $1.00 in Decimal.  In float
+        # this would be 0.9999999999999998.  The pre-Sprint-766 code path
+        # would float-roundtrip the aggregate, eroding precision.
+        matches = [
+            ReconciliationMatch(
+                bank_txn=_bank("0.01"),
+                ledger_txn=_ledger("0.01"),
+                match_type=MatchType.MATCHED,
+            )
+            for _ in range(100)
+        ]
+        summary = calculate_summary(matches)
+        assert summary.matched_amount == Decimal("1.00")
+        assert summary.total_bank == Decimal("1.00")
+        assert summary.total_ledger == Decimal("1.00")
+        assert summary.reconciling_difference == Decimal("0.00")
+
+    def test_to_dict_at_boundary_quantizes_half_up(self) -> None:
+        # Reconciling difference of $1234.005 → HALF_UP rounds to 1234.01.
+        matches = [
+            ReconciliationMatch(
+                bank_txn=_bank("1234.005"),
+                ledger_txn=None,
+                match_type=MatchType.BANK_ONLY,
+            ),
+        ]
+        summary = calculate_summary(matches)
+        d = summary.to_dict()
+        assert d["bank_only_amount"] == 1234.01
+
+
+# ---------------------------------------------------------------------------
+# Helper consolidation: three_way_match_engine.MONETARY_EPSILON
+# ---------------------------------------------------------------------------
+
+
+class TestMonetaryNearZeroConsolidation:
+    def test_three_way_epsilon_aliases_shared_constant(self) -> None:
+        from shared.monetary import MONETARY_NEAR_ZERO
+        from three_way_match_engine import MONETARY_EPSILON
+
+        # Sprint 766: same object — three_way_match_engine no longer
+        # owns its own ``Decimal("0.005")``.
+        assert MONETARY_EPSILON is MONETARY_NEAR_ZERO
+        assert MONETARY_EPSILON == Decimal("0.005")
+
+    def test_balance_tolerance_distinct_from_near_zero(self) -> None:
+        # These are semantically different and must not be conflated.
+        from shared.monetary import BALANCE_TOLERANCE, MONETARY_NEAR_ZERO
+
+        assert BALANCE_TOLERANCE == Decimal("0.01")  # equality tolerance
+        assert MONETARY_NEAR_ZERO == Decimal("0.005")  # denominator guard
+        assert BALANCE_TOLERANCE != MONETARY_NEAR_ZERO

--- a/backend/tests/test_bank_rec_materiality.py
+++ b/backend/tests/test_bank_rec_materiality.py
@@ -1,0 +1,245 @@
+"""
+Sprint 763 — RPT-10 Bank Reconciliation materiality remediation tests.
+
+Covers:
+- BankRecConfig coerces float / int / str inputs to Decimal in __post_init__.
+- BankRecConfig rejects negative thresholds.
+- ``reconcile_bank_statement`` emits ``active_thresholds`` with the
+  thresholds the engine actually applied + a ``materiality_source`` tag.
+- The route-layer wiring populates ``materiality_source = "caller"`` only
+  when the request supplied an override; otherwise ``"default"``.
+- Decimal-precision boundary at the materiality threshold ($50,000.00 vs
+  $49,999.99 vs $50,000.01) — no float-drift false positives or negatives.
+- Large-engagement scale (>$1B materiality) round-trips through the
+  response without precision loss.
+- ``_test_high_value_transactions`` accepts both Decimal and float inputs
+  for backward compatibility with legacy callers.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from bank_reconciliation import (
+    DEFAULT_BANK_REC_MATERIALITY,
+    DEFAULT_BANK_REC_PERFORMANCE_MATERIALITY,
+    BankRecConfig,
+    BankTransaction,
+    MatchType,
+    ReconciliationMatch,
+    ReconciliationSummary,
+    _test_high_value_transactions,
+    compute_bank_rec_diagnostic_score,
+    reconcile_bank_statement,
+)
+
+# ---------------------------------------------------------------------------
+# BankRecConfig coercion + validation
+# ---------------------------------------------------------------------------
+
+
+class TestBankRecConfigCoercion:
+    def test_default_thresholds_are_decimal(self) -> None:
+        cfg = BankRecConfig()
+        assert isinstance(cfg.materiality, Decimal)
+        assert isinstance(cfg.performance_materiality, Decimal)
+        assert isinstance(cfg.amount_tolerance, Decimal)
+        assert cfg.materiality == DEFAULT_BANK_REC_MATERIALITY
+        assert cfg.performance_materiality == DEFAULT_BANK_REC_PERFORMANCE_MATERIALITY
+
+    def test_float_kwargs_coerced_to_decimal(self) -> None:
+        cfg = BankRecConfig(materiality=25_000.0, performance_materiality=10_000.0)
+        assert isinstance(cfg.materiality, Decimal)
+        assert cfg.materiality == Decimal("25000")
+        assert cfg.performance_materiality == Decimal("10000")
+
+    def test_int_kwargs_coerced_to_decimal(self) -> None:
+        cfg = BankRecConfig(materiality=75_000)
+        assert isinstance(cfg.materiality, Decimal)
+        assert cfg.materiality == Decimal("75000")
+
+    def test_str_kwargs_coerced_to_decimal(self) -> None:
+        cfg = BankRecConfig(materiality="100000.50")
+        assert cfg.materiality == Decimal("100000.50")
+
+    def test_decimal_kwargs_pass_through(self) -> None:
+        cfg = BankRecConfig(materiality=Decimal("250000.00"))
+        assert cfg.materiality == Decimal("250000.00")
+
+    def test_negative_materiality_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            BankRecConfig(materiality=-1.0)
+
+    def test_negative_performance_materiality_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            BankRecConfig(performance_materiality=-50_000)
+
+    def test_negative_amount_tolerance_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            BankRecConfig(amount_tolerance=-0.01)
+
+
+# ---------------------------------------------------------------------------
+# active_thresholds emission + materiality_source plumbing
+# ---------------------------------------------------------------------------
+
+
+def _minimal_inputs() -> dict:
+    """Construct the smallest valid input set for reconcile_bank_statement."""
+    return {
+        "bank_rows": [],
+        "ledger_rows": [],
+        "bank_columns": ["date", "description", "amount"],
+        "ledger_columns": ["date", "description", "amount"],
+    }
+
+
+class TestActiveThresholdsEmission:
+    def test_default_run_tags_source_default(self) -> None:
+        result = reconcile_bank_statement(**_minimal_inputs())
+        assert result.active_thresholds is not None
+        assert result.active_thresholds["materiality_source"] == "default"
+        assert result.active_thresholds["materiality"] == "50000.00"
+        assert result.active_thresholds["performance_materiality"] == "50000.00"
+        assert result.active_thresholds["amount_tolerance"] == "0.01"
+        assert result.active_thresholds["date_tolerance_days"] == 0
+
+    def test_caller_supplied_tags_source_caller(self) -> None:
+        cfg = BankRecConfig(materiality=Decimal("25000"), performance_materiality=Decimal("10000"))
+        result = reconcile_bank_statement(**_minimal_inputs(), config=cfg, materiality_source="caller")
+        assert result.active_thresholds["materiality_source"] == "caller"
+        assert result.active_thresholds["materiality"] == "25000"
+        assert result.active_thresholds["performance_materiality"] == "10000"
+
+    def test_to_dict_includes_active_thresholds(self) -> None:
+        result = reconcile_bank_statement(**_minimal_inputs())
+        d = result.to_dict()
+        assert "active_thresholds" in d
+        assert d["active_thresholds"]["materiality_source"] == "default"
+
+    def test_invalid_materiality_source_rejected(self) -> None:
+        with pytest.raises(ValueError, match="materiality_source"):
+            reconcile_bank_statement(**_minimal_inputs(), materiality_source="auto")
+
+
+# ---------------------------------------------------------------------------
+# Decimal-precision boundary at the materiality threshold
+# ---------------------------------------------------------------------------
+
+
+def _match(amount: Decimal | float | str) -> ReconciliationMatch:
+    """Build a one-sided match (bank only) at a given amount."""
+    return ReconciliationMatch(
+        bank_txn=BankTransaction(
+            date="2026-01-15",
+            description="Test txn",
+            amount=Decimal(str(amount)) if not isinstance(amount, Decimal) else amount,
+        ),
+        ledger_txn=None,
+        match_type=MatchType.BANK_ONLY,
+        match_confidence=0.0,
+    )
+
+
+class TestMaterialityBoundary:
+    def test_at_exactly_materiality_flagged(self) -> None:
+        # >= materiality is the engine's documented contract
+        result = _test_high_value_transactions([_match(Decimal("50000.00"))], materiality=Decimal("50000.00"))
+        assert result.flagged_count == 1
+
+    def test_one_cent_below_not_flagged(self) -> None:
+        result = _test_high_value_transactions([_match(Decimal("49999.99"))], materiality=Decimal("50000.00"))
+        assert result.flagged_count == 0
+
+    def test_one_cent_above_flagged(self) -> None:
+        result = _test_high_value_transactions([_match(Decimal("50000.01"))], materiality=Decimal("50000.00"))
+        assert result.flagged_count == 1
+
+    def test_legacy_float_caller_still_works(self) -> None:
+        # _test_high_value_transactions is widely called with float in the
+        # historical test corpus; coercion via safe_decimal must keep
+        # this path working.
+        result = _test_high_value_transactions([_match(75_000.0)], materiality=50_000.0)
+        assert result.flagged_count == 1
+
+    def test_decimal_arithmetic_at_boundary_is_exact(self) -> None:
+        # In float space, summing 100 × $0.01 yields 0.9999999999999998
+        # rather than 1.00 — a transaction at exactly the resulting
+        # threshold would not flag.  In Decimal space the sum is exact
+        # and the boundary holds.
+        threshold = sum((Decimal("0.01") for _ in range(100)), Decimal("0"))
+        assert threshold == Decimal("1.00")
+        result = _test_high_value_transactions([_match(Decimal("1.00"))], materiality=threshold)
+        assert result.flagged_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Large-engagement scale (> $1B / > $1T)
+# ---------------------------------------------------------------------------
+
+
+class TestLargeScale:
+    def test_billion_dollar_materiality_round_trips(self) -> None:
+        cfg = BankRecConfig(
+            materiality=Decimal("1000000000.00"),
+            performance_materiality=Decimal("500000000.00"),
+        )
+        result = reconcile_bank_statement(**_minimal_inputs(), config=cfg, materiality_source="caller")
+        assert result.active_thresholds["materiality"] == "1000000000.00"
+        assert result.active_thresholds["performance_materiality"] == "500000000.00"
+
+    def test_trillion_dollar_transaction_flagged_against_billion_materiality(
+        self,
+    ) -> None:
+        result = _test_high_value_transactions(
+            [_match(Decimal("1500000000000.00"))],  # $1.5T
+            materiality=Decimal("1000000000.00"),  # $1B
+        )
+        assert result.flagged_count == 1
+
+    def test_sub_penny_threshold_does_not_underflow(self) -> None:
+        # Decimal handles sub-penny precision without underflow; float would.
+        result = _test_high_value_transactions([_match(Decimal("0.005"))], materiality=Decimal("0.005"))
+        assert result.flagged_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic score uses Decimal-space comparison at the materiality boundary
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticScoreBoundary:
+    def test_reconciling_difference_at_performance_materiality_does_not_double_count(
+        self,
+    ) -> None:
+        # >0.01 AND > performance_materiality both add to score; verify
+        # the boundary matches the Decimal contract.
+        summary = ReconciliationSummary(
+            matched_count=1,
+            matched_amount=0.0,
+            bank_only_count=0,
+            ledger_only_count=0,
+            reconciling_difference=49_999.99,  # below performance_materiality
+            total_bank=0.0,
+            total_ledger=0.0,
+        )
+        result = compute_bank_rec_diagnostic_score([], summary, performance_materiality=Decimal("50000.00"))
+        # 15 (has diff) only; the >performance_materiality branch did not
+        # fire because reconciling_difference < performance_materiality.
+        assert result["score"] == 15
+
+    def test_reconciling_difference_above_performance_materiality_fires_both_branches(
+        self,
+    ) -> None:
+        summary = ReconciliationSummary(
+            matched_count=1,
+            matched_amount=0.0,
+            bank_only_count=0,
+            ledger_only_count=0,
+            reconciling_difference=50_000.01,  # above performance_materiality
+            total_bank=0.0,
+            total_ledger=0.0,
+        )
+        result = compute_bank_rec_diagnostic_score([], summary, performance_materiality=Decimal("50000.00"))
+        # 15 + 10 = 25
+        assert result["score"] == 25

--- a/backend/tests/test_intercompany_layered_detection.py
+++ b/backend/tests/test_intercompany_layered_detection.py
@@ -1,0 +1,327 @@
+"""
+Sprint 764 — Intercompany layered detection tests.
+
+Covers the layered detection contract:
+- Resolver cascade: request → engagement → none.
+- Layered detection: metadata-exact → heuristic_separator → heuristic_keyword.
+- Findings carry ``detection_method``, ``mapping_source``, and
+  detection-quality-aware ``confidence`` scores.
+- Backward compatibility: legacy callers (no mapping) match prior behavior.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+from account_classifier import AccountClassifier
+from audit.rules.relationships import detect_intercompany_imbalances
+from shared.intercompany_resolver import (
+    detection_method_label,
+    resolve_counterparty_mapping,
+)
+
+# ---------------------------------------------------------------------------
+# Resolver cascade: request → engagement → none
+# ---------------------------------------------------------------------------
+
+
+class TestResolverCascade:
+    def test_request_mapping_wins_over_engagement(self) -> None:
+        # Even if engagement has a stored mapping, the request-supplied
+        # one takes precedence.  The engagement_id / db are not even
+        # consulted when request_mapping is non-empty.
+        request_map = {"Loan from Subsidiary A": "subsidiary_a"}
+        mapping, source = resolve_counterparty_mapping(
+            request_mapping=request_map,
+            engagement_id=999,
+            db=MagicMock(),  # unused
+        )
+        assert source == "request"
+        assert mapping == {"loan from subsidiary a": "subsidiary_a"}
+
+    def test_engagement_mapping_used_when_request_absent(self) -> None:
+        eng = MagicMock()
+        eng.intercompany_counterparties = json.dumps({"Due From Parent Co": "parent_corp"})
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = eng
+
+        mapping, source = resolve_counterparty_mapping(
+            request_mapping=None,
+            engagement_id=42,
+            db=db,
+        )
+        assert source == "engagement"
+        assert mapping == {"due from parent co": "parent_corp"}
+
+    def test_none_when_no_request_no_engagement(self) -> None:
+        mapping, source = resolve_counterparty_mapping(
+            request_mapping=None,
+            engagement_id=None,
+            db=None,
+        )
+        assert source == "none"
+        assert mapping == {}
+
+    def test_none_when_engagement_has_no_mapping(self) -> None:
+        eng = MagicMock()
+        eng.intercompany_counterparties = None
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = eng
+
+        mapping, source = resolve_counterparty_mapping(request_mapping=None, engagement_id=42, db=db)
+        assert source == "none"
+        assert mapping == {}
+
+    def test_empty_request_mapping_falls_through_to_engagement(self) -> None:
+        # An empty dict on the request body should not "win" with empty
+        # source — falls through so engagement still gets a chance.
+        eng = MagicMock()
+        eng.intercompany_counterparties = json.dumps({"Due From Parent": "parent"})
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = eng
+
+        mapping, source = resolve_counterparty_mapping(request_mapping={}, engagement_id=42, db=db)
+        assert source == "engagement"
+
+    def test_malformed_engagement_json_falls_back_to_none(self) -> None:
+        eng = MagicMock()
+        eng.intercompany_counterparties = "{not valid json"
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = eng
+
+        mapping, source = resolve_counterparty_mapping(request_mapping=None, engagement_id=42, db=db)
+        assert source == "none"
+        assert mapping == {}
+
+    def test_case_folding_on_keys(self) -> None:
+        # Account names in the trial balance vary in case; resolver
+        # case-folds keys for case-insensitive matching downstream.
+        mapping, _ = resolve_counterparty_mapping(
+            request_mapping={"DUE FROM Parent CO": "parent_corp"},
+            engagement_id=None,
+            db=None,
+        )
+        assert "due from parent co" in mapping
+
+
+# ---------------------------------------------------------------------------
+# detection_method_label classifier
+# ---------------------------------------------------------------------------
+
+
+class TestDetectionMethodLabel:
+    def test_metadata_path_takes_precedence(self) -> None:
+        assert detection_method_label(used_metadata=True, separator_parsed=False) == "metadata_exact"
+        assert detection_method_label(used_metadata=True, separator_parsed=True) == "metadata_exact"
+
+    def test_separator_path_when_no_metadata(self) -> None:
+        assert detection_method_label(used_metadata=False, separator_parsed=True) == "heuristic_separator"
+
+    def test_keyword_only_fallback(self) -> None:
+        assert detection_method_label(used_metadata=False, separator_parsed=False) == "heuristic_keyword"
+
+
+# ---------------------------------------------------------------------------
+# Layered detection in detect_intercompany_imbalances
+# ---------------------------------------------------------------------------
+
+
+def _balances(*entries: tuple[str, float, float]) -> dict[str, dict[str, float]]:
+    """Helper: build the account_balances dict shape the engine expects."""
+    return {key: {"debit": d, "credit": c} for key, d, c in entries}
+
+
+def _classifier() -> AccountClassifier:
+    return AccountClassifier()
+
+
+class TestLayeredDetection:
+    def test_metadata_exact_match_used_when_provided(self) -> None:
+        # Account name has no separator and no obvious counterparty in
+        # the text, but metadata names the counterparty explicitly.
+        balances = _balances(
+            ("intercompany_loan_a", 50000.0, 0.0),
+            ("intercompany_loan_b", 0.0, 50000.0),
+        )
+        mapping = {
+            "intercompany_loan_a": "subsidiary_x",
+            "intercompany_loan_b": "subsidiary_x",
+        }
+        findings = detect_intercompany_imbalances(
+            account_balances=balances,
+            materiality_threshold=10000.0,
+            classifier=_classifier(),
+            provided_account_types={},
+            provided_account_names={},
+            counterparty_mapping=mapping,
+            mapping_source="request",
+        )
+        # Both accounts share counterparty "subsidiary_x" — but
+        # has_debit AND has_credit, so net_total = 0 and the group is
+        # filtered out by BALANCE_TOLERANCE.  Use a non-offsetting
+        # scenario to assert findings presence.
+        # We retest the same path with non-offsetting:
+        balances2 = _balances(("intercompany_loan_a", 50000.0, 0.0))
+        findings2 = detect_intercompany_imbalances(
+            account_balances=balances2,
+            materiality_threshold=10000.0,
+            classifier=_classifier(),
+            provided_account_types={},
+            provided_account_names={},
+            counterparty_mapping={"intercompany_loan_a": "subsidiary_x"},
+            mapping_source="request",
+        )
+        assert len(findings2) >= 1
+        f = findings2[0]
+        assert f["detection_method"] == "metadata_exact"
+        assert f["mapping_source"] == "request"
+        assert f["confidence"] == 1.0
+
+    def test_heuristic_separator_when_metadata_misses(self) -> None:
+        # Mapping is empty for this specific account, so the engine
+        # falls through to the separator parser.
+        balances = _balances(
+            ("intercompany_-_subsidiary_b", 25000.0, 0.0),
+        )
+        # Provide a display name so the separator can find a counterparty
+        names = {"intercompany_-_subsidiary_b": "Intercompany - Subsidiary B"}
+        findings = detect_intercompany_imbalances(
+            account_balances=balances,
+            materiality_threshold=10000.0,
+            classifier=_classifier(),
+            provided_account_types={},
+            provided_account_names=names,
+            counterparty_mapping={},  # empty
+            mapping_source="none",
+        )
+        assert len(findings) >= 1
+        f = findings[0]
+        assert f["detection_method"] == "heuristic_separator"
+        assert f["mapping_source"] == "none"
+        assert f["confidence"] == 0.85
+
+    def test_keyword_only_when_no_separator_no_metadata(self) -> None:
+        # Account contains the keyword "intercompany" but has no
+        # separator; counterparty cannot be extracted.  Account is
+        # filtered out (no counterparty group), so no findings.  This
+        # documents the boundary: keyword-only triggers IC but cannot
+        # be grouped.
+        balances = _balances(("intercompany_account", 25000.0, 0.0))
+        findings = detect_intercompany_imbalances(
+            account_balances=balances,
+            materiality_threshold=10000.0,
+            classifier=_classifier(),
+            provided_account_types={},
+            provided_account_names={},
+            counterparty_mapping={},
+            mapping_source="none",
+        )
+        # No counterparty extracted ⇒ account does not enter any group
+        # ⇒ no findings.  This matches legacy behavior; keyword-only
+        # accounts without a counterparty are not flagged here (anomaly
+        # detection picks them up via related_party rules instead).
+        assert findings == []
+
+    def test_metadata_overrides_keyword_for_non_keyword_accounts(self) -> None:
+        # Account has no IC keyword in its name; only metadata flags it
+        # as IC.  Layered detection accepts auditor judgment here.
+        balances = _balances(("loan_to_affiliate", 75000.0, 0.0))
+        names = {"loan_to_affiliate": "Loan to Affiliate"}
+        mapping = {"loan to affiliate": "affiliate_co"}
+        findings = detect_intercompany_imbalances(
+            account_balances=balances,
+            materiality_threshold=10000.0,
+            classifier=_classifier(),
+            provided_account_types={},
+            provided_account_names=names,
+            counterparty_mapping=mapping,
+            mapping_source="engagement",
+        )
+        assert len(findings) >= 1
+        assert findings[0]["detection_method"] == "metadata_exact"
+        assert findings[0]["mapping_source"] == "engagement"
+
+    def test_legacy_caller_no_mapping_works_unchanged(self) -> None:
+        # The pre-Sprint-764 calling convention (no mapping kwargs)
+        # must still produce valid findings with appropriate labels.
+        balances = _balances(("intercompany_-_subsidiary_z", 30000.0, 0.0))
+        names = {"intercompany_-_subsidiary_z": "Intercompany - Subsidiary Z"}
+        findings = detect_intercompany_imbalances(
+            account_balances=balances,
+            materiality_threshold=10000.0,
+            classifier=_classifier(),
+            provided_account_types={},
+            provided_account_names=names,
+        )
+        assert len(findings) >= 1
+        # Default mapping_source is "none"; method is heuristic_separator.
+        assert findings[0]["mapping_source"] == "none"
+        assert findings[0]["detection_method"] == "heuristic_separator"
+
+    def test_findings_have_required_explainability_fields(self) -> None:
+        balances = _balances(("intercompany_-_subsidiary_q", 20000.0, 0.0))
+        names = {"intercompany_-_subsidiary_q": "Intercompany - Subsidiary Q"}
+        findings = detect_intercompany_imbalances(
+            account_balances=balances,
+            materiality_threshold=10000.0,
+            classifier=_classifier(),
+            provided_account_types={},
+            provided_account_names=names,
+        )
+        for f in findings:
+            assert "detection_method" in f
+            assert f["detection_method"] in (
+                "metadata_exact",
+                "heuristic_separator",
+                "heuristic_keyword",
+            )
+            assert "mapping_source" in f
+            assert f["mapping_source"] in ("request", "engagement", "none")
+            assert "confidence" in f
+            assert 0.0 < f["confidence"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Engagement.to_dict surfaces the stored mapping
+# ---------------------------------------------------------------------------
+
+
+class TestEngagementSerialization:
+    def test_to_dict_emits_decoded_mapping(self) -> None:
+        from datetime import UTC, datetime
+
+        from engagement_model import Engagement, EngagementStatus
+
+        eng = Engagement(
+            client_id=1,
+            period_start=datetime.now(UTC),
+            period_end=datetime.now(UTC),
+            status=EngagementStatus.ACTIVE,
+            created_by=1,
+            intercompany_counterparties=json.dumps({"Due From Parent": "parent_corp"}),
+        )
+        # Bypass DB roundtrip — set defaults that to_dict expects
+        eng.created_at = datetime.now(UTC)
+        eng.updated_at = datetime.now(UTC)
+        eng.performance_materiality_factor = 0.75
+        eng.trivial_threshold_factor = 0.05
+        d = eng.to_dict()
+        assert d["intercompany_counterparties"] == {"Due From Parent": "parent_corp"}
+
+    def test_to_dict_emits_none_when_unset(self) -> None:
+        from datetime import UTC, datetime
+
+        from engagement_model import Engagement, EngagementStatus
+
+        eng = Engagement(
+            client_id=1,
+            period_start=datetime.now(UTC),
+            period_end=datetime.now(UTC),
+            status=EngagementStatus.ACTIVE,
+            created_by=1,
+        )
+        eng.created_at = datetime.now(UTC)
+        eng.updated_at = datetime.now(UTC)
+        eng.performance_materiality_factor = 0.75
+        eng.trivial_threshold_factor = 0.05
+        d = eng.to_dict()
+        assert d["intercompany_counterparties"] is None

--- a/backend/tests/test_multi_period_quantization.py
+++ b/backend/tests/test_multi_period_quantization.py
@@ -1,0 +1,124 @@
+"""
+Sprint 767 — multi_period_comparison output-boundary quantization tests.
+
+Asserts that monetary fields emitted by ``MovementSummary.to_dict()``,
+``LeadSheetMovementSummary.to_dict()``, ``BudgetVariance.to_dict()``,
+``ThreeWayLeadSheetSummary.to_dict()``, and ``ThreeWayMovementSummary.to_dict()``
+are quantized to 2dp ROUND_HALF_UP via ``shared.monetary.quantize_monetary``.
+
+Prevents float drift from leaking through `(current - prior)` subtraction
+into the response wire format.
+"""
+
+from decimal import ROUND_HALF_UP, Decimal
+
+import multi_period_comparison as mpc
+
+
+def _make_acct(name: str, debit: float = 0.0, credit: float = 0.0, type_: str = "asset") -> dict:
+    return {"account": name, "debit": debit, "credit": credit, "type": type_}
+
+
+def _is_at_most_2dp(value: float | None) -> bool:
+    """A serialized monetary float should have at most 2 decimal digits."""
+    if value is None:
+        return True
+    # Reconstruct via quantize and compare; tolerates exact-binary floats
+    # like 1.0, 100.5, 1234.56 — but rejects 0.1 + 0.2 = 0.30000000000000004
+    quantized = float(Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+    return abs(value - quantized) < 1e-9
+
+
+class TestAccountMovementQuantization:
+    def test_subtraction_drift_does_not_leak_to_response(self) -> None:
+        # 0.1 + 0.2 = 0.30000000000000004 in float.  After quantize at the
+        # response boundary, the wire value should be 0.30 exactly.
+        prior = [_make_acct("Foo", debit=0.1)]
+        current = [_make_acct("Foo", debit=0.1 + 0.2)]
+        result = mpc.compare_trial_balances(prior, current)
+        d = result.to_dict()
+        movement = d["all_movements"][0]
+        # 0.1 + 0.2 - 0.1 = 0.2 (with float drift); quantization snaps it
+        assert movement["change_amount"] == 0.20
+        assert _is_at_most_2dp(movement["prior_balance"])
+        assert _is_at_most_2dp(movement["current_balance"])
+        assert _is_at_most_2dp(movement["change_amount"])
+
+    def test_half_up_at_5_thousandths_boundary(self) -> None:
+        # $1,234.005 should round to 1234.01 under HALF_UP (Python's
+        # default banker's rounding would round to 1234.00).
+        prior = [_make_acct("Foo", debit=1000.00)]
+        current = [_make_acct("Foo", debit=1234.005)]
+        result = mpc.compare_trial_balances(prior, current)
+        d = result.to_dict()
+        movement = d["all_movements"][0]
+        assert movement["current_balance"] == 1234.01
+
+    def test_lead_sheet_aggregates_quantized(self) -> None:
+        prior = [_make_acct("A", debit=100.001), _make_acct("B", debit=200.002)]
+        current = [_make_acct("A", debit=110.005), _make_acct("B", debit=220.005)]
+        result = mpc.compare_trial_balances(prior, current)
+        d = result.to_dict()
+        for ls in d["lead_sheet_summaries"]:
+            assert _is_at_most_2dp(ls["prior_total"])
+            assert _is_at_most_2dp(ls["current_total"])
+            assert _is_at_most_2dp(ls["net_change"])
+
+    def test_tb_totals_quantized(self) -> None:
+        prior = [_make_acct("A", debit=0.1), _make_acct("B", debit=0.2)]
+        current = [_make_acct("A", debit=0.1), _make_acct("B", debit=0.2)]
+        result = mpc.compare_trial_balances(prior, current).to_dict()
+        # 0.1 + 0.2 = 0.30000000000000004 → must be snapped to 0.30
+        assert result["prior_total_debits"] == 0.30
+        assert result["current_total_debits"] == 0.30
+
+
+class TestThreeWayQuantization:
+    def test_budget_variance_dollar_fields_quantized(self) -> None:
+        prior = [_make_acct("Foo", debit=100.00)]
+        current = [_make_acct("Foo", debit=120.00)]
+        # Budget at 100.005 — variance vs current = 19.995 → quantize 19.99 (HALF_EVEN)
+        # but with HALF_UP: 19.995 → 20.00.  The contract is HALF_UP.
+        budget = [_make_acct("Foo", debit=100.005)]
+        result = mpc.compare_three_periods(prior, current, budget).to_dict()
+        movement = result["all_movements"][0]
+        bv = movement["budget_variance"]
+        assert bv is not None
+        # 120 - 100.005 = 19.995 → HALF_UP rounds to 20.00
+        assert bv["variance_amount"] == 20.00
+        assert _is_at_most_2dp(bv["budget_balance"])
+
+    def test_three_way_tb_totals_quantized(self) -> None:
+        prior = [_make_acct("A", debit=0.1)]
+        current = [_make_acct("A", debit=0.1)]
+        budget = [_make_acct("A", debit=0.1)]
+        result = mpc.compare_three_periods(prior, current, budget).to_dict()
+        assert _is_at_most_2dp(result["budget_total_debits"])
+
+    def test_three_way_lead_sheet_aggregates_quantized(self) -> None:
+        prior = [_make_acct("A", debit=100.001)]
+        current = [_make_acct("A", debit=110.005)]
+        budget = [_make_acct("A", debit=105.0049)]
+        result = mpc.compare_three_periods(prior, current, budget).to_dict()
+        for ls in result["lead_sheet_summaries"]:
+            assert _is_at_most_2dp(ls["prior_total"])
+            assert _is_at_most_2dp(ls["current_total"])
+            assert _is_at_most_2dp(ls["budget_total"])
+            assert _is_at_most_2dp(ls["budget_variance"])
+
+
+class TestPercentFieldsRemainRaw:
+    """Percent fields are non-monetary and should NOT be quantized to 2dp."""
+
+    def test_change_percent_keeps_full_precision(self) -> None:
+        prior = [_make_acct("Foo", debit=3.0)]
+        current = [_make_acct("Foo", debit=4.0)]
+        result = mpc.compare_trial_balances(prior, current).to_dict()
+        # change_percent = (4 - 3) / 3 * 100 = 33.333...
+        movement = result["all_movements"][0]
+        assert movement["change_percent"] is not None
+        assert movement["change_percent"] > 33.3
+        assert movement["change_percent"] < 33.4
+        # Specifically: not snapped to 33.33 (i.e., still has the trailing
+        # repeating digits beyond 2dp)
+        assert movement["change_percent"] != 33.33

--- a/backend/tests/test_variance_basis_contract.py
+++ b/backend/tests/test_variance_basis_contract.py
@@ -1,0 +1,218 @@
+"""
+Sprint 765 — Variance basis declaration contract tests.
+
+Asserts that every variance-emitting response surfaces ``variance_basis``
++ ``variance_formula`` and that the declared basis matches the actual
+computation in every code path.
+
+The contract:
+- ``variance_basis == "absolute_prior"``
+- ``variance_formula == "(current - prior) / abs(prior) * 100"``
+- For any (current, prior) pair with abs(prior) > NEAR_ZERO, the emitted
+  percent_variance / change_percent equals the formula applied to those
+  inputs (within float tolerance).
+
+See: ``docs/04-compliance/variance-formula-policy.md``.
+"""
+
+import httpx
+import pytest
+
+import multi_period_comparison as mpc
+import prior_period_comparison as ppc
+from auth import require_verified_user
+from main import app
+
+# ---------------------------------------------------------------------------
+# Module-level constants are aligned across files
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyConstants:
+    def test_basis_is_absolute_prior_in_both_modules(self) -> None:
+        assert mpc.VARIANCE_BASIS == "absolute_prior"
+        assert ppc.VARIANCE_BASIS == "absolute_prior"
+        assert mpc.VARIANCE_BASIS == ppc.VARIANCE_BASIS
+
+    def test_formula_string_is_aligned(self) -> None:
+        expected = "(current - prior) / abs(prior) * 100"
+        assert mpc.VARIANCE_FORMULA == expected
+        assert ppc.VARIANCE_FORMULA == expected
+
+
+# ---------------------------------------------------------------------------
+# multi_period_comparison.MovementSummary surfaces the contract
+# ---------------------------------------------------------------------------
+
+
+def _make_acct(name: str, debit: float = 0.0, credit: float = 0.0, type_: str = "asset") -> dict:
+    return {"account": name, "debit": debit, "credit": credit, "type": type_}
+
+
+class TestMultiPeriodResponse:
+    def test_two_way_to_dict_includes_basis_fields(self) -> None:
+        prior = [_make_acct("Cash", debit=10000.0)]
+        current = [_make_acct("Cash", debit=12000.0)]
+        result = mpc.compare_trial_balances(prior, current).to_dict()
+        assert result["variance_basis"] == "absolute_prior"
+        assert result["variance_formula"] == "(current - prior) / abs(prior) * 100"
+
+    def test_three_way_to_dict_includes_basis_fields(self) -> None:
+        prior = [_make_acct("Cash", debit=10000.0)]
+        current = [_make_acct("Cash", debit=12000.0)]
+        budget = [_make_acct("Cash", debit=11000.0)]
+        result = mpc.compare_three_periods(prior, current, budget).to_dict()
+        assert result["variance_basis"] == "absolute_prior"
+        assert result["variance_formula"] == "(current - prior) / abs(prior) * 100"
+
+    def test_change_percent_matches_formula_for_normal_account(self) -> None:
+        # Cash $10,000 → $12,000.  abs(prior) = 10000.  Expected: +20.0%
+        prior = [_make_acct("Cash", debit=10000.0)]
+        current = [_make_acct("Cash", debit=12000.0)]
+        result = mpc.compare_trial_balances(prior, current)
+        cash = next(m for m in result.all_movements if m.account_name == "Cash")
+        # Apply the documented formula directly
+        expected = (cash.current_balance - cash.prior_balance) / abs(cash.prior_balance) * 100
+        assert cash.change_percent == pytest.approx(expected)
+        assert cash.change_percent == pytest.approx(20.0)
+
+    def test_change_percent_matches_formula_for_credit_normal_account(self) -> None:
+        # Liability $5,000 → $7,500.  Internally debit-credit-net is
+        # negative; abs(prior) = 5000.  Expected: +50.0% in raw terms
+        # (sign flip happens only at display layer).
+        prior = [_make_acct("AP", credit=5000.0, type_="liability")]
+        current = [_make_acct("AP", credit=7500.0, type_="liability")]
+        result = mpc.compare_trial_balances(prior, current)
+        ap = next(m for m in result.all_movements if m.account_name == "AP")
+        expected = (ap.current_balance - ap.prior_balance) / abs(ap.prior_balance) * 100
+        assert ap.change_percent == pytest.approx(expected)
+
+    def test_near_zero_prior_yields_null_percent(self) -> None:
+        # Prior $0 → Current $1,000.  abs(prior) <= NEAR_ZERO ⇒ None.
+        prior = [_make_acct("New Acct", debit=0.0)]
+        current = [_make_acct("New Acct", debit=1000.0)]
+        result = mpc.compare_trial_balances(prior, current)
+        new = next(m for m in result.all_movements if m.account_name == "New Acct")
+        assert new.change_percent is None
+
+
+# ---------------------------------------------------------------------------
+# prior_period_comparison.PeriodComparison surfaces the contract
+# ---------------------------------------------------------------------------
+
+
+def _summary(**kwargs: float) -> dict:
+    return {
+        "period_label": "FY2024",
+        "total_assets": 0.0,
+        "current_assets": 0.0,
+        "inventory": 0.0,
+        "total_liabilities": 0.0,
+        "current_liabilities": 0.0,
+        "total_equity": 0.0,
+        "total_revenue": 0.0,
+        "cost_of_goods_sold": 0.0,
+        "total_expenses": 0.0,
+        "operating_expenses": 0.0,
+        **kwargs,
+    }
+
+
+class TestPriorPeriodResponse:
+    def test_to_dict_includes_basis_fields(self) -> None:
+        current = _summary(total_assets=120_000.0)
+        prior = _summary(total_assets=100_000.0)
+        comp = ppc.compare_periods(current, prior, prior_id=42)
+        d = comp.to_dict()
+        assert d["variance_basis"] == "absolute_prior"
+        assert d["variance_formula"] == "(current - prior) / abs(prior) * 100"
+
+    def test_calculate_variance_matches_formula(self) -> None:
+        # current=120, prior=100 → +20.0% under absolute_prior.
+        dollar_var, pct_var, _, _ = ppc.calculate_variance(120.0, 100.0)
+        assert dollar_var == pytest.approx(20.0)
+        assert pct_var == pytest.approx(20.0)
+        # Apply the formula directly
+        expected = (120.0 - 100.0) / abs(100.0) * 100
+        assert pct_var == pytest.approx(expected)
+
+    def test_calculate_variance_negative_prior_uses_absolute_denominator(
+        self,
+    ) -> None:
+        # Liability prior parsed as net debit-credit, sign-negative.
+        # Absolute-prior basis: abs(-5000) = 5000 → +20% magnitude.
+        # Signed-prior basis would have given -20% — confirms we are NOT
+        # using signed-prior denominator.
+        dollar_var, pct_var, _, _ = ppc.calculate_variance(-4000.0, -5000.0)
+        assert dollar_var == pytest.approx(1000.0)
+        assert pct_var == pytest.approx(20.0)
+        # The signed-prior alternative would have produced -20.0
+        signed_alt = (-4000.0 - -5000.0) / -5000.0 * 100
+        assert signed_alt == pytest.approx(-20.0)
+        assert pct_var != pytest.approx(signed_alt)
+
+    def test_calculate_variance_near_zero_prior_yields_none(self) -> None:
+        # abs(prior) < NEAR_ZERO ⇒ percent_variance is None.
+        _, pct_var, _, _ = ppc.calculate_variance(100.0, 0.0)
+        assert pct_var is None
+        _, pct_var2, _, _ = ppc.calculate_variance(100.0, 0.001)
+        assert pct_var2 is None
+
+
+# ---------------------------------------------------------------------------
+# Wire contract: variance_basis must survive FastAPI response_model serialization
+# ---------------------------------------------------------------------------
+
+
+class _MockUser:
+    """Minimal verified-user stand-in for protected route tests."""
+
+    def __init__(self) -> None:
+        from shared.entitlements import UserTier  # local import: avoid circular
+
+        self.id = 1
+        self.email = "wire-contract@test"
+        self.is_verified = True
+        self.tier = UserTier.PROFESSIONAL
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("bypass_csrf")
+async def test_compare_periods_route_emits_variance_basis_on_wire() -> None:
+    """The Pydantic response model must surface variance_basis on the wire.
+
+    Without this, the response_model would silently strip the field and
+    the engine's emission would never reach consumers.  Sprint 765/767
+    contract guarantee.
+    """
+    from auth import require_current_user
+    from shared import entitlement_checks
+
+    user = _MockUser()
+    app.dependency_overrides[require_verified_user] = lambda: user
+    app.dependency_overrides[require_current_user] = lambda: user
+
+    # Bypass entitlement check (tool gating not under test here).
+    original = entitlement_checks.check_upload_limit  # type: ignore[attr-defined]
+
+    try:
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+            payload = {
+                "prior_accounts": [
+                    {"account": "Cash", "debit": 50000.0, "credit": 0.0, "type": "asset"},
+                ],
+                "current_accounts": [
+                    {"account": "Cash", "debit": 65000.0, "credit": 0.0, "type": "asset"},
+                ],
+                "prior_label": "FY2024",
+                "current_label": "FY2025",
+                "materiality_threshold": 0.0,
+            }
+            response = await client.post("/audit/compare-periods", json=payload)
+            assert response.status_code == 200, response.text
+            data = response.json()
+            # The contract: variance_basis + variance_formula on the wire
+            assert data.get("variance_basis") == "absolute_prior"
+            assert data.get("variance_formula") == "(current - prior) / abs(prior) * 100"
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/three_way_match_engine.py
+++ b/backend/three_way_match_engine.py
@@ -27,19 +27,20 @@ from enum import Enum
 from typing import Any, Optional
 
 from shared.column_detector import ColumnFieldConfig, detect_columns
+from shared.monetary import MONETARY_NEAR_ZERO
 from shared.parsing_helpers import parse_date, safe_decimal, safe_float, safe_str
 
-# Monetary epsilon for denominator guards — values whose absolute magnitude
-# is below this are considered "near zero" and cannot be used as a divisor.
-# 0.005 is half a cent: below any presentation-rounded currency amount yet
-# large enough to avoid false near-zero triggers from floating-point noise.
+# Sprint 766: monetary epsilon consolidated to ``shared.monetary.MONETARY_NEAR_ZERO``
+# (Decimal("0.005")).  ``MONETARY_EPSILON`` retained as a backwards-compatible
+# alias so call sites within this engine and any downstream importers keep
+# working without churn.
 #
 # IMPORTANT: this is separate from ``price_variance_threshold`` (which is a
 # *decision* threshold — "what variance % is material?").  Conflating the two
 # produced RPT-11: a 5% decision threshold being used as a "$0.05 is close
 # enough to zero" denominator guard, which mis-classified any unit_price
 # below $0.05 as a 100% variance.
-MONETARY_EPSILON: Decimal = Decimal("0.005")
+MONETARY_EPSILON: Decimal = MONETARY_NEAR_ZERO
 
 # =============================================================================
 # ENUMS

--- a/docs/04-compliance/variance-formula-policy.md
+++ b/docs/04-compliance/variance-formula-policy.md
@@ -1,0 +1,63 @@
+# Variance Formula Policy
+
+**Status:** Active — Sprint 765 (2026-04-30)
+**Scope:** Every Paciolus endpoint that emits a percent variance, percent change, or budget variance percent.
+
+---
+
+## Formula
+
+```
+percent_variance = (current - prior) / abs(prior) * 100
+```
+
+The **denominator basis is `abs(prior)`** — the absolute value of the prior-period balance.  This is the canonical "absolute prior" basis.  It is consistent across:
+
+- `multi_period_comparison.compare_trial_balances` (prior ↔ current account movements)
+- `multi_period_comparison.compare_three_periods` (prior ↔ current ↔ budget; both the period and budget comparisons use this basis)
+- `prior_period_comparison.calculate_variance` (current ↔ prior diagnostic summary)
+- Lead-sheet summary aggregates within all of the above
+
+## Why absolute prior
+
+Two reasonable conventions exist for percent-change denominators:
+
+1. **Signed prior** — `(current - prior) / prior * 100`.  Preserves the sign of the prior balance, but produces sign-flipped percentages on credit-normal accounts (liabilities, equity, revenue), which is counter-intuitive in audit workpapers.
+2. **Absolute prior** — `(current - prior) / abs(prior) * 100`.  Yields a percent whose sign tracks the *direction of change in the absolute amount*, regardless of whether the underlying balance is debit-normal or credit-normal.
+
+Paciolus uses **absolute prior** because it produces audit-intuitive output: a 10% positive percent variance on a liability and a 10% positive percent variance on an asset both mean "the absolute balance grew by 10%."  Display sign-flips (so a liability *increase* shows as positive) are handled separately at the response layer via `display_change_amount` / `display_change_percent` for credit-normal categories.
+
+## Near-zero guard
+
+When `abs(prior) <= NEAR_ZERO` (constant `0.005`), `percent_variance` is set to `null` rather than computed.  This avoids divide-by-near-zero amplification on dormant or newly-created accounts.  Consumers must treat `null` as "not meaningfully expressible as a percentage" and rely on `dollar_variance` / `change_amount` instead.
+
+## Disclosure on the wire
+
+Every variance-emitting response surfaces:
+
+```json
+{
+  "variance_basis": "absolute_prior",
+  "variance_formula": "(current - prior) / abs(prior) * 100"
+}
+```
+
+Memos, PDFs, and downstream consumers should render the formula alongside any percent variance figure.  The contract test `backend/tests/test_variance_basis_contract.py` enforces that the declared basis matches the actual computation across all variance-emitting code paths.
+
+## Migration / change policy
+
+Changing the basis (e.g., to signed prior) is a breaking change that affects every memo, PDF, and historical comparison.  It would require:
+
+1. A new policy document superseding this one.
+2. Updates to all `to_dict()` paths emitting `variance_basis`.
+3. Recomputation of any cached prior-period comparisons.
+4. Stakeholder review (CEO + audit lead) — auditor judgments based on prior basis would be invalidated.
+
+This is intentionally high-friction.  The basis should be considered stable.
+
+## Related
+
+- `backend/prior_period_comparison.py:VARIANCE_BASIS`, `VARIANCE_FORMULA`
+- `backend/multi_period_comparison.py:VARIANCE_BASIS`, `VARIANCE_FORMULA`
+- `backend/tests/test_variance_basis_contract.py`
+- ASC 205-10 (comparative statements) — discloses comparative basis but does not prescribe a denominator convention; this policy makes the convention explicit.

--- a/scripts/openapi-snapshot.json
+++ b/scripts/openapi-snapshot.json
@@ -4792,6 +4792,18 @@
       "BankRecResponse": {
         "description": "Complete bank reconciliation response.",
         "properties": {
+          "active_thresholds": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Active Thresholds"
+          },
           "bank_column_detection": {
             "$ref": "#/components/schemas/BankColumnDetectionResponse"
           },
@@ -15727,6 +15739,18 @@
       "MovementSummaryResponse": {
         "description": "2-way period comparison response.",
         "properties": {
+          "active_thresholds": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Active Thresholds"
+          },
           "all_movements": {
             "items": {
               "$ref": "#/components/schemas/AccountMovementResponse"
@@ -15758,6 +15782,15 @@
               "type": "string"
             },
             "title": "Dormant Accounts",
+            "type": "array"
+          },
+          "duplicate_account_warnings": {
+            "default": [],
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Duplicate Account Warnings",
             "type": "array"
           },
           "expectations_evaluated": {
@@ -15829,6 +15862,28 @@
           "total_accounts": {
             "title": "Total Accounts",
             "type": "integer"
+          },
+          "variance_basis": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Variance Basis"
+          },
+          "variance_formula": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Variance Formula"
           }
         },
         "required": [
@@ -17797,6 +17852,28 @@
           "total_categories_compared": {
             "title": "Total Categories Compared",
             "type": "integer"
+          },
+          "variance_basis": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Variance Basis"
+          },
+          "variance_formula": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Variance Formula"
           }
         },
         "required": [
@@ -24012,6 +24089,18 @@
             "title": "Accounts Under Budget",
             "type": "integer"
           },
+          "active_thresholds": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Active Thresholds"
+          },
           "all_movements": {
             "items": {
               "additionalProperties": true,
@@ -24065,6 +24154,15 @@
             "title": "Dormant Accounts",
             "type": "array"
           },
+          "duplicate_account_warnings": {
+            "default": [],
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Duplicate Account Warnings",
+            "type": "array"
+          },
           "expectations_evaluated": {
             "default": [],
             "items": {
@@ -24072,6 +24170,17 @@
             },
             "title": "Expectations Evaluated",
             "type": "array"
+          },
+          "framework_note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Framework Note"
           },
           "lead_sheet_summaries": {
             "items": {
@@ -24124,6 +24233,28 @@
           "total_accounts": {
             "title": "Total Accounts",
             "type": "integer"
+          },
+          "variance_basis": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Variance Basis"
+          },
+          "variance_formula": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Variance Formula"
           }
         },
         "required": [

--- a/tasks/archive/sprints-763-767-details.md
+++ b/tasks/archive/sprints-763-767-details.md
@@ -1,0 +1,124 @@
+# Sprints 763–767 Details
+
+> Archived from `tasks/todo.md` Active Phase on 2026-04-30.
+
+---
+
+### Sprint 763: RPT-10 finish — bank-rec materiality emission + Decimal-typed config
+**Status:** COMPLETE — 2026-04-30.
+**Priority:** P1. Closes the actual remaining RPT-10 gap after the route already accepts overrides at `routes/bank_reconciliation.py:56–90`.
+**Source:** Financial Calculation Correctness audit B; discovery pass confirmed `BankRecConfig.materiality` / `performance_materiality` are still float-typed and the response does not surface which thresholds were active.
+
+**Complexity:** 3/5. Touches the engine config, the runner signature, and the response schema; tests need an override-vs-default pair plus a Decimal-precision boundary case.
+
+**What lands:**
+- `BankRecConfig` monetary fields → `Decimal` (`materiality`, `performance_materiality`, `amount_tolerance`). `__post_init__` coerces float/int/str inputs via `safe_decimal` for backward compatibility with existing route plumbing.
+- Engine emits `active_thresholds = {"materiality": ..., "performance_materiality": ..., "amount_tolerance": ..., "materiality_source": "caller"|"default"}` in the reconciliation result. Mirrors the `MovementSummary.active_thresholds` pattern from RPT-02.
+- Route layer tags `materiality_source = "caller"` when either field is supplied on the request, `"default"` otherwise.
+- Tests: caller-supplied override propagates; absent fields default to documented values + `materiality_source == "default"`; Decimal-precision boundary at the `materiality` comparison boundary (e.g., $50,000.00 vs $49,999.99 vs $50,000.01); large-engagement scale (>$1B materiality) round-trips through the response without precision loss.
+- Docs: `docs/04-compliance/` cross-reference unchanged; the bank-rec route OpenAPI snapshot regenerated with the new response field.
+
+**Out of scope:**
+- Full Decimal port of `bank_reconciliation.py` engine internals (all `BankTransaction.amount` / `LedgerTransaction.amount` etc.) — that is Sprint 766.
+- Adding new materiality cascade hooks — caller can already wire engagement materiality at the route layer.
+
+**Verification:**
+- `pytest backend/tests/test_recon_engine.py backend/tests/test_bank_rec_split_and_jes.py backend/tests/test_bank_rec_memo.py -v` clean.
+- New tests `backend/tests/test_bank_rec_materiality.py` cover the matrix above; ≥4 added cases.
+- `npm run build` (frontend) clean if the new field is consumed by the UI; otherwise unchanged.
+- `scripts/openapi-snapshot.json` regenerated to absorb the response-schema delta.
+
+**Review:**
+- Landed: `BankRecConfig` Decimal-typed with `safe_decimal`-coerced `__post_init__` (rejects negative thresholds explicitly); `_test_high_value_transactions`, `run_reconciliation_tests`, `compute_bank_rec_diagnostic_score` now Decimal-typed at the boundary; `BankRecResult.active_thresholds` populated by `reconcile_bank_statement` from config + `materiality_source` arg; route layer tags `materiality_source = "caller"` only when an override was supplied.
+- Tests: 22 new in `test_bank_rec_materiality.py` (config coercion + validation, active_thresholds emission, materiality boundary at $50k ± 1¢, large-engagement scale, Decimal-arithmetic precision at boundary, diagnostic-score boundary). 125 existing bank-rec tests + 269 cross-cutting tests all green.
+- OpenAPI snapshot regenerated: paths 220 / schemas 422 (unchanged); `active_thresholds` field added to `BankRecResponse`.
+- Frontend impact: none (UI does not yet consume `active_thresholds`; non-breaking additive field).
+
+
+---
+
+### Sprint 764: Intercompany layered detection (metadata + heuristic + confidence)
+**Status:** COMPLETE — 2026-04-30. Metadata-source decision: **(iii) cascade** (request override → engagement default → none).
+**Priority:** P2. Real defect: `audit/rules/relationships.py` is 100% heuristic separator-parsing with no metadata path and no explainability on findings.
+**Source:** Financial Calculation Correctness audit E; discovery confirmed `_extract_counterparty()` is delimiter-based with no override path.
+
+**Complexity:** 4/5. Adds a new schema surface, a confidence-scored detection layer, and explainability fields on findings.
+
+**What lands:**
+- `Engagement.intercompany_counterparties` (Text-typed JSON-encoded mapping) added to `engagement_model.py`; serialized in `to_dict`. Same Text+JSON pattern as `ToolRun.flagged_accounts` for SQLite/Postgres portability.
+- Alembic migration `b5c6d7e8f9a0_add_intercompany_counterparties_to_engagements.py` — additive nullable column; downgrade drops it.
+- New `shared/intercompany_resolver.py` — `resolve_counterparty_mapping(request_mapping, engagement_id, db)` returns `(mapping, source)` with cascade precedence: request → engagement → none. Mirrors `shared/materiality_resolver.py` shape.
+- `audit/rules/relationships.py::detect_intercompany_imbalances` accepts `counterparty_mapping` + `mapping_source` kwargs. Layered detection: metadata-exact (confidence 1.0) → heuristic_separator (0.85) → heuristic_keyword (0.65). Findings carry `detection_method` and `mapping_source`.
+- `StreamingAuditor.detect_intercompany_imbalances` forwards both kwargs through. Default values preserve legacy callers.
+- Metadata lookup tries multiple key shapes (`display.lower()`, `account_key.lower()`, bare `provided_name.lower()`) so auditors can populate the mapping with the bare provided name without worrying about the em-dash join in `build_display_name`.
+
+**Verification:**
+- New tests `backend/tests/test_intercompany_layered_detection.py` (18 tests): resolver cascade matrix, `detection_method_label` classifier, layered detection paths, backward-compat for legacy callers, `Engagement.to_dict` round-trip.
+- Legacy intercompany tests (`test_contra_and_detection_fixes.py`, anomaly framework) all pass — 82/82 — confirming no regression to the heuristic path.
+- `test_alembic_models_parity.py` clean — Alembic catches up to the model.
+
+**Out of scope:**
+- ML-based name similarity (semantic embeddings). Keep within deterministic primitives.
+- Wiring the resolver from the TB diagnostic route — the engine accepts the kwargs, but the route plumbing to call `resolve_counterparty_mapping()` from the request body is a follow-up sprint. Defaults preserve current behavior until the route is wired.
+- Frontend UI for managing the engagement mapping — separate sprint when product wants the auditor surface.
+
+
+---
+
+### Sprint 765: variance_basis declarative field on multi-period + prior-period responses
+**Status:** COMPLETE — 2026-04-30.
+**Priority:** P2. Closes the audit's variance-policy ambiguity without a formula change (basis is already `abs(prior)` everywhere — gap is purely declarative).
+**Source:** Financial Calculation Correctness audit D; discovery confirmed `prior_period_comparison.py:189–224` and `multi_period_comparison.py` already use `abs(prior)` consistently.
+
+**Complexity:** 2/5. Pure schema/contract addition; no math changes.
+
+**What lands:**
+- `MovementSummary` and `PeriodComparison` (and three-way variant) emit `variance_basis: "absolute_prior"` plus a `variance_formula: "(current - prior) / abs(prior) * 100"` doc string.
+- New page `docs/04-compliance/variance-formula-policy.md` documenting the chosen basis, rationale, near-zero guard (`NEAR_ZERO = 0.005`), and division-by-zero handling.
+- Contract test in `backend/tests/test_variance_basis_contract.py` that asserts every variance-emitting endpoint surfaces `variance_basis` and that the value matches the actual computation.
+
+**Out of scope:**
+- Switching the basis itself — production semantics unchanged.
+
+
+---
+
+### Sprint 766: bank_reconciliation.py full Decimal port + helper consolidation
+**Status:** COMPLETE — 2026-04-30.
+**Priority:** P2. Hardens the actual remaining float-heavy outlier flagged in the audit's section C.
+**Source:** Financial Calculation Correctness audit C; discovery confirmed bank-rec stores all amounts as float and `three_way_match_engine.py` defines its own `MONETARY_EPSILON` rather than importing from `shared/monetary.py`.
+
+**Complexity:** 4/5. Touches every monetary path through bank-rec; risk of subtle parity drift on existing test fixtures.
+
+**What lands:**
+- `BankTransaction.amount`, `LedgerTransaction.amount`, all summary aggregates → `Decimal` with `safe_decimal` coercion in `__post_init__`.
+- Comparison surfaces (variance bands, materiality gates, tolerance checks) all in Decimal space.
+- `three_way_match_engine.MONETARY_EPSILON` removed; module imports `BALANCE_TOLERANCE` from `shared/monetary.py` instead.
+- Output serialization quantized to 2dp via `quantize_monetary` at the response boundary (preserves existing JSON shape — Decimal is rendered to fixed-precision string or float per existing schema convention).
+- Regression tests: parity with existing fixtures (penny-perfect on every prior-recon output); new precision tests at $0.01 / $0.005 / $1T+ scale.
+
+**Out of scope:**
+- Reworking the matching algorithm itself.
+- DB-schema changes (none required — bank-rec is stateless / zero-storage).
+
+
+---
+
+### Sprint 767: multi_period output-boundary quantization
+**Status:** COMPLETE — 2026-04-30.
+**Priority:** P3. Tightens the float→Decimal→float round-trip flagged in audit section C.
+**Source:** Financial Calculation Correctness audit C; discovery confirmed `compare_trial_balances()` uses `Decimal` internally then casts back to `float` at the boundary, losing the precision discipline.
+
+**Complexity:** 2/5. Output-boundary surgery; no decision-logic change.
+
+**What lands:**
+- `AccountMovement` / `LeadSheetMovementSummary` / `MovementSummary` monetary fields on `to_dict()` go through `quantize_monetary` rather than raw `float()`.
+- Decision-path comparisons (significance classification, sign-change detection) stay in Decimal until the final `to_dict()` boundary.
+- Tests: `0.005`-boundary quantization (HALF_UP), penny-precision parity with existing fixtures.
+
+**Out of scope:**
+- Changing the response field types from numeric to string — keep wire compat.
+
+
+---
+

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -81,10 +81,13 @@
 ---
 
 ## Active Phase
-
 > **Launch-readiness Council Review — 2026-04-16.** 8-agent consensus: code is launch-ready; gating path is CEO calendar (Phase 3 validation → Phase 4.1 Stripe cutover → legal sign-off). Full verdict tradeoff map in conversation transcript.
 >
 > **Prior sprint detail:** All pre-Sprint-738 work archived under `tasks/archive/`. See [`tasks/COMPLETED_ERAS.md`](COMPLETED_ERAS.md) for the era index and archive file pointers. Sprints 732/739/740 archived to [`tasks/archive/sprints-732-740-details.md`](archive/sprints-732-740-details.md). Sprints 742–759 (architectural remediation) archived to [`tasks/archive/sprints-742-759-details.md`](archive/sprints-742-759-details.md).
+> **Source:** External Financial Calculation Correctness audit (2026-04-30). Discovery pass confirmed substantial portions of the brief were already remediated (RPT-02 thresholds dataclass, RPT-11 epsilon separation, AR aging non-midpoint bucket bounds). Path B targets the genuinely outstanding defects + Decimal hardening of the bank-rec outlier and the multi-period output boundary. Conflict Loop captured in conversation transcript (2026-04-30).
+>
+> **Acceptance bar:** monetary decision logic Decimal-safe in the touched surfaces; materiality/threshold behavior dynamic + emitted in responses (active_thresholds + source); variance basis declared explicitly; intercompany layered with metadata + confidence + explainability; tests proving each fix and preventing regression.
+> Sprints 763–767 archived to `tasks/archive/sprints-763-767-details.md`.
 
 ### Sprint 738: Alembic migration drift cleanup
 **Status:** PENDING — pre-4.1 sequence position 1.5. Could slip post-4.1 if priority shifts; not customer-visible either way.
@@ -210,3 +213,4 @@ Bundle the 19 patch + safe-minor updates into one commit, mirroring the 2026-04-
 - Adding contract tests for the 3 non-memo report PDFs (combined audit, financial statements, anomaly summary) — separate filing if needed.
 
 ---
+


### PR DESCRIPTION
## Summary

Five-sprint umbrella PR closing the externally-audited correctness gaps in materiality emission, variance-basis declaration, monetary precision, and intercompany detection explainability.

- **Sprint 763** — RPT-10 finish: `BankRecConfig` Decimal-typed; `active_thresholds` + `materiality_source` ("caller"/"default") emitted on bank-rec response.
- **Sprint 765** — `variance_basis: "absolute_prior"` + `variance_formula` declared on multi-period and prior-period responses; new `docs/04-compliance/variance-formula-policy.md`.
- **Sprint 767** — multi-period output-boundary quantization (HALF_UP via `quantize_monetary` instead of raw `float()` casts).
- **Sprint 766** — full Decimal port of `bank_reconciliation.py` engine internals (`ReconciliationSummary`, `RecFlaggedItem`, `OutstandingItemsAging`, `SuggestedJE`); helper consolidation (`shared.monetary.MONETARY_NEAR_ZERO`; `three_way_match_engine.MONETARY_EPSILON` → alias).
- **Sprint 764** — Intercompany layered detection with engagement+request cascade. New `Engagement.intercompany_counterparties` field (Alembic migration `b5c6d7e8f9a0`); new `shared/intercompany_resolver.py`; findings carry `detection_method` + `mapping_source` + method-aware `confidence`.

## Discovery context

Conflict Loop in conversation transcript (2026-04-30) established that ~half of the original audit brief was already remediated (RPT-02 thresholds dataclass, RPT-11 epsilon separation, AR aging non-midpoint bucket bounds). Path B targeted only the genuinely outstanding defects.

## Migration notes

- All API additions are backward-compatible (Optional fields).
- No formula changes; variance basis remains `(current - prior) / abs(prior) * 100`.
- Rounding policy at boundary moved HALF_EVEN → HALF_UP for bank-rec and multi-period engines; documented in `shared/monetary.py`.
- New persistent state `Engagement.intercompany_counterparties` is nullable (Text/JSON); existing data unchanged.

## Residual debt (intentionally out of scope)

- TB diagnostic route plumbing for `resolve_counterparty_mapping` (engine accepts kwargs; route still uses defaults). Follow-up sprint.
- Frontend UI for managing engagement counterparty mapping.
- Sprint 738 Alembic drift cleanup unaffected; this migration is additive at head.

## Test plan

- [x] 77 new tests across 5 files (`test_bank_rec_materiality` 22, `test_bank_rec_decimal_port` 17, `test_variance_basis_contract` 12 incl. wire-level, `test_multi_period_quantization` 8, `test_intercompany_layered_detection` 18).
- [x] Cumulative regression sweep across 29 test files: **1144/1144 passed**.
- [x] OpenAPI drift check clean (220 paths / 422 schemas).
- [x] Alembic models parity test passes.
- [ ] Required CI checks pass (auto-run on PR open).
- [ ] Reviewer spot-checks the Engagement migration (additive, nullable; no production data risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)