### PR TITLE
Sprint 771a: Button primitive — replace 20 button class-string copies

### DIFF
--- a/frontend/src/app/tools/ap-testing/page.tsx
+++ b/frontend/src/app/tools/ap-testing/page.tsx
@@ -5,6 +5,7 @@ import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { APScoreCard, APTestResultGrid, APDataQualityBadge, FlaggedPaymentTable } from '@/components/apTesting'
 import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, ToolSettingsDrawer, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractAPProof } from '@/components/shared/proof'
+import { Button } from '@/components/ui/Button'
 import { useAPTesting } from '@/hooks/useAPTesting'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
 import { useFileUpload } from '@/hooks/useFileUpload'
@@ -159,12 +160,9 @@ export default function APTestingPage() {
               >
                 <h3 className="font-serif text-sm text-theme-error-text mb-1">Analysis Failed</h3>
                 <p className="font-sans text-sm text-content-secondary">{error}</p>
-                <button
-                  onClick={handleNewTest}
-                  className="mt-3 px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors"
-                >
+                <Button variant="secondary" onClick={handleNewTest} className="mt-3">
                   Try Again
-                </button>
+                </Button>
               </div>
             )}
 
@@ -179,26 +177,23 @@ export default function APTestingPage() {
                 </p>
               </div>
               <div className="flex items-center gap-3">
-                <button
+                <Button
+                  variant="primary"
                   onClick={() => exportBody && handleExportMemo(exportBody)}
                   disabled={exporting !== null || !result}
-                  className="px-4 py-2 bg-sage-600 border border-sage-600 rounded-lg text-oatmeal-50 font-sans text-sm hover:bg-sage-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {exporting === 'pdf' ? 'Generating...' : 'Download Testing Memo'}
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant="secondary"
                   onClick={() => exportBody && handleExportCSV(exportBody)}
                   disabled={exporting !== null || !result}
-                  className="px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {exporting === 'csv' ? 'Exporting...' : 'Export Flagged CSV'}
-                </button>
-                <button
-                  onClick={handleNewTest}
-                  className="px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors"
-                >
+                </Button>
+                <Button variant="secondary" onClick={handleNewTest}>
                   New Test
-                </button>
+                </Button>
               </div>
             </div>
 

--- a/frontend/src/app/tools/fixed-assets/page.tsx
+++ b/frontend/src/app/tools/fixed-assets/page.tsx
@@ -5,6 +5,7 @@ import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { FixedAssetScoreCard, FixedAssetTestResultGrid, FixedAssetDataQualityBadge, FlaggedFixedAssetTable } from '@/components/fixedAssetTesting'
 import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractFAProof } from '@/components/shared/proof'
+import { Button } from '@/components/ui/Button'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
 import { useFileUpload } from '@/hooks/useFileUpload'
 import { useFixedAssetTesting } from '@/hooks/useFixedAssetTesting'
@@ -147,12 +148,9 @@ export default function FixedAssetTestingPage() {
               >
                 <h3 className="font-serif text-sm text-theme-error-text mb-1">Analysis Failed</h3>
                 <p className="font-sans text-sm text-content-secondary">{error}</p>
-                <button
-                  onClick={handleNewTest}
-                  className="mt-3 px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors"
-                >
+                <Button variant="secondary" onClick={handleNewTest} className="mt-3">
                   Try Again
-                </button>
+                </Button>
               </div>
             )}
 
@@ -167,26 +165,23 @@ export default function FixedAssetTestingPage() {
                     </p>
                   </div>
                   <div className="flex items-center gap-3">
-                    <button
+                    <Button
+                      variant="primary"
                       onClick={() => exportBody && handleExportMemo(exportBody)}
                       disabled={exporting !== null || !result}
-                      className="px-4 py-2 bg-sage-600 border border-sage-600 rounded-lg text-oatmeal-50 font-sans text-sm hover:bg-sage-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {exporting === 'pdf' ? 'Generating...' : 'Download Testing Memo'}
-                    </button>
-                    <button
+                    </Button>
+                    <Button
+                      variant="secondary"
                       onClick={() => exportBody && handleExportCSV(exportBody)}
                       disabled={exporting !== null || !result}
-                      className="px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {exporting === 'csv' ? 'Exporting...' : 'Export Flagged CSV'}
-                    </button>
-                    <button
-                      onClick={handleNewTest}
-                      className="px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors"
-                    >
+                    </Button>
+                    <Button variant="secondary" onClick={handleNewTest}>
                       New Test
-                    </button>
+                    </Button>
                   </div>
                 </div>
 

--- a/frontend/src/app/tools/inventory-testing/page.tsx
+++ b/frontend/src/app/tools/inventory-testing/page.tsx
@@ -5,6 +5,7 @@ import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { InventoryScoreCard, InventoryTestResultGrid, InventoryDataQualityBadge, FlaggedInventoryTable } from '@/components/inventoryTesting'
 import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractInventoryProof } from '@/components/shared/proof'
+import { Button } from '@/components/ui/Button'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
 import { useFileUpload } from '@/hooks/useFileUpload'
 import { useInventoryTesting } from '@/hooks/useInventoryTesting'
@@ -147,12 +148,9 @@ export default function InventoryTestingPage() {
               >
                 <h3 className="font-serif text-sm text-theme-error-text mb-1">Analysis Failed</h3>
                 <p className="font-sans text-sm text-content-secondary">{error}</p>
-                <button
-                  onClick={handleNewTest}
-                  className="mt-3 px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors"
-                >
+                <Button variant="secondary" onClick={handleNewTest} className="mt-3">
                   Try Again
-                </button>
+                </Button>
               </div>
             )}
 
@@ -167,26 +165,23 @@ export default function InventoryTestingPage() {
                     </p>
                   </div>
                   <div className="flex items-center gap-3">
-                    <button
+                    <Button
+                      variant="primary"
                       onClick={() => exportBody && handleExportMemo(exportBody)}
                       disabled={exporting !== null || !result}
-                      className="px-4 py-2 bg-sage-600 border border-sage-600 rounded-lg text-oatmeal-50 font-sans text-sm hover:bg-sage-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {exporting === 'pdf' ? 'Generating...' : 'Download Testing Memo'}
-                    </button>
-                    <button
+                    </Button>
+                    <Button
+                      variant="secondary"
                       onClick={() => exportBody && handleExportCSV(exportBody)}
                       disabled={exporting !== null || !result}
-                      className="px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {exporting === 'csv' ? 'Exporting...' : 'Export Flagged CSV'}
-                    </button>
-                    <button
-                      onClick={handleNewTest}
-                      className="px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors"
-                    >
+                    </Button>
+                    <Button variant="secondary" onClick={handleNewTest}>
                       New Test
-                    </button>
+                    </Button>
                   </div>
                 </div>
 

--- a/frontend/src/app/tools/payroll-testing/page.tsx
+++ b/frontend/src/app/tools/payroll-testing/page.tsx
@@ -5,6 +5,7 @@ import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { PayrollScoreCard, PayrollTestResultGrid, PayrollDataQualityBadge, FlaggedEmployeeTable } from '@/components/payrollTesting'
 import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, ToolSettingsDrawer, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractPayrollProof } from '@/components/shared/proof'
+import { Button } from '@/components/ui/Button'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
 import { useFileUpload } from '@/hooks/useFileUpload'
 import { usePayrollTesting } from '@/hooks/usePayrollTesting'
@@ -162,12 +163,9 @@ export default function PayrollTestingPage() {
               >
                 <h3 className="font-serif text-sm text-theme-error-text mb-1">Analysis Failed</h3>
                 <p className="font-sans text-sm text-content-secondary">{error}</p>
-                <button
-                  onClick={handleNewTest}
-                  className="mt-3 px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors"
-                >
+                <Button variant="secondary" onClick={handleNewTest} className="mt-3">
                   Try Again
-                </button>
+                </Button>
               </div>
             )}
 
@@ -182,26 +180,23 @@ export default function PayrollTestingPage() {
                     </p>
                   </div>
                   <div className="flex items-center gap-3">
-                    <button
+                    <Button
+                      variant="primary"
                       onClick={() => exportBody && handleExportMemo(exportBody)}
                       disabled={exporting !== null || !result}
-                      className="px-4 py-2 bg-sage-600 border border-sage-600 rounded-lg text-oatmeal-50 font-sans text-sm hover:bg-sage-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {exporting === 'pdf' ? 'Generating...' : 'Download Testing Memo'}
-                    </button>
-                    <button
+                    </Button>
+                    <Button
+                      variant="secondary"
                       onClick={() => exportBody && handleExportCSV(exportBody)}
                       disabled={exporting !== null || !result}
-                      className="px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {exporting === 'csv' ? 'Exporting...' : 'Export Flagged CSV'}
-                    </button>
-                    <button
-                      onClick={handleNewTest}
-                      className="px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors"
-                    >
+                    </Button>
+                    <Button variant="secondary" onClick={handleNewTest}>
                       New Test
-                    </button>
+                    </Button>
                   </div>
                 </div>
 

--- a/frontend/src/app/tools/revenue-testing/page.tsx
+++ b/frontend/src/app/tools/revenue-testing/page.tsx
@@ -5,6 +5,7 @@ import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { RevenueScoreCard, RevenueTestResultGrid, RevenueDataQualityBadge, FlaggedRevenueTable } from '@/components/revenueTesting'
 import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, UpgradeGate, Citation, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractRevenueProof } from '@/components/shared/proof'
+import { Button } from '@/components/ui/Button'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
 import { useFileUpload } from '@/hooks/useFileUpload'
 import { useRevenueTesting } from '@/hooks/useRevenueTesting'
@@ -184,12 +185,9 @@ export default function RevenueTestingPage() {
               >
                 <h3 className="font-serif text-sm text-theme-error-text mb-1">Analysis Failed</h3>
                 <p className="font-sans text-sm text-content-secondary">{error}</p>
-                <button
-                  onClick={handleNewTest}
-                  className="mt-3 px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors"
-                >
+                <Button variant="secondary" onClick={handleNewTest} className="mt-3">
                   Try Again
-                </button>
+                </Button>
               </div>
             )}
 
@@ -204,26 +202,23 @@ export default function RevenueTestingPage() {
                     </p>
                   </div>
                   <div className="flex items-center gap-3">
-                    <button
+                    <Button
+                      variant="primary"
                       onClick={() => exportBody && handleExportMemo(exportBody)}
                       disabled={exporting !== null || !result}
-                      className="px-4 py-2 bg-sage-600 border border-sage-600 rounded-lg text-oatmeal-50 font-sans text-sm hover:bg-sage-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {exporting === 'pdf' ? 'Generating...' : 'Download Testing Memo'}
-                    </button>
-                    <button
+                    </Button>
+                    <Button
+                      variant="secondary"
                       onClick={() => exportBody && handleExportCSV(exportBody)}
                       disabled={exporting !== null || !result}
-                      className="px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {exporting === 'csv' ? 'Exporting...' : 'Export Flagged CSV'}
-                    </button>
-                    <button
-                      onClick={handleNewTest}
-                      className="px-4 py-2 bg-surface-card border border-oatmeal-300 rounded-lg text-content-primary font-sans text-sm hover:bg-surface-card-secondary transition-colors"
-                    >
+                    </Button>
+                    <Button variant="secondary" onClick={handleNewTest}>
                       New Test
-                    </button>
+                    </Button>
                   </div>
                 </div>
 

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react'
+
+/**
+ * Button — shared primary/secondary/ghost button primitive.
+ *
+ * Sprint 771a: Extracted from the ~30 hand-rolled `bg-sage-600 …` and
+ * `bg-surface-card border border-oatmeal-300 …` class-string copies
+ * across tool pages. Brand-token migrations (Oat & Obsidian) and
+ * disabled-state changes now happen in one place.
+ *
+ * Primary  → sage-600 fill, oatmeal-50 text. Use for the page's main
+ *            commit-the-action button (Run, Export, Generate).
+ * Secondary→ surface-card fill, oatmeal-300 border. Use for tertiary
+ *            actions sitting alongside primary (Cancel, New Test).
+ * Ghost    → transparent fill, oatmeal-300 border, hover lights up.
+ *            Use for inline toolbar actions where primary fill would
+ *            be visual noise.
+ *
+ * Sizes:
+ *   sm → text-xs, px-3 py-1.5
+ *   md → text-sm, px-4 py-2  (default)
+ *   lg → text-sm, px-8 py-3, rounded-xl  (hero CTA, e.g. "Run AR Aging")
+ */
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost'
+type ButtonSize = 'sm' | 'md' | 'lg'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  children: ReactNode
+}
+
+const VARIANT_CLASSES: Record<ButtonVariant, string> = {
+  primary:
+    'bg-sage-600 border border-sage-600 text-oatmeal-50 hover:bg-sage-700',
+  secondary:
+    'bg-surface-card border border-oatmeal-300 text-content-primary hover:bg-surface-card-secondary',
+  ghost:
+    'bg-transparent border border-oatmeal-300 text-content-primary hover:bg-surface-card-secondary',
+}
+
+const SIZE_CLASSES: Record<ButtonSize, string> = {
+  sm: 'px-3 py-1.5 text-xs rounded-lg',
+  md: 'px-4 py-2 text-sm rounded-lg',
+  lg: 'px-8 py-3 text-sm rounded-xl',
+}
+
+const BASE =
+  'font-sans transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-hidden focus:ring-2 focus:ring-sage-500 focus:ring-offset-2'
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = 'primary', size = 'md', className, children, ...rest },
+  ref,
+) {
+  const classes = [BASE, VARIANT_CLASSES[variant], SIZE_CLASSES[size], className]
+    .filter(Boolean)
+    .join(' ')
+  return (
+    <button ref={ref} className={classes} {...rest}>
+      {children}
+    </button>
+  )
+})

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -266,3 +266,39 @@ Bundle the 19 patch + safe-minor updates into one commit, mirroring the 2026-04-
 
 ---
 
+### Sprint 771a: Button primitive (subset of Sprint 771)
+**Status:** COMPLETE — landed on branch `sprint-771a-button-primitive`.
+**Priority:** P3.
+**Source:** Frontend efficiency audit (2026-05-01) finding 2.2.
+
+Splitting Sprint 771 into 771a (Button primitive — this sprint) and 771b (the three Tool* primitives — `ToolHeroHeader` / `ToolLoadingState` / `ToolErrorState`, deferred to a follow-up). 771a is the lowest-risk, highest-leverage subset: ~30 hand-rolled `bg-sage-600 …` and `bg-surface-card border border-oatmeal-300 …` button class-string copies are the most common offender, and a centralized primitive removes that drift point ahead of the hero/loading/error rollup.
+
+**What landed:**
+- `frontend/src/components/ui/Button.tsx` (new, ~60 lines) — `forwardRef` button with `variant: 'primary' | 'secondary' | 'ghost'` and `size: 'sm' | 'md' | 'lg'`. Single base class string covers font, transition, disabled state, focus ring; variant/size class maps compose on top. Inline doc-comment explains each variant's intended use (primary = page-commit action, secondary = tertiary alongside primary, ghost = inline toolbar).
+- 5 tool pages migrated from inline class strings to `<Button>`:
+  - `app/tools/ap-testing/page.tsx`
+  - `app/tools/fixed-assets/page.tsx`
+  - `app/tools/inventory-testing/page.tsx`
+  - `app/tools/payroll-testing/page.tsx`
+  - `app/tools/revenue-testing/page.tsx`
+- Each of the 5 pages had the same 4-button shape: 1 secondary "Try Again" in the error state + 3 buttons in the success-state action bar (primary "Download Testing Memo", secondary "Export Flagged CSV", secondary "New Test"). 20 total buttons replaced.
+
+**What did NOT change (deferred):**
+- AR aging (`px-8 py-3 rounded-xl` "Run AR Aging Analysis" hero CTA) — different size variant; needs `size="lg"` migration in 771b alongside the dual-FileDropZone landing of Sprint 770.
+- Statistical sampling — its primary button differs slightly (no `disabled:opacity-50` suffix); migrate alongside 771b.
+- `account-risk-heatmap`, `composite-risk` — buttons embedded in row-editor mini-components flagged for `React.memo` extraction in Sprint 773 follow-up; migrate when those subtrees are touched.
+- `ToolSettingsDrawer` — full-width primary button; migrate alongside 771b.
+- The other Sprint 771 primitives (ToolHeroHeader, ToolLoadingState, ToolErrorState) — deferred to 771b.
+
+**Verification:**
+- `cd frontend && npx tsc --noEmit` → exit 0.
+- `cd frontend && npx jest --watch=false` → see commit-message tail.
+- `cd frontend && npm run build` → see commit-message tail.
+
+**Out of scope:**
+- ESLint rule banning the inline class strings the new primitive replaces — useful future fence, not this sprint.
+
+**Commit SHA:** see branch `sprint-771a-button-primitive` (filled at PR merge).
+
+---
+


### PR DESCRIPTION
## Summary
- `frontend/src/components/ui/Button.tsx` (new): `forwardRef` button with `variant: 'primary' | 'secondary' | 'ghost'` and `size: 'sm' | 'md' | 'lg'`. Single base class string (font, transition, disabled, focus ring); variant + size class maps compose on top.
- Migrated **5 tool pages**, identical 4-button shape each (1 secondary "Try Again" in error state + primary memo / secondary CSV / secondary new-test in success-state action bar) — **20 buttons replaced**: `ap-testing`, `fixed-assets`, `inventory-testing`, `payroll-testing`, `revenue-testing`.

Splits Sprint 771 into 771a (Button primitive — this PR) and 771b (deferred `ToolHeroHeader` / `ToolLoadingState` / `ToolErrorState` rollup). 771a is the highest-leverage subset: ~30 hand-rolled `bg-sage-600 …` and `bg-surface-card border border-oatmeal-300 …` button class-string copies were the most common drift point. Centralizing them now de-risks 771b.

## Test plan
- [x] `cd frontend && npx tsc --noEmit` → exit 0
- [x] `cd frontend && npx jest --watch=false` → 207 suites, 2,013 tests pass
- [x] `cd frontend && npm run build` → exit 0; routes correctly dynamic (`ƒ`)

## Out of scope (deferred)
- AR aging "Run AR Aging Analysis" hero CTA (`px-8 py-3 rounded-xl`) — needs `size="lg"` migration alongside Sprint 770 dual-FileDropZone work.
- Statistical sampling primary button (slightly different disabled suffix) — bundle with 771b.
- Buttons inside `account-risk-heatmap` / `composite-risk` row editors — flagged for `React.memo` extraction in Sprint 773 follow-up.
- `ToolSettingsDrawer` full-width primary — bundle with 771b.
- `ToolHeroHeader` / `ToolLoadingState` / `ToolErrorState` primitives — Sprint 771b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)