### PR TITLE
Sprint 773: type-collision disambiguation + DISTANCE map removal

### DIFF
--- a/frontend/src/__tests__/motionTokens.test.ts
+++ b/frontend/src/__tests__/motionTokens.test.ts
@@ -7,7 +7,6 @@
 import {
   TIMING,
   EASE,
-  DISTANCE,
   STATE_CROSSFADE,
   RESOLVE_ENTER,
   EMPHASIS_SETTLE,
@@ -80,15 +79,6 @@ describe('EASE', () => {
         ],
       }
     `)
-  })
-})
-
-describe('DISTANCE', () => {
-  it('has inlined distance values', () => {
-    expect(DISTANCE.subtle).toBe(12)
-    expect(DISTANCE.standard).toBe(24)
-    expect(DISTANCE.dramatic).toBe(40)
-    expect(DISTANCE.state).toBe(8)
   })
 })
 

--- a/frontend/src/app/(diagnostic)/flux/page.tsx
+++ b/frontend/src/app/(diagnostic)/flux/page.tsx
@@ -7,7 +7,7 @@ import { useDiagnostic } from '@/contexts/DiagnosticContext';
 import { GuestCTA } from '@/components/shared';
 import type { FluxItem, FluxSummary, ReconScore, ReconStats } from '@/types/diagnostic';
 import { ACCEPTED_FILE_EXTENSIONS_STRING } from '@/utils/fileFormats';
-import { getRiskLevelClasses, type RiskLevel } from '@/utils/themeUtils';
+import { getRiskLevelClasses, type ThresholdRiskLevel } from '@/utils/themeUtils';
 import { formatCurrency, downloadBlob, apiDownload, apiPost } from '@/utils';
 
 /** Browser-only expectation state for ISA 520 documentation */
@@ -280,7 +280,7 @@ export default function FluxPage() {
                                             </td>
                                             <td className="p-4 text-right font-mono">{item.display_percent}</td>
                                             <td className="p-4 text-center">
-                                                <RiskBadge level={item.risk_level as RiskLevel} />
+                                                <RiskBadge level={item.risk_level as ThresholdRiskLevel} />
                                             </td>
                                             <td className="p-4 text-content-tertiary text-xs">
                                                 {item.variance_indicators.join(", ")}
@@ -328,7 +328,7 @@ export default function FluxPage() {
                                                     <div key={item.account} className="px-6 py-4">
                                                         <div className="flex items-center gap-2 mb-2">
                                                             <span className="font-sans text-sm font-medium text-content-primary">{item.account}</span>
-                                                            <RiskBadge level={item.risk_level as RiskLevel} />
+                                                            <RiskBadge level={item.risk_level as ThresholdRiskLevel} />
                                                             <span className="font-mono text-xs text-content-tertiary">
                                                                 {formatCurrency(item.delta_amount, true)} ({item.display_percent})
                                                             </span>
@@ -400,7 +400,7 @@ function SummaryCard({ label, value, variant = "default" }: { label: string, val
     );
 }
 
-function RiskBadge({ level }: { level: RiskLevel }) {
+function RiskBadge({ level }: { level: ThresholdRiskLevel }) {
     const classes = getRiskLevelClasses(level);
     return (
         <span className={`px-2 py-1 rounded-sm text-xs font-sans font-medium border ${classes}`}>

--- a/frontend/src/app/(diagnostic)/recon/page.tsx
+++ b/frontend/src/app/(diagnostic)/recon/page.tsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion';
 import { useAuthSession } from '@/contexts/AuthSessionContext';
 import { useDiagnostic } from '@/contexts/DiagnosticContext';
 import { GuestCTA , DisclaimerBox, CitationFooter } from '@/components/shared';
-import { getRiskLevelClasses, type RiskLevel } from '@/utils/themeUtils';
+import { getRiskLevelClasses, type ThresholdRiskLevel } from '@/utils/themeUtils';
 
 export default function ReconPage() {
     const { isAuthenticated } = useAuthSession();
@@ -89,7 +89,7 @@ export default function ReconPage() {
                                     <td className="p-4 font-medium text-content-primary">{item.account}</td>
                                     <td className="p-4 text-center font-mono font-bold text-content-primary">{item.score}</td>
                                     <td className="p-4 text-center">
-                                        <RiskBadge level={item.band as RiskLevel} />
+                                        <RiskBadge level={item.band as ThresholdRiskLevel} />
                                     </td>
                                     <td className="p-4">
                                         <div className="flex flex-wrap gap-2">
@@ -121,7 +121,7 @@ export default function ReconPage() {
     );
 }
 
-function RiskBadge({ level }: { level: RiskLevel }) {
+function RiskBadge({ level }: { level: ThresholdRiskLevel }) {
     const classes = getRiskLevelClasses(level);
     return (
         <span className={`px-2 py-1 rounded-sm text-xs font-sans font-medium border ${classes}`}>

--- a/frontend/src/app/tools/account-risk-heatmap/page.tsx
+++ b/frontend/src/app/tools/account-risk-heatmap/page.tsx
@@ -23,7 +23,7 @@ import {
   type HeatmapRequest,
   type PriorityTier,
   type RawSignalInput,
-  type Severity,
+  type HeatmapSeverity,
 } from '@/types/accountRiskHeatmap'
 
 const EMPTY_SIGNAL = (): RawSignalInput => ({
@@ -36,7 +36,7 @@ const EMPTY_SIGNAL = (): RawSignalInput => ({
   confidence: 1.0,
 })
 
-const SEVERITIES: Severity[] = ['high', 'medium', 'low']
+const SEVERITIES: HeatmapSeverity[] = ['high', 'medium', 'low']
 
 export default function AccountRiskHeatmapPage() {
   const { user, isAuthenticated, isLoading: authLoading } = useAuthSession()
@@ -229,8 +229,8 @@ export default function AccountRiskHeatmapPage() {
                           </td>
                           <td className="py-2 pr-3">
                             <select
-                              value={s.severity as Severity}
-                              onChange={e => updateSignal(idx, 'severity', e.target.value as Severity)}
+                              value={s.severity as HeatmapSeverity}
+                              onChange={e => updateSignal(idx, 'severity', e.target.value as HeatmapSeverity)}
                               className="px-2 py-1.5 rounded-md bg-surface-input border border-theme text-content-primary font-sans text-sm focus:outline-hidden focus:ring-2 focus:ring-sage-500"
                               aria-label={`Severity signal ${idx + 1}`}
                             >

--- a/frontend/src/app/tools/composite-risk/page.tsx
+++ b/frontend/src/app/tools/composite-risk/page.tsx
@@ -25,7 +25,7 @@ import {
   RISK_LEVEL_LABELS,
   type AccountRiskAssessmentInput,
   type Assertion,
-  type RiskLevel,
+  type CompositeRiskLevel,
 } from '@/types/compositeRisk'
 
 const EMPTY_ROW = (): AccountRiskAssessmentInput => ({
@@ -187,7 +187,7 @@ export default function CompositeRiskPage() {
                           <td className="py-2 pr-3">
                             <select
                               value={row.inherent_risk}
-                              onChange={e => updateRow(idx, 'inherent_risk', e.target.value as RiskLevel)}
+                              onChange={e => updateRow(idx, 'inherent_risk', e.target.value as CompositeRiskLevel)}
                               className="w-full px-2 py-1.5 rounded-md bg-surface-input border border-theme text-content-primary font-sans text-sm focus:outline-hidden focus:ring-2 focus:ring-sage-500"
                               aria-label={`Inherent risk row ${idx + 1}`}
                             >
@@ -201,7 +201,7 @@ export default function CompositeRiskPage() {
                           <td className="py-2 pr-3">
                             <select
                               value={row.control_risk}
-                              onChange={e => updateRow(idx, 'control_risk', e.target.value as RiskLevel)}
+                              onChange={e => updateRow(idx, 'control_risk', e.target.value as CompositeRiskLevel)}
                               className="w-full px-2 py-1.5 rounded-md bg-surface-input border border-theme text-content-primary font-sans text-sm focus:outline-hidden focus:ring-2 focus:ring-sage-500"
                               aria-label={`Control risk row ${idx + 1}`}
                             >
@@ -361,9 +361,9 @@ function CompositeRiskResults({ data }: { data: import('@/types/compositeRisk').
             Composite Risk Profile
           </h2>
           <span
-            className={`inline-flex items-center px-3 py-1 rounded-full border text-xs font-sans font-semibold uppercase tracking-wider ${RISK_BADGE_STYLES[overall as RiskLevel]}`}
+            className={`inline-flex items-center px-3 py-1 rounded-full border text-xs font-sans font-semibold uppercase tracking-wider ${RISK_BADGE_STYLES[overall as CompositeRiskLevel]}`}
           >
-            Overall Tier: {RISK_LEVEL_LABELS[overall as RiskLevel]}
+            Overall Tier: {RISK_LEVEL_LABELS[overall as CompositeRiskLevel]}
           </span>
         </div>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
@@ -449,7 +449,7 @@ function CompositeRiskResults({ data }: { data: import('@/types/compositeRisk').
   )
 }
 
-function RiskPill({ level }: { level: RiskLevel }) {
+function RiskPill({ level }: { level: CompositeRiskLevel }) {
   return (
     <span
       className={`inline-flex items-center px-2 py-0.5 rounded-md border text-xs font-sans font-medium ${RISK_BADGE_STYLES[level]}`}

--- a/frontend/src/types/accountRiskHeatmap.ts
+++ b/frontend/src/types/accountRiskHeatmap.ts
@@ -6,7 +6,15 @@
  */
 
 export type PriorityTier = 'high' | 'moderate' | 'low'
-export type Severity = 'high' | 'medium' | 'low'
+
+/**
+ * 3-value severity scale used by the Account Risk Heatmap aggregator.
+ *
+ * Distinct from the canonical 4-value `Severity` in `types/shared.ts`
+ * (which adds `'critical'`); the heatmap input is stricter because the
+ * backend aggregator only emits 3 buckets.
+ */
+export type HeatmapSeverity = 'high' | 'medium' | 'low'
 
 export const PRIORITY_TIER_STYLES: Record<PriorityTier, string> = {
   high: 'bg-clay-100 text-clay-800 border-clay-300',
@@ -24,7 +32,7 @@ export interface RawSignalInput {
   account_number?: string
   account_name: string
   source: string
-  severity?: Severity | string
+  severity?: HeatmapSeverity | string
   issue: string
   materiality?: string
   confidence?: number

--- a/frontend/src/types/compositeRisk.ts
+++ b/frontend/src/types/compositeRisk.ts
@@ -7,7 +7,13 @@
  * data (TB anomaly score, tool scores, going concern indicators).
  */
 
-export type RiskLevel = 'low' | 'moderate' | 'elevated' | 'high'
+/**
+ * Composite (RMM-matrix) risk level used by the ISA 315 risk-scoring tool.
+ * Distinct from `ThresholdRiskLevel` (`utils/themeUtils.ts` — 4-value with
+ * `'none'`, used by per-row diagnostic visualizations) and from `RiskLevel`
+ * (`types/diagnostic.ts` enum — streaming-auditor finding tier).
+ */
+export type CompositeRiskLevel = 'low' | 'moderate' | 'elevated' | 'high'
 
 export type Assertion =
   | 'existence'
@@ -16,7 +22,7 @@ export type Assertion =
   | 'rights'
   | 'presentation'
 
-export const RISK_LEVELS: RiskLevel[] = ['low', 'moderate', 'elevated', 'high']
+export const RISK_LEVELS: CompositeRiskLevel[] = ['low', 'moderate', 'elevated', 'high']
 export const ASSERTIONS: Assertion[] = [
   'existence',
   'completeness',
@@ -25,7 +31,7 @@ export const ASSERTIONS: Assertion[] = [
   'presentation',
 ]
 
-export const RISK_LEVEL_LABELS: Record<RiskLevel, string> = {
+export const RISK_LEVEL_LABELS: Record<CompositeRiskLevel, string> = {
   low: 'Low',
   moderate: 'Moderate',
   elevated: 'Elevated',
@@ -40,7 +46,7 @@ export const ASSERTION_LABELS: Record<Assertion, string> = {
   presentation: 'Presentation',
 }
 
-export const RISK_BADGE_STYLES: Record<RiskLevel, string> = {
+export const RISK_BADGE_STYLES: Record<CompositeRiskLevel, string> = {
   low: 'bg-sage-50 text-sage-700 border-sage-200',
   moderate: 'bg-oatmeal-100 text-obsidian-700 border-oatmeal-300',
   elevated: 'bg-clay-50 text-clay-700 border-clay-200',
@@ -50,8 +56,8 @@ export const RISK_BADGE_STYLES: Record<RiskLevel, string> = {
 export interface AccountRiskAssessmentInput {
   account_name: string
   assertion: Assertion
-  inherent_risk: RiskLevel
-  control_risk: RiskLevel
+  inherent_risk: CompositeRiskLevel
+  control_risk: CompositeRiskLevel
   fraud_risk_factor: boolean
   auditor_notes: string
 }
@@ -67,9 +73,9 @@ export interface CompositeRiskProfileRequest {
 export interface AccountRiskAssessmentResponse {
   account_name: string
   assertion: Assertion
-  inherent_risk: RiskLevel
-  control_risk: RiskLevel
-  combined_risk: RiskLevel
+  inherent_risk: CompositeRiskLevel
+  control_risk: CompositeRiskLevel
+  combined_risk: CompositeRiskLevel
   fraud_risk_factor: boolean
   auditor_notes?: string | null
 }
@@ -83,7 +89,7 @@ export interface CompositeRiskProfileResponse {
   high_risk_accounts: number
   fraud_risk_accounts: number
   total_assessments: number
-  risk_distribution: Record<RiskLevel, number>
-  overall_risk_tier?: RiskLevel | null
+  risk_distribution: Record<CompositeRiskLevel, number>
+  overall_risk_tier?: CompositeRiskLevel | null
   disclaimer: string
 }

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -86,7 +86,7 @@ export type {
   VarianceDirection,
   InputState,
   BadgeVariant,
-  RiskLevel,
+  ThresholdRiskLevel,
 } from './themeUtils';
 
 // Marketing motion presets (Sprint 337)

--- a/frontend/src/utils/motionTokens.ts
+++ b/frontend/src/utils/motionTokens.ts
@@ -53,22 +53,6 @@ export const EASE = {
 } as const
 
 // =============================================================================
-// DISTANCE — extends OFFSET with state-transition shifts
-// =============================================================================
-
-/** @deprecated Entrance distances now use lift from '@/lib/motion'. Internal tool-state usage within this file is expected */
-export const DISTANCE = {
-  /** Labels, badges, lightweight items */
-  subtle: 12,
-  /** Section headers, cards, default entrance */
-  standard: 24,
-  /** Hero features, timeline steps */
-  dramatic: 40,
-  /** Crossfade Y-offset between tool upload states */
-  state: 8,
-} as const
-
-// =============================================================================
 // STATE_CROSSFADE — Variants for UploadStatus transitions
 // =============================================================================
 
@@ -80,7 +64,7 @@ export const DISTANCE = {
 export const STATE_CROSSFADE = {
   initial: {
     opacity: 0,
-    y: DISTANCE.state,
+    y: 8,
   },
   animate: {
     opacity: 1,
@@ -92,7 +76,7 @@ export const STATE_CROSSFADE = {
   },
   exit: {
     opacity: 0,
-    y: -DISTANCE.state,
+    y: -8,
     transition: {
       duration: TIMING.fast,
       ease: EASE.exit,

--- a/frontend/src/utils/themeUtils.ts
+++ b/frontend/src/utils/themeUtils.ts
@@ -183,12 +183,22 @@ export function getBadgeClasses(variant: BadgeVariant): string {
 // RISK LEVEL CLASSES
 // =============================================================================
 
-export type RiskLevel = 'high' | 'medium' | 'low' | 'none';
+/**
+ * Threshold-style risk level used by per-row diagnostic visualizations
+ * (flux, recon) where signals collapse into a 3-level present/absent
+ * scale plus the explicit `none`.
+ *
+ * Distinct from `CompositeRiskLevel` (`types/compositeRisk.ts` —
+ * 'low' | 'moderate' | 'elevated' | 'high', the ISA 315 RMM matrix
+ * scale) and from `DiagnosticRiskLevel` (`types/diagnostic.ts` enum,
+ * the streaming-auditor finding tier).
+ */
+export type ThresholdRiskLevel = 'high' | 'medium' | 'low' | 'none';
 
 /**
  * Risk level badge classes.
  */
-export const RISK_LEVEL_CLASSES: Record<RiskLevel, string> = {
+export const RISK_LEVEL_CLASSES: Record<ThresholdRiskLevel, string> = {
   high: 'bg-clay-50 text-clay-700 border-clay-200',
   medium: 'bg-oatmeal-100 text-oatmeal-700 border-oatmeal-300',
   low: 'bg-sage-50 text-sage-700 border-sage-200',
@@ -198,7 +208,7 @@ export const RISK_LEVEL_CLASSES: Record<RiskLevel, string> = {
 /**
  * Get risk level badge classes.
  */
-export function getRiskLevelClasses(level: RiskLevel): string {
+export function getRiskLevelClasses(level: ThresholdRiskLevel): string {
   return RISK_LEVEL_CLASSES[level] || RISK_LEVEL_CLASSES.none;
 }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -266,3 +266,32 @@ Bundle the 19 patch + safe-minor updates into one commit, mirroring the 2026-04-
 
 ---
 
+### Sprint 773: Type disambiguation + dead-code (subset)
+**Status:** COMPLETE — landed on branch `sprint-773-type-disambig-dead-code-subset`.
+**Priority:** P3.
+**Source:** Frontend efficiency audit (2026-05-01) findings 1.3, 1.4, 1.8.
+
+Scoped down from the original Sprint 773 grab-bag to the three lowest-risk sub-items: type-collision disambiguation (`Severity`, `RiskLevel`) and one dead-code removal (`DISTANCE` map). Render-perf wraps and inline mini-component extraction deferred to a follow-up filing — the audit's findings 1.5/1.6/1.7/2.5/2.6 + 4.1 remain on the table.
+
+**What landed:**
+- `types/accountRiskHeatmap.ts` — `Severity` (3-value `'high' | 'medium' | 'low'`) renamed to `HeatmapSeverity` to remove the collision with the canonical 4-value `Severity` in `types/shared.ts`. Disambiguating doc-comment added explaining why the heatmap input is stricter (backend aggregator only emits 3 buckets).
+- `utils/themeUtils.ts` — `RiskLevel` (4-value `'high' | 'medium' | 'low' | 'none'`) renamed to `ThresholdRiskLevel`. Disambiguating doc-comment cross-references the other two `RiskLevel` definitions in the codebase.
+- `types/compositeRisk.ts` — `RiskLevel` (4-value `'low' | 'moderate' | 'elevated' | 'high'`) renamed to `CompositeRiskLevel`. Same disambiguating doc-comment pattern.
+- `utils/motionTokens.ts` — deprecated `DISTANCE` map deleted. `DISTANCE.state` was the only entry referenced (twice, both inside the file itself in `STATE_CROSSFADE`); inlined as the literal `8` at the call sites. The other entries (`subtle`, `standard`, `dramatic`) were already unused — entrance distances moved to `lib/motion`'s `lift` per the deprecation note. Companion test block in `__tests__/motionTokens.test.ts` removed.
+- Consumers updated: `app/(diagnostic)/recon/page.tsx`, `app/(diagnostic)/flux/page.tsx`, `app/tools/account-risk-heatmap/page.tsx`, `app/tools/composite-risk/page.tsx`, `utils/index.ts` (re-export rename).
+
+**What did NOT change (deferred):**
+- `contexts/DiagnosticContext.tsx:10` re-export of `RiskLevel` from `types/diagnostic.ts` (the third `RiskLevel` definition — an enum). Renaming the source enum would ripple across more consumers than this surgical sprint warrants — bundle with a future engagement-tooling cleanup if/when one arises.
+- `MechanicalGauge.tsx`'s local `RiskLevel` (file-scoped, no leak).
+- `useWorkspaceInsights.ts`'s local `RiskLevel` (hook-scoped, separate domain).
+- All Sprint 773 audit-finding render-perf wraps (`React.memo` for `MovementSummaryCards`, `BudgetSummaryCards`, `HeatmapResults`, `CompositeRiskResults`, row editors), motion-literal hoists, and inline mini-component extraction.
+
+**Verification:**
+- `cd frontend && npx tsc --noEmit` → exit 0.
+- `cd frontend && npx jest --watch=false` → see commit-message tail.
+- `cd frontend && npm run build` → see commit-message tail.
+
+**Commit SHA:** see branch `sprint-773-type-disambig-dead-code-subset` (filled at PR merge).
+
+---
+


### PR DESCRIPTION
## Summary
Scoped subset of the Sprint 773 grab-bag — three lowest-risk sub-items from the 2026-05-01 frontend efficiency audit (findings 1.3, 1.4, 1.8). Render-perf wraps and inline mini-component extraction (audit findings 1.5 / 1.6 / 1.7 / 2.5 / 2.6 + 4.1) deferred to follow-ups.

### Type renames
- `types/accountRiskHeatmap.ts`: `Severity` → `HeatmapSeverity` (3-value; removes collision with canonical 4-value `Severity` in `types/shared.ts`).
- `utils/themeUtils.ts`: `RiskLevel` → `ThresholdRiskLevel` (4-value incl. `'none'`; per-row diagnostic visualizations).
- `types/compositeRisk.ts`: `RiskLevel` → `CompositeRiskLevel` (RMM-matrix tier used by ISA 315 risk scoring).

Each rename adds a disambiguating doc-comment cross-referencing the other two `RiskLevel` definitions.

### Dead code
- `utils/motionTokens.ts`: deprecated `DISTANCE` map deleted. Only `.state` was referenced (twice, both inside `STATE_CROSSFADE`); inlined as literal `8` at call sites. Other entries (`subtle`, `standard`, `dramatic`) were already unused — entrance distances moved to `lib/motion`'s `lift` per the deprecation note. Companion `__tests__/motionTokens.test.ts` block removed.

### Consumers updated
- `app/(diagnostic)/recon/page.tsx`, `app/(diagnostic)/flux/page.tsx`
- `app/tools/account-risk-heatmap/page.tsx`, `app/tools/composite-risk/page.tsx`
- `utils/index.ts` (re-export rename)

## Test plan
- [x] `cd frontend && npx tsc --noEmit` → exit 0
- [x] `cd frontend && npx jest --watch=false` → 207 suites, 2,012 tests pass (was 2,013; -1 from removed DISTANCE test block)
- [x] `cd frontend && npm run build` → exit 0; routes correctly dynamic (`ƒ`)

## Out of scope (deferred)
- `contexts/DiagnosticContext.tsx` re-export of `types/diagnostic` enum's `RiskLevel` — rename ripples across more consumers than this surgical sprint warrants.
- `MechanicalGauge.tsx` + `useWorkspaceInsights.ts` file-scoped `RiskLevel` types — no leak, separate domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)