### PR TITLE
Sprint 769: memoize Diagnostic + Engagement context values

### DIFF
--- a/frontend/src/contexts/DiagnosticContext.tsx
+++ b/frontend/src/contexts/DiagnosticContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useCallback, useMemo, ReactNode } from 'react';
 import type {
   DiagnosticResult,
   DiagnosticContextType,
@@ -27,16 +27,21 @@ export function DiagnosticProvider({ children }: { children: ReactNode }): React
   // We'll stick to React State (memory) to be strictly aligned with "No Storage".
   // Note: Tab refresh will clear data, which is acceptable/desired for security.
 
-  const setResult = (data: DiagnosticResult | null) => {
+  const setResult = useCallback((data: DiagnosticResult | null) => {
     setResultState(data);
-  };
+  }, []);
 
-  const clearResult = () => {
+  const clearResult = useCallback(() => {
     setResultState(null);
-  };
+  }, []);
+
+  const value = useMemo<DiagnosticContextType>(
+    () => ({ result, setResult, clearResult, isLoading, setIsLoading }),
+    [result, isLoading, setResult, clearResult],
+  );
 
   return (
-    <DiagnosticContext.Provider value={{ result, setResult, clearResult, isLoading, setIsLoading }}>
+    <DiagnosticContext.Provider value={value}>
       {children}
     </DiagnosticContext.Provider>
   );

--- a/frontend/src/contexts/EngagementContext.tsx
+++ b/frontend/src/contexts/EngagementContext.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   useCallback,
   useEffect,
+  useMemo,
   ReactNode,
   ReactElement,
 } from 'react';
@@ -101,7 +102,20 @@ export function EngagementProvider({ children }: { children: ReactNode }): React
     setToolRuns(runs);
   }, [activeEngagement, getToolRuns]);
 
-  // Read ?engagement=X from URL on mount
+  // Read ?engagement=X from URL on mount.
+  //
+  // Intentional one-shot pattern: deps are limited to the auth gate so this
+  // effect only fires when the user becomes authenticated. The omitted deps
+  // (`searchParams`, `selectEngagement`, `activeEngagement`) are read inside
+  // but should NOT re-trigger the effect:
+  //   • `searchParams` changes on every URL update (including selectEngagement's
+  //     own router.replace) — including it would loop.
+  //   • `selectEngagement` re-creates whenever searchParams change — same loop.
+  //   • `activeEngagement` is the guard that prevents re-execution once a
+  //     selection has been made; including it would re-run the effect on every
+  //     selection change (defeating the "mount-once" intent).
+  // The activeEngagement-guard inside the body is the load-bearing mechanism
+  // that prevents over-firing.
   useEffect(() => {
     if (!isAuthenticated || !token) return;
 
@@ -114,18 +128,32 @@ export function EngagementProvider({ children }: { children: ReactNode }): React
     }
   }, [isAuthenticated, token]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const contextValue: EngagementContextType = {
-    activeEngagement,
-    toolRuns,
-    materiality,
-    isLoading,
-    toastMessage,
-    selectEngagement,
-    clearEngagement,
-    refreshToolRuns,
-    triggerLinkToast,
-    dismissToast,
-  };
+  const contextValue = useMemo<EngagementContextType>(
+    () => ({
+      activeEngagement,
+      toolRuns,
+      materiality,
+      isLoading,
+      toastMessage,
+      selectEngagement,
+      clearEngagement,
+      refreshToolRuns,
+      triggerLinkToast,
+      dismissToast,
+    }),
+    [
+      activeEngagement,
+      toolRuns,
+      materiality,
+      isLoading,
+      toastMessage,
+      selectEngagement,
+      clearEngagement,
+      refreshToolRuns,
+      triggerLinkToast,
+      dismissToast,
+    ],
+  );
 
   return (
     <EngagementContext.Provider value={contextValue}>

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -266,3 +266,28 @@ Bundle the 19 patch + safe-minor updates into one commit, mirroring the 2026-04-
 
 ---
 
+### Sprint 769: Frontend context memoization (render-perf hotfix)
+**Status:** COMPLETE — landed on branch `sprint-769-frontend-context-memoization`.
+**Priority:** P2. No user-visible bug, but cascade re-renders measurably affect interactive latency in tools mounted under DiagnosticProvider/EngagementProvider.
+**Source:** Frontend efficiency audit (2026-05-01) findings 1.1 + 1.2.
+
+`DiagnosticContext` and `EngagementContext` were building a fresh `value` object literal on every provider render. With `setResult` / `clearResult` also fresh closures, every consumer re-rendered whenever the provider's parent re-rendered, regardless of whether the carried state actually changed.
+
+**What landed:**
+- `DiagnosticContext.tsx` — `setResult` / `clearResult` wrapped in `useCallback([])`; provider `value` wrapped in `useMemo([result, isLoading, setResult, clearResult])`. (`setIsLoading` is the React-stable `useState` setter, omitted from deps per React semantics.)
+- `EngagementContext.tsx` — `contextValue` wrapped in `useMemo` with the full 10-key dep array (5 state values + 5 already-memoized handlers).
+- Inline rationale block added above the URL-sync `useEffect` (`EngagementContext.tsx:115`) documenting why `searchParams` / `selectEngagement` / `activeEngagement` are deliberately excluded from deps: including `searchParams` would loop because `selectEngagement`'s own `router.replace` rotates the value; `selectEngagement` itself re-creates whenever `searchParams` change (same loop); and `activeEngagement` is the load-bearing one-shot guard inside the body. The eslint-disable is intentional, not a stale-closure bug.
+
+**Verification:**
+- `cd frontend && npx tsc --noEmit` → exit 0.
+- `cd frontend && npx jest --watch=false --testPathPatterns="(Diagnostic|Engagement)"` → **52 passed, 0 failed** (7 suites). Pre-existing `act()` warnings on `EngagementBanner.tsx:35` are not regressions and originate from `useEffect`-triggered `setClientName` in test renders unrelated to Sprint 769's surface.
+- `cd frontend && npm run build` → exit 0; all routes correctly dynamic (`ƒ`).
+
+**Out of scope:**
+- Splitting either context into state-vs-dispatch halves — bigger refactor, not warranted by current symptoms.
+- Other render-perf findings (row mappings, table memoization, result-subtree wraps) — bundled in Sprint 773.
+
+**Commit SHA:** see branch `sprint-769-frontend-context-memoization` (filled at PR merge).
+
+---
+


### PR DESCRIPTION
## Summary
- `DiagnosticContext.tsx`: wrap `setResult` / `clearResult` in `useCallback([])`; wrap `value` in `useMemo` keyed on `[result, isLoading, setResult, clearResult]`.
- `EngagementContext.tsx`: wrap `contextValue` in `useMemo` with the full 10-key dep array (5 state + 5 already-memoized handlers).
- `EngagementContext.tsx`: inline rationale block above the URL-sync `useEffect` documenting why `searchParams` / `selectEngagement` / `activeEngagement` are deliberately excluded from deps (loop avoidance + one-shot guard via `!activeEngagement`).

Both providers were rebuilding fresh `value` object literals on every parent render, forcing every consumer to re-render regardless of whether carried state actually changed.

## Test plan
- [x] `cd frontend && npx tsc --noEmit` → exit 0
- [x] `cd frontend && npx jest --testPathPatterns="(Diagnostic|Engagement)"` → 52 passed, 0 failed (7 suites)
- [x] `cd frontend && npm run build` → exit 0; routes correctly dynamic (`ƒ`)

## Out of scope
- State/dispatch split (bigger refactor, not warranted at this size).
- Remaining render-perf findings — see Sprint 773 series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)