### PR TITLE
Sprint 773c: hoist sort comparator + row motion literals

### DIFF
--- a/frontend/src/components/multiPeriod/AccountMovementTable.tsx
+++ b/frontend/src/components/multiPeriod/AccountMovementTable.tsx
@@ -5,6 +5,23 @@ import type { AccountMovement } from '@/hooks'
 import { formatCurrency, SIGNIFICANCE_COLORS } from './constants'
 import { MovementBadge } from './MovementBadge'
 
+// Sprint 773c: hoisted out of the useMemo body so it's not recreated
+// on every memo run. Returns a string for `account_name` (locale-aware
+// sort) and a number for the abs-value columns.
+function getSortValue(m: AccountMovement, sortKey: string): string | number {
+  switch (sortKey) {
+    case 'account_name':
+      return m.account_name.toLowerCase()
+    case 'change_percent':
+      return Math.abs(m.change_percent || 0)
+    case 'budget_variance':
+      return Math.abs(m.budget_variance?.variance_amount || 0)
+    case 'change_amount':
+    default:
+      return Math.abs(m.change_amount)
+  }
+}
+
 export function AccountMovementTable({ movements, filter, hasBudget }: {
   movements: AccountMovement[]
   filter: { type: string; significance: string; search: string }
@@ -22,16 +39,8 @@ export function AccountMovementTable({ movements, filter, hasBudget }: {
       result = result.filter(m => m.account_name.toLowerCase().includes(q))
     }
     return [...result].sort((a, b) => {
-      const aVal = sortKey === 'change_amount' ? Math.abs(a.change_amount) :
-                   sortKey === 'account_name' ? a.account_name.toLowerCase() :
-                   sortKey === 'change_percent' ? Math.abs(a.change_percent || 0) :
-                   sortKey === 'budget_variance' ? Math.abs(a.budget_variance?.variance_amount || 0) :
-                   Math.abs(a.change_amount)
-      const bVal = sortKey === 'change_amount' ? Math.abs(b.change_amount) :
-                   sortKey === 'account_name' ? b.account_name.toLowerCase() :
-                   sortKey === 'change_percent' ? Math.abs(b.change_percent || 0) :
-                   sortKey === 'budget_variance' ? Math.abs(b.budget_variance?.variance_amount || 0) :
-                   Math.abs(b.change_amount)
+      const aVal = getSortValue(a, sortKey)
+      const bVal = getSortValue(b, sortKey)
       if (typeof aVal === 'string' && typeof bVal === 'string') {
         return sortDesc ? bVal.localeCompare(aVal) : aVal.localeCompare(bVal)
       }

--- a/frontend/src/components/shared/testing/FlaggedEntriesTable.tsx
+++ b/frontend/src/components/shared/testing/FlaggedEntriesTable.tsx
@@ -10,6 +10,12 @@ const ITEMS_PER_PAGE = 25
 
 const SEVERITY_ORDER: Record<TestingSeverity, number> = { high: 3, medium: 2, low: 1, informational: 0 }
 
+// Sprint 773c: hoisted from inline literals on motion.tr so the row
+// renderer doesn't allocate three fresh objects per row per render.
+const ROW_INITIAL = { opacity: 0, x: -2 } as const
+const ROW_ANIMATE = { opacity: 1, x: 0 } as const
+const ROW_TRANSITION = { duration: TIMING.settle, ease: EASE.emphasis } as const
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export type ColumnDef<TEntry extends Record<string, unknown> = Record<string, unknown>> = {
@@ -269,9 +275,9 @@ export function FlaggedEntriesTable<TEntry extends Record<string, unknown>>({
               return (
                 <motion.tr
                   key={`${fe.test_key}-${String(fe.entry['row_number'] ?? fe.entry['row_index'] ?? i)}-${i}`}
-                  initial={{ opacity: 0, x: -2 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ duration: TIMING.settle, ease: EASE.emphasis }}
+                  initial={ROW_INITIAL}
+                  animate={ROW_ANIMATE}
+                  transition={ROW_TRANSITION}
                   className={`border-b border-theme-divider cursor-pointer transition-colors ${borderClass}
                     ${isExpanded ? 'bg-sage-50/30' : 'even:bg-oatmeal-50/50 hover:bg-sage-50/40'}`}
                   onClick={() => setExpandedRow(isExpanded ? null : globalIdx)}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -266,3 +266,28 @@ Bundle the 19 patch + safe-minor updates into one commit, mirroring the 2026-04-
 
 ---
 
+### Sprint 773c: Render-perf finishers (sort comparator + motion literal hoists)
+**Status:** COMPLETE — landed on branch `sprint-773c-render-perf-finishers`.
+**Priority:** P3.
+**Source:** Frontend efficiency audit (2026-05-01) findings 1.7 + 1.8 sub-items remaining after Sprint 773 + 773b.
+
+Two surgical hoists. Pure perf wins, zero behavior change.
+
+**What landed:**
+- `components/multiPeriod/AccountMovementTable.tsx` — sort comparator hoisted from inside the `useMemo` body to a module-scope `getSortValue(m, sortKey)` function. Each memo run was previously rebuilding two parallel ternary chains per row. Now the sort callback is a thin wrapper around the hoisted helper. Audit finding 1.8 sub-item.
+- `components/shared/testing/FlaggedEntriesTable.tsx` — `motion.tr` `initial`/`animate`/`transition` literals hoisted to module-scope `ROW_INITIAL` / `ROW_ANIMATE` / `ROW_TRANSITION` (`as const`). Each rendered row was previously allocating three fresh objects; with `ITEMS_PER_PAGE = 25`, that's ~75 object allocations per render → 0. Audit finding 1.7 sub-item.
+
+**Verification:**
+- `cd frontend && npx tsc --noEmit` → exit 0.
+- `cd frontend && npx jest --watch=false --testPathPatterns="(FlaggedEntries|AccountMovement|multiPeriod)"` → **32 passed, 0 failed** (4 suites).
+- `cd frontend && npm run build` → exit 0; routes correctly dynamic (`ƒ`).
+
+**Out of scope (deferred):**
+- `<RowEditor>` / `<SignalRow>` extraction in composite-risk + heatmap pages — bigger surgery, separate filing.
+- `Reveal` placement inside memoized result subtrees — requires careful reasoning about scroll-trigger interaction with memo stability.
+- `RiskBadge` / `StatTile` mini-component unification (audit 2.5/2.6).
+
+**Commit SHA:** see branch `sprint-773c-render-perf-finishers` (filled at PR merge).
+
+---
+


### PR DESCRIPTION
## Summary
Two surgical hoists from the 2026-05-01 frontend efficiency audit (findings 1.7 + 1.8 sub-items remaining after Sprint 773 + 773b). Pure perf wins, zero behavior change.

- `components/multiPeriod/AccountMovementTable.tsx` — sort comparator hoisted from inside the `useMemo` body to a module-scope `getSortValue(m, sortKey)` helper. Each memo run was previously rebuilding two parallel ternary chains per row. The sort callback is now a thin wrapper. *(Audit finding 1.8 sub-item.)*
- `components/shared/testing/FlaggedEntriesTable.tsx` — `motion.tr` `initial` / `animate` / `transition` literals hoisted to module-scope `ROW_INITIAL` / `ROW_ANIMATE` / `ROW_TRANSITION` (`as const`). Each rendered row was previously allocating three fresh objects; with `ITEMS_PER_PAGE = 25`, that's ~75 object allocations per render → 0. *(Audit finding 1.7 sub-item.)*

## Test plan
- [x] `cd frontend && npx tsc --noEmit` → exit 0
- [x] `cd frontend && npx jest --watch=false --testPathPatterns="(FlaggedEntries|AccountMovement|multiPeriod)"` → 32 passed, 0 failed (4 suites)
- [x] `cd frontend && npm run build` → exit 0; routes correctly dynamic (`ƒ`)

## Out of scope (deferred)
- `<RowEditor>` / `<SignalRow>` extraction in composite-risk + heatmap pages — bigger surgery, separate filing.
- `Reveal` placement inside memoized result subtrees — requires careful reasoning about scroll-trigger interaction with memo stability.
- `RiskBadge` / `StatTile` mini-component unification (audit 2.5 / 2.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)