### PR TITLE
Sprint 773b: React.memo wraps for 4 result subtrees

### DIFF
--- a/frontend/src/app/tools/account-risk-heatmap/page.tsx
+++ b/frontend/src/app/tools/account-risk-heatmap/page.tsx
@@ -11,7 +11,7 @@
  * from upstream diagnostic engines. CSV export downloads the same aggregation.
  */
 
-import { useCallback, useMemo, useState } from 'react'
+import { memo, useCallback, useMemo, useState } from 'react'
 import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { DisclaimerBox, GuestCTA, UnverifiedCTA, CitationFooter } from '@/components/shared'
 import { UpgradeGate } from '@/components/shared/UpgradeGate'
@@ -394,7 +394,7 @@ export default function AccountRiskHeatmapPage() {
 
 /* ─── Results ──────────────────────────────────────────────────────── */
 
-function HeatmapResults({ result }: { result: import('@/types/accountRiskHeatmap').HeatmapResponse }) {
+const HeatmapResults = memo(function HeatmapResults({ result }: { result: import('@/types/accountRiskHeatmap').HeatmapResponse }) {
   return (
     <div className="space-y-6">
       <section className="theme-card p-6">
@@ -527,7 +527,7 @@ function HeatmapResults({ result }: { result: import('@/types/accountRiskHeatmap
       <CitationFooter standards={['ISA 315', 'ISA 520']} />
     </div>
   )
-}
+})
 
 function TierPill({ tier }: { tier: PriorityTier }) {
   return (

--- a/frontend/src/app/tools/composite-risk/page.tsx
+++ b/frontend/src/app/tools/composite-risk/page.tsx
@@ -11,7 +11,7 @@
  * Form input only — no file upload, no data persisted (Zero-Storage).
  */
 
-import { useCallback, useMemo, useState } from 'react'
+import { memo, useCallback, useMemo, useState } from 'react'
 import { useAuthSession } from '@/contexts/AuthSessionContext'
 import { DisclaimerBox, GuestCTA, UnverifiedCTA, CitationFooter } from '@/components/shared'
 import { UpgradeGate } from '@/components/shared/UpgradeGate'
@@ -351,7 +351,7 @@ export default function CompositeRiskPage() {
 
 /* ─── Results sub-component ───────────────────────────────────────── */
 
-function CompositeRiskResults({ data }: { data: import('@/types/compositeRisk').CompositeRiskProfileResponse }) {
+const CompositeRiskResults = memo(function CompositeRiskResults({ data }: { data: import('@/types/compositeRisk').CompositeRiskProfileResponse }) {
   const overall = data.overall_risk_tier ?? 'low'
   return (
     <div className="space-y-6">
@@ -447,7 +447,7 @@ function CompositeRiskResults({ data }: { data: import('@/types/compositeRisk').
       <CitationFooter standards={['ISA 315', 'ISA 330']} />
     </div>
   )
-}
+})
 
 function RiskPill({ level }: { level: RiskLevel }) {
   return (

--- a/frontend/src/components/multiPeriod/BudgetSummaryCards.tsx
+++ b/frontend/src/components/multiPeriod/BudgetSummaryCards.tsx
@@ -1,6 +1,7 @@
+import { memo } from 'react'
 import type { MovementSummaryResponse } from '@/hooks'
 
-export function BudgetSummaryCards({ comparison }: { comparison: MovementSummaryResponse }) {
+export const BudgetSummaryCards = memo(function BudgetSummaryCards({ comparison }: { comparison: MovementSummaryResponse }) {
   if (!comparison.budget_label) return null
   return (
     <div className="theme-card p-4">
@@ -23,4 +24,4 @@ export function BudgetSummaryCards({ comparison }: { comparison: MovementSummary
       </div>
     </div>
   )
-}
+})

--- a/frontend/src/components/multiPeriod/MovementSummaryCards.tsx
+++ b/frontend/src/components/multiPeriod/MovementSummaryCards.tsx
@@ -1,29 +1,30 @@
+import { memo } from 'react'
 import { motion } from 'framer-motion'
 import type { MovementSummaryResponse } from '@/hooks'
 import { fadeIn, stagger } from './constants'
 
-export function MovementSummaryCards({ comparison }: { comparison: MovementSummaryResponse }) {
-  const cards = [
-    { key: 'new_account', label: 'New Accounts', icon: '+', color: 'sage' },
-    { key: 'closed_account', label: 'Closed Accounts', icon: '-', color: 'clay' },
-    { key: 'sign_change', label: 'Sign Changes', icon: '~', color: 'clay' },
-    { key: 'increase', label: 'Increases', icon: '\u2191', color: 'sage' },
-    { key: 'decrease', label: 'Decreases', icon: '\u2193', color: 'clay' },
-    { key: 'unchanged', label: 'Unchanged', icon: '=', color: 'oatmeal' },
-  ]
+const CARDS = [
+  { key: 'new_account', label: 'New Accounts', icon: '+', color: 'sage' },
+  { key: 'closed_account', label: 'Closed Accounts', icon: '-', color: 'clay' },
+  { key: 'sign_change', label: 'Sign Changes', icon: '~', color: 'clay' },
+  { key: 'increase', label: 'Increases', icon: '\u2191', color: 'sage' },
+  { key: 'decrease', label: 'Decreases', icon: '\u2193', color: 'clay' },
+  { key: 'unchanged', label: 'Unchanged', icon: '=', color: 'oatmeal' },
+] as const
 
-  const borderAccentMap: Record<string, string> = {
-    sage: 'border-l-4 border-l-sage-500',
-    clay: 'border-l-4 border-l-clay-500',
-    oatmeal: 'border-l-4 border-l-oatmeal-400',
-  }
+const BORDER_ACCENT_MAP: Record<string, string> = {
+  sage: 'border-l-4 border-l-sage-500',
+  clay: 'border-l-4 border-l-clay-500',
+  oatmeal: 'border-l-4 border-l-oatmeal-400',
+}
 
+export const MovementSummaryCards = memo(function MovementSummaryCards({ comparison }: { comparison: MovementSummaryResponse }) {
   return (
     <motion.div className="grid grid-cols-3 md:grid-cols-6 gap-3" variants={stagger} initial="hidden" animate="visible">
-      {cards.map(({ key, label, icon, color }) => (
+      {CARDS.map(({ key, label, icon, color }) => (
         <motion.div
           key={key}
-          className={`theme-card p-3 text-center ${borderAccentMap[color]}`}
+          className={`theme-card p-3 text-center ${BORDER_ACCENT_MAP[color]}`}
           variants={fadeIn}
         >
           <div className="text-content-tertiary text-xs font-mono mb-1">{icon}</div>
@@ -35,4 +36,4 @@ export function MovementSummaryCards({ comparison }: { comparison: MovementSumma
       ))}
     </motion.div>
   )
-}
+})

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -266,3 +266,32 @@ Bundle the 19 patch + safe-minor updates into one commit, mirroring the 2026-04-
 
 ---
 
+### Sprint 773b: React.memo wraps for result subtrees
+**Status:** COMPLETE — landed on branch `sprint-773b-react-memo-result-subtrees`.
+**Priority:** P3.
+**Source:** Frontend efficiency audit (2026-05-01) findings 1.5 + 1.6 — render-perf wraps deferred from Sprint 773's grab-bag scope reduction.
+
+Wraps four post-result subtrees with `React.memo` so dashboard filter/sort interactions and other parent state changes don't cascade through them. None change behavior — pure render-perf.
+
+**What landed:**
+- `components/multiPeriod/MovementSummaryCards.tsx` — wrapped in `memo(…)`. Hoisted the `cards` array and `borderAccentMap` to module-scope `CARDS` / `BORDER_ACCENT_MAP` (`as const`) so they're not re-created per render. Audit finding 1.5 + finding hoist sub-item.
+- `components/multiPeriod/BudgetSummaryCards.tsx` — wrapped in `memo(…)`.
+- `app/tools/account-risk-heatmap/page.tsx` — page-private `HeatmapResults` (line 397) wrapped in `memo(…)`. Imports `memo` from `react`.
+- `app/tools/composite-risk/page.tsx` — page-private `CompositeRiskResults` (line 354) wrapped in `memo(…)`. Imports `memo` from `react`.
+
+**Verification:**
+- `cd frontend && npx tsc --noEmit` → exit 0.
+- `cd frontend && npx jest --watch=false --testPathPatterns="(multiPeriod|MovementSummary|BudgetSummary|composite|heatmap)"` → **43 passed, 0 failed** (7 suites).
+- `cd frontend && npm run build` → exit 0; routes correctly dynamic (`ƒ`).
+
+**Out of scope (deferred):**
+- Row-editor `<RowEditor>` / `<SignalRow>` extraction in composite-risk + heatmap (audit 1.6 sub-item) — bigger surgery, separate filing.
+- `FlaggedRow` / `FlaggedEntriesTable` motion-literal hoists (audit 1.7) — separate filing.
+- `AccountMovementTable` sort-comparator hoist (audit 1.8 sub-item).
+- `Reveal` placement inside memoized subtrees (audit 1.7).
+- `RiskBadge` / `StatTile` mini-component unification (audit 2.5/2.6).
+
+**Commit SHA:** see branch `sprint-773b-react-memo-result-subtrees` (filled at PR merge).
+
+---
+


### PR DESCRIPTION
## Summary
Continues the Sprint 773 grab-bag (audit findings 1.5 + 1.6 — deferred from the type-disambiguation subset). Pure render-perf, no behavior changes.

### Wraps
- `components/multiPeriod/MovementSummaryCards.tsx` — `memo(…)`; hoisted `CARDS` array + `BORDER_ACCENT_MAP` to module scope (`as const`) so they aren't recreated per render.
- `components/multiPeriod/BudgetSummaryCards.tsx` — `memo(…)`.
- `app/tools/account-risk-heatmap/page.tsx` — page-private `HeatmapResults` (line 397) wrapped in `memo(…)`.
- `app/tools/composite-risk/page.tsx` — page-private `CompositeRiskResults` (line 354) wrapped in `memo(…)`.

These subtrees previously re-rendered on every parent state change (filter inputs, sort toggles, row keystrokes). After `memo`, they only re-render when their declared props change.

## Test plan
- [x] `cd frontend && npx tsc --noEmit` → exit 0
- [x] `cd frontend && npx jest --testPathPatterns="(multiPeriod|MovementSummary|BudgetSummary|composite|heatmap)"` → 43 passed, 0 failed (7 suites)
- [x] `cd frontend && npm run build` → exit 0; routes correctly dynamic (`ƒ`)

## Out of scope (deferred)
- Row-editor `<RowEditor>` / `<SignalRow>` extraction (audit 1.6 sub-item).
- `FlaggedRow` / `FlaggedEntriesTable` motion-literal hoists (audit 1.7) — landed in Sprint 773c.
- `AccountMovementTable` sort-comparator hoist — landed in Sprint 773c.
- `Reveal` placement inside memoized subtrees.
- `RiskBadge` / `StatTile` mini-component unification (audit 2.5 / 2.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)