### PR TITLE
Sprint 772a: lazy-load Recharts (BenfordChart) + GlobalCommandPalette

### DIFF
--- a/frontend/src/__tests__/JournalEntryTestingPage.test.tsx
+++ b/frontend/src/__tests__/JournalEntryTestingPage.test.tsx
@@ -36,6 +36,13 @@ jest.mock('@/components/jeTesting', () => ({
   SamplingPanel: () => <div data-testid="sampling-panel">Sampling</div>,
 }))
 
+// Sprint 772a: page.tsx now imports BenfordChart via next/dynamic from
+// the direct path, bypassing the barrel mock above. Re-mock the direct
+// path so the chart still renders as a stub under jsdom.
+jest.mock('@/components/jeTesting/BenfordChart', () => ({
+  BenfordChart: () => <div data-testid="benford-chart">Benford</div>,
+}))
+
 jest.mock('@/hooks/useCanvasAccentSync', () => ({ useCanvasAccentSync: jest.fn() }))
 jest.mock('@/components/shared/proof', () => ({
   ProofSummaryBar: () => <div data-testid="proof-summary-bar">Proof</div>,

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,14 +1,25 @@
 'use client'
 
 import type { ReactElement } from 'react'
+import dynamic from 'next/dynamic'
 import { MotionConfig } from 'framer-motion'
 import { AuthProvider } from '@/contexts/AuthContext'
 import { CommandPaletteProvider } from '@/contexts/CommandPaletteContext'
 import { ToastProvider } from '@/contexts/ToastContext'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
-import { GlobalCommandPalette, ToastContainer } from '@/components/shared'
+import { ToastContainer } from '@/components/shared'
 import { ImpersonationBanner } from '@/components/shared/ImpersonationBanner'
 import { ThemeProvider } from '@/components/ThemeProvider'
+
+// Sprint 772a: GlobalCommandPalette mounts on every route but only
+// renders when isOpen + isAuthenticated. The Cmd+K listener lives in
+// CommandPaletteContext (eagerly mounted) so the palette UI itself can
+// be split into a separate chunk — loaded async on every page, not
+// blocking first paint of marketing/auth/error routes.
+const GlobalCommandPalette = dynamic(
+  () => import('@/components/shared/CommandPalette/GlobalCommandPalette').then(m => ({ default: m.GlobalCommandPalette })),
+  { ssr: false },
+)
 
 /**
  * Providers — Client-side provider chain for Next.js App Router.

--- a/frontend/src/app/tools/journal-entry-testing/page.tsx
+++ b/frontend/src/app/tools/journal-entry-testing/page.tsx
@@ -1,15 +1,25 @@
 'use client'
 
 import { useState, useCallback } from 'react'
+import dynamic from 'next/dynamic'
 import { useAuthSession } from '@/contexts/AuthSessionContext'
-import { JEScoreCard, TestResultGrid, GLDataQualityBadge, BenfordChart, FlaggedEntryTable, SamplingPanel } from '@/components/jeTesting'
+import { JEScoreCard, TestResultGrid, GLDataQualityBadge, FlaggedEntryTable, SamplingPanel } from '@/components/jeTesting'
 import { GuestCTA, UnverifiedCTA, ZeroStorageNotice, DisclaimerBox, ToolStatePresence, ToolSettingsDrawer, Citation, CitationFooter } from '@/components/shared'
 import { ProofSummaryBar, ProofPanel, extractJEProof } from '@/components/shared/proof'
+import { ChartSkeleton } from '@/components/shared/skeletons'
 import { useCanvasAccentSync } from '@/hooks/useCanvasAccentSync'
 import { useFileUpload } from '@/hooks/useFileUpload'
 import { useJETesting } from '@/hooks/useJETesting'
 import { useTestingExport } from '@/hooks/useTestingExport'
 import { isAcceptedFileType, ACCEPTED_FILE_EXTENSIONS_STRING } from '@/utils/fileFormats'
+
+// Sprint 772a: BenfordChart pulls recharts (~90 kB gzipped). Defer until
+// the success branch actually renders it so first-load JS for the upload
+// flow stays light.
+const BenfordChart = dynamic(
+  () => import('@/components/jeTesting/BenfordChart').then(m => ({ default: m.BenfordChart })),
+  { ssr: false, loading: () => <ChartSkeleton /> },
+)
 
 /**
  * Journal Entry Testing — Full Tool (Sprint 66)

--- a/frontend/src/components/shared/skeletons/ChartSkeleton.tsx
+++ b/frontend/src/components/shared/skeletons/ChartSkeleton.tsx
@@ -1,0 +1,24 @@
+/**
+ * ChartSkeleton — fallback placeholder for lazy-loaded chart components.
+ *
+ * Sprint 772a: shows while next/dynamic resolves recharts (~90 kB gzipped).
+ * The default 200px height matches BenfordChart and TrendSparkline render
+ * footprints closely enough that there's no visible layout shift when the
+ * real component swaps in.
+ */
+
+interface ChartSkeletonProps {
+  /** Tailwind height class (default: 'h-[200px]') */
+  heightClass?: string
+}
+
+export function ChartSkeleton({ heightClass = 'h-[200px]' }: ChartSkeletonProps) {
+  return (
+    <div
+      className={`animate-pulse bg-surface-card border border-oatmeal-300/30 rounded-xl ${heightClass} relative overflow-hidden`}
+      aria-hidden="true"
+    >
+      <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-oatmeal-50/10 to-transparent" style={{ animation: 'shimmer 1.5s infinite' }} />
+    </div>
+  )
+}

--- a/frontend/src/components/shared/skeletons/index.ts
+++ b/frontend/src/components/shared/skeletons/index.ts
@@ -6,6 +6,7 @@
 
 export { SkeletonPage } from './SkeletonPage'
 export { CardGridSkeleton } from './CardGridSkeleton'
+export { ChartSkeleton } from './ChartSkeleton'
 export { FormSkeleton } from './FormSkeleton'
 export { ListSkeleton } from './ListSkeleton'
 export { UploadZoneSkeleton } from './UploadZoneSkeleton'

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -266,3 +266,31 @@ Bundle the 19 patch + safe-minor updates into one commit, mirroring the 2026-04-
 
 ---
 
+### Sprint 772a: Lazy-load Recharts + GlobalCommandPalette
+**Status:** COMPLETE — landed on branch `sprint-772a-lazy-recharts-cmdk`.
+**Priority:** P2.
+**Source:** Frontend efficiency audit (2026-05-01) findings 3.1 + 3.2.
+
+Splits Sprint 772 into 772a (this commit — Recharts + CommandPalette lazy-loads) and 772b (LazyMotion evaluation, deferred to a follow-up so the framer-motion footprint can be measured against this baseline). Audit's claim that `TrendSparkline` was eagerly loaded by dashboard/multi-period turned out to be stale (`grep` confirmed zero page-level consumers of `TrendSparkline` / `TrendSummaryCard` / `TrendSection` outside of test files); `BenfordChart` is the only real recharts entry point.
+
+**What landed:**
+- `frontend/src/components/shared/skeletons/ChartSkeleton.tsx` (new) — lightweight 200px shimmer placeholder; matches BenfordChart's render footprint closely enough that there's no visible layout shift on swap-in. Re-exported from `skeletons/index.ts`.
+- `app/tools/journal-entry-testing/page.tsx` — `BenfordChart` removed from the eager barrel import; replaced with `next/dynamic({ ssr: false, loading: () => <ChartSkeleton /> })` against the direct `@/components/jeTesting/BenfordChart` path. The chart only loads its recharts chunk when the success branch actually renders it.
+- `app/providers.tsx` — `GlobalCommandPalette` removed from the eager barrel import; replaced with `next/dynamic({ ssr: false })` against the direct path. The Cmd+K listener already lives in `CommandPaletteContext` (verified at `CommandPaletteContext.tsx:107`) so the eager event-handler registration is preserved while the palette UI itself code-splits.
+- `__tests__/JournalEntryTestingPage.test.tsx` — added `jest.mock('@/components/jeTesting/BenfordChart', …)` direct-path stub to mirror the barrel mock. Without it, the dynamic import bypasses the barrel mock under jsdom and renders the real component, which crashes on `benford.total_count.toLocaleString()` against the test fixture.
+
+**Verification:**
+- `cd frontend && npx tsc --noEmit` → exit 0.
+- `cd frontend && npx jest --watch=false --testPathPatterns="JournalEntryTesting"` → **8 passed, 0 failed**.
+- `cd frontend && npx jest --watch=false` (full suite) → see commit-message tail.
+- `cd frontend && npm run build` → see commit-message tail.
+
+**Out of scope / deferred:**
+- LazyMotion evaluation (audit 3.3) — deferred to 772b; needs `next build --analyze` baseline against this lazy-load baseline to measure actual bundle delta.
+- Hoisting CommandPalette mount to be conditional on `isOpen` — would save the chunk fetch entirely for users who never press Cmd+K, but adds complexity and the dynamic-import path already keeps the chunk off the main bundle.
+- Removing the `GlobalCommandPalette` re-export from `components/shared/index.ts` — currently unused-via-barrel after this change, but removing the re-export risks breaking unrelated consumers we haven't enumerated.
+
+**Commit SHA:** see branch `sprint-772a-lazy-recharts-cmdk` (filled at PR merge).
+
+---
+


### PR DESCRIPTION
## Summary
- `components/shared/skeletons/ChartSkeleton.tsx` (new): lightweight shimmer placeholder; re-exported from `skeletons/index.ts`.
- `app/tools/journal-entry-testing/page.tsx`: `BenfordChart` now loaded via `next/dynamic` with `ssr: false` + `ChartSkeleton` fallback. Recharts (~90 kB gzipped) only loads when the success branch renders.
- `app/providers.tsx`: `GlobalCommandPalette` loaded via `next/dynamic`. The Cmd+K listener already lives in `CommandPaletteContext` (line 107), so the listener registers eagerly while the palette UI itself code-splits.
- `__tests__/JournalEntryTestingPage.test.tsx`: added direct-path mock for `@/components/jeTesting/BenfordChart` — the barrel mock no longer covers the dynamic import path.

Splits Sprint 772 into 772a (this PR — Recharts + CommandPalette lazy-loads) and 772b (`LazyMotion` evaluation, deferred). The audit's claim that `TrendSparkline` was eagerly loaded was stale — grep confirmed zero page-level consumers outside test files; `BenfordChart` is the only real recharts entry point.

## Test plan
- [x] `cd frontend && npx tsc --noEmit` → exit 0
- [x] `cd frontend && npx jest --watch=false` → 207 suites, 2,013 tests pass
- [x] `cd frontend && npm run build` → exit 0; routes correctly dynamic (`ƒ`)

## Out of scope
- `LazyMotion` evaluation for framer-motion bundle — Sprint 772b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)