### PR TITLE
Sprint 762: flux_expectations memo PDF contract test (18/18 coverage)

### DIFF
--- a/backend/tests/test_export_pdf_contract.py
+++ b/backend/tests/test_export_pdf_contract.py
@@ -33,6 +33,7 @@ from bank_reconciliation_memo_generator import generate_bank_rec_memo
 from currency_memo_generator import generate_currency_conversion_memo
 from expense_category_memo import generate_expense_category_memo
 from fixed_asset_testing_memo_generator import generate_fixed_asset_testing_memo
+from flux_expectations_memo import generate_flux_expectations_memo
 from inventory_testing_memo_generator import generate_inventory_testing_memo
 from je_testing_memo_generator import generate_je_testing_memo
 from multi_period_memo_generator import generate_multi_period_memo
@@ -542,17 +543,74 @@ def test_currency_memo_pdf_contains_all_required_section_labels() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Flux Expectations Memo (ISA 520 — practitioner-authored expectations)
+# ---------------------------------------------------------------------------
+
+# `generate_flux_expectations_memo` accepts plain dicts for `flux_result`
+# and `expectations` (the route's Pydantic input is unwrapped to dicts
+# before invoking the generator), so the contract test fixture is flat
+# like the others rather than needing nested Pydantic sub-models.
+_FLUX_EXPECTATIONS_FLUX_FIXTURE = {
+    "items": [
+        {
+            "account": "Revenue",
+            "type": "Revenue",
+            "current": 500000,
+            "prior": 300000,
+            "delta_amount": 200000,
+            "delta_percent": 66.67,
+            "display_percent": "66.7%",
+            "is_new": False,
+            "is_removed": False,
+            "sign_flip": False,
+            "risk_level": "high",
+            "variance_indicators": ["Large Variance"],
+        },
+    ],
+    "summary": {
+        "total_items": 1,
+        "high_risk_count": 1,
+        "medium_risk_count": 0,
+        "new_accounts": 0,
+        "removed_accounts": 0,
+        "threshold": 10000,
+    },
+}
+
+_FLUX_EXPECTATIONS_EXPECTATIONS_FIXTURE = {
+    "Revenue": {
+        "auditor_expectation": "Expected 15 percent growth based on industry trend",
+        "auditor_explanation": "Actual growth of 66.7 percent due to new contract",
+    },
+}
+
+FLUX_EXPECTATIONS_MEMO_REQUIRED_SECTIONS: tuple[str, ...] = (
+    "ISA",  # title prefix "ISA 520 ..."
+    "Scope",  # section I header
+    "Variance",  # section II content + per-item observed variance table
+    "Conclusion",  # per-item structured conclusion block
+    "Sign-Off",  # section III "Formal Sign-Off"
+    "Disclaimer",  # section IV header
+)
+
+
+def test_flux_expectations_memo_pdf_contains_all_required_section_labels() -> None:
+    pdf_bytes = generate_flux_expectations_memo(
+        flux_result=_FLUX_EXPECTATIONS_FLUX_FIXTURE,
+        expectations=_FLUX_EXPECTATIONS_EXPECTATIONS_FIXTURE,
+        filename="test.csv",
+        client_name="Acme",
+    )
+    _assert_labels_present(pdf_bytes, FLUX_EXPECTATIONS_MEMO_REQUIRED_SECTIONS, "Flux Expectations")
+
+
+# ---------------------------------------------------------------------------
 # Shared utilities + coverage status
 # ---------------------------------------------------------------------------
 
-# Coverage post-Sprint-754b finishing pass: 17/18 memos.
-# Skipped: flux_expectations memo — requires nested Pydantic sub-model
-# serialization (FluxExpectationsMemoInput with .flux + .expectations
-# typed sub-models, not a flat dict like the others). Adding it is a
-# follow-up that builds the typed input fixture; the route handler is
-# already exercised end-to-end by `tests/test_flux_expectations.py`.
+# Coverage post-Sprint-762: 18/18 memos covered.
 #
-# When extending to flux_expectations or new memos:
+# When extending to new memos:
 #   1. Create a `<MEMO>_REQUIRED_SECTIONS: tuple[str, ...]` constant
 #      with verified labels (run the generator + extract text first).
 #   2. Add a test_<memo>_pdf_contains_all_required_section_labels using

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -197,22 +197,23 @@ Bundle the 19 patch + safe-minor updates into one commit, mirroring the 2026-04-
 ---
 
 ### Sprint 762: flux_expectations memo PDF contract test (close 17/18 → 18/18)
-**Status:** PENDING. Closes the lone gap from the post-initiative finishing pass memo-coverage push.
+**Status:** COMPLETE — landed on branch `sprint-773c-render-perf-finishers` (current branch carries 762 + 773c finishers).
 **Priority:** P3.
 **Source:** Post-Sprint-754b memo contract test sweep (commit `60946271`). 17/18 memos covered; flux_expectations skipped because its dataclass nests `FluxExpectationLine` Pydantic sub-models that need a non-trivial fixture.
 
-**What lands:**
-- `backend/tests/test_export_pdf_contract.py::test_flux_expectations_memo_pdf_contract` — single test mirroring the established memo-contract pattern (asserts: PDF bytes returned, `%PDF-` magic header, ReportLab Story renders without exception, branded variant with logo+colors works).
-- Inline fixture for `FluxExpectationsResult` with at least one `FluxExpectationLine` entry; reuse existing `_make_flux_result` helper if shape-compatible.
-- Update `tasks/lessons.md` with the nested-Pydantic-fixture pattern if a generalizable lesson emerges.
+**What landed:**
+- `backend/tests/test_export_pdf_contract.py::test_flux_expectations_memo_pdf_contains_all_required_section_labels` — single test mirroring the established memo-contract pattern, plus inline `_FLUX_EXPECTATIONS_FLUX_FIXTURE` and `_FLUX_EXPECTATIONS_EXPECTATIONS_FIXTURE` and a `FLUX_EXPECTATIONS_MEMO_REQUIRED_SECTIONS` tuple covering ISA, Scope, Variance, Conclusion, Sign-Off, Disclaimer anchors.
+- Discovery: `generate_flux_expectations_memo` accepts plain dicts for both inputs (the route's Pydantic input is unwrapped before the call), so the worry about nested-Pydantic fixtures was misplaced — the fixture is flat like every other memo. Comment in the test file updated to record this finding for future maintainers.
+- Coverage banner updated from "Sprint 754b finishing pass: 17/18 memos" to "Sprint 762: 18/18 memos covered."
 
 **Verification:**
-- `pytest backend/tests/test_export_pdf_contract.py -v` — 18/18 memo contract tests pass (was 17/18).
-- No coverage regression in `flux_expectations_memo_generator.py`.
+- `python -m pytest tests/test_export_pdf_contract.py -v` — **19 passed, 0 failed** (18 contract tests + 1 smoke check; was 18, now +1 with flux_expectations).
 
 **Out of scope:**
 - Refactoring the memo generator — pure test addition.
 - Adding contract tests for the 3 non-memo report PDFs (combined audit, financial statements, anomaly summary) — separate filing if needed.
+
+**Commit SHA:** filled at commit time.
 
 ---
 


### PR DESCRIPTION
## Summary
Adds the lone missing memo to the Sprint 749 contract-test pattern, closing the **17/18 → 18/18** gap. New `test_flux_expectations_memo_pdf_contains_all_required_section_labels` asserts ISA, Scope, Variance, Conclusion, Sign-Off, Disclaimer anchors appear in the rendered PDF.

**Discovery:** `generate_flux_expectations_memo` accepts plain dicts for both `flux_result` and `expectations` (the route's Pydantic input is unwrapped before invocation), so no nested-Pydantic fixture is needed — the prior 17/18 comment over-stated the cost. The file's coverage banner now reflects 18/18.

## Files
- `backend/tests/test_export_pdf_contract.py` — new test + inline `_FLUX_EXPECTATIONS_FLUX_FIXTURE` / `_FLUX_EXPECTATIONS_EXPECTATIONS_FIXTURE` + `FLUX_EXPECTATIONS_MEMO_REQUIRED_SECTIONS` tuple.
- `tasks/todo.md` — Sprint 762 marked COMPLETE.

## Test plan
- [x] `cd backend && python -m pytest tests/test_export_pdf_contract.py -v` → 19 passed (18 contract tests + 1 smoke check; was 18, now +1).
- [x] No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)